### PR TITLE
Introduce use of cancellation tokens

### DIFF
--- a/packages/dotnet/Criipto.Signatures.IntegrationTests/CancellationTokenTests.cs
+++ b/packages/dotnet/Criipto.Signatures.IntegrationTests/CancellationTokenTests.cs
@@ -1,0 +1,41 @@
+using Criipto.Signatures.Models;
+using Xunit;
+
+namespace Criipto.Signatures.IntegrationTests;
+
+public class CancellationTokenTests
+{
+    private static readonly List<DocumentInput> DefaultDocuments =
+    [
+        new DocumentInput
+        {
+            pdf = new PadesDocumentInput { title = "TEST", blob = Dsl.Sample },
+        },
+    ];
+
+    [Fact]
+    public async Task ThrowsOnCancellationRequested()
+    {
+        // arrange
+        using var client = new CriiptoSignaturesClient(Dsl.CLIENT_ID, Dsl.CLIENT_SECRET, "test");
+
+        using var cts = new CancellationTokenSource(TimeSpan.Zero);
+
+        // act
+        Task action() =>
+            client.CreateSignatureOrder(
+                new CreateSignatureOrderInput()
+                {
+                    title = "Title",
+                    expiresInDays = 1,
+                    documents = DefaultDocuments,
+                },
+                cts.Token
+            );
+
+        // assert
+        Assert.True(cts.IsCancellationRequested);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(action);
+    }
+}

--- a/packages/dotnet/Criipto.Signatures/Client.cs
+++ b/packages/dotnet/Criipto.Signatures/Client.cs
@@ -54,11 +54,12 @@ public class CriiptoSignaturesClient : IDisposable
 
     private async Task<TResponse> SendMutation<TResponse>(
         GraphQL.GraphQLRequest request,
-        Func<TResponse> defineResponseType
+        Func<TResponse> defineResponseType,
+        CancellationToken cancellationToken = default
     )
     {
         var response = await graphQLClient
-            .SendMutationAsync(request, defineResponseType)
+            .SendMutationAsync(request, defineResponseType, cancellationToken)
             .ConfigureAwait(false);
 
         if (response.Errors?.Length > 0)
@@ -69,44 +70,56 @@ public class CriiptoSignaturesClient : IDisposable
         return response.Data;
     }
 
-    public async Task<SignatureOrder> CreateSignatureOrder(CreateSignatureOrderInput input)
+    public async Task<SignatureOrder> CreateSignatureOrder(
+        CreateSignatureOrderInput input,
+        CancellationToken cancellationToken = default
+    )
     {
         if (input == null)
             throw new ArgumentNullException(nameof(input));
 
         var data = await SendMutation(
                 CreateSignatureOrderMutation.Request(new { input = input }),
-                () => new { createSignatureOrder = new CreateSignatureOrderOutput() }
+                () => new { createSignatureOrder = new CreateSignatureOrderOutput() },
+                cancellationToken
             )
             .ConfigureAwait(false);
 
         return data.createSignatureOrder.signatureOrder;
     }
 
-    public async Task<Signatory> AddSignatory(AddSignatoryInput input)
+    public async Task<Signatory> AddSignatory(
+        AddSignatoryInput input,
+        CancellationToken cancellationToken = default
+    )
     {
         var data = await SendMutation(
                 AddSignatoryMutation.Request(new { input = input }),
-                () => new { addSignatory = new AddSignatoryOutput() }
+                () => new { addSignatory = new AddSignatoryOutput() },
+                cancellationToken
             )
             .ConfigureAwait(false);
 
         return data.addSignatory.signatory;
     }
 
-    public async Task<Signatory> AddSignatory(SignatureOrder signatureOrder)
+    public async Task<Signatory> AddSignatory(
+        SignatureOrder signatureOrder,
+        CancellationToken cancellationToken = default
+    )
     {
         if (signatureOrder == null)
             throw new ArgumentNullException(nameof(signatureOrder));
 
         var input = new AddSignatoryInput();
         input.signatureOrderId = signatureOrder.id;
-        return await AddSignatory(input).ConfigureAwait(false);
+        return await AddSignatory(input, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<Signatory> AddSignatory(
         SignatureOrder signatureOrder,
-        AddSignatoryInput input
+        AddSignatoryInput input,
+        CancellationToken cancellationToken = default
     )
     {
         if (signatureOrder == null)
@@ -115,20 +128,27 @@ public class CriiptoSignaturesClient : IDisposable
             throw new ArgumentNullException(nameof(input));
 
         input.signatureOrderId = signatureOrder.id;
-        return await AddSignatory(input).ConfigureAwait(false);
+        return await AddSignatory(input, cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task<Signatory> AddSignatory(string signatureOrderId)
+    public async Task<Signatory> AddSignatory(
+        string signatureOrderId,
+        CancellationToken cancellationToken = default
+    )
     {
         if (signatureOrderId == null)
             throw new ArgumentNullException(nameof(signatureOrderId));
 
         var input = new AddSignatoryInput();
         input.signatureOrderId = signatureOrderId;
-        return await AddSignatory(input).ConfigureAwait(false);
+        return await AddSignatory(input, cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task<Signatory> AddSignatory(string signatureOrderId, AddSignatoryInput input)
+    public async Task<Signatory> AddSignatory(
+        string signatureOrderId,
+        AddSignatoryInput input,
+        CancellationToken cancellationToken = default
+    )
     {
         if (signatureOrderId == null)
             throw new ArgumentNullException(nameof(signatureOrderId));
@@ -136,14 +156,18 @@ public class CriiptoSignaturesClient : IDisposable
             throw new ArgumentNullException(nameof(input));
 
         input.signatureOrderId = signatureOrderId;
-        return await AddSignatory(input).ConfigureAwait(false);
+        return await AddSignatory(input, cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task<List<Signatory>> AddSignatories(AddSignatoriesInput input)
+    public async Task<List<Signatory>> AddSignatories(
+        AddSignatoriesInput input,
+        CancellationToken cancellationToken = default
+    )
     {
         var data = await SendMutation(
                 AddSignatoriesMutation.Request(new { input = input }),
-                () => new { addSignatories = new AddSignatoriesOutput() }
+                () => new { addSignatories = new AddSignatoriesOutput() },
+                cancellationToken
             )
             .ConfigureAwait(false);
 
@@ -152,7 +176,8 @@ public class CriiptoSignaturesClient : IDisposable
 
     public async Task<List<Signatory>> AddSignatories(
         SignatureOrder signatureOrder,
-        List<CreateSignatureOrderSignatoryInput> signatories
+        List<CreateSignatureOrderSignatoryInput> signatories,
+        CancellationToken cancellationToken = default
     )
     {
         if (signatureOrder == null)
@@ -163,12 +188,13 @@ public class CriiptoSignaturesClient : IDisposable
         var input = new AddSignatoriesInput();
         input.signatureOrderId = signatureOrder.id;
         input.signatories = signatories;
-        return await AddSignatories(input).ConfigureAwait(false);
+        return await AddSignatories(input, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<List<Signatory>> AddSignatories(
         string signatureOrderId,
-        List<CreateSignatureOrderSignatoryInput> signatories
+        List<CreateSignatureOrderSignatoryInput> signatories,
+        CancellationToken cancellationToken = default
     )
     {
         if (signatureOrderId == null)
@@ -179,21 +205,29 @@ public class CriiptoSignaturesClient : IDisposable
         var input = new AddSignatoriesInput();
         input.signatureOrderId = signatureOrderId;
         input.signatories = signatories;
-        return await AddSignatories(input).ConfigureAwait(false);
+        return await AddSignatories(input, cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task<Signatory> ChangeSignatory(ChangeSignatoryInput input)
+    public async Task<Signatory> ChangeSignatory(
+        ChangeSignatoryInput input,
+        CancellationToken cancellationToken = default
+    )
     {
         var data = await SendMutation(
                 ChangeSignatoryMutation.Request(new { input = input }),
-                () => new { changeSignatory = new ChangeSignatoryOutput() }
+                () => new { changeSignatory = new ChangeSignatoryOutput() },
+                cancellationToken
             )
             .ConfigureAwait(false);
 
         return data.changeSignatory.signatory;
     }
 
-    public async Task<Signatory> ChangeSignatory(Signatory signatory, ChangeSignatoryInput input)
+    public async Task<Signatory> ChangeSignatory(
+        Signatory signatory,
+        ChangeSignatoryInput input,
+        CancellationToken cancellationToken = default
+    )
     {
         if (signatory == null)
             throw new ArgumentNullException(nameof(signatory));
@@ -201,10 +235,14 @@ public class CriiptoSignaturesClient : IDisposable
             throw new ArgumentNullException(nameof(input));
 
         input.signatoryId = signatory.id;
-        return await ChangeSignatory(input).ConfigureAwait(false);
+        return await ChangeSignatory(input, cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task<Signatory> ChangeSignatory(string signatoryId, ChangeSignatoryInput input)
+    public async Task<Signatory> ChangeSignatory(
+        string signatoryId,
+        ChangeSignatoryInput input,
+        CancellationToken cancellationToken = default
+    )
     {
         if (signatoryId == null)
             throw new ArgumentNullException(nameof(signatoryId));
@@ -212,17 +250,21 @@ public class CriiptoSignaturesClient : IDisposable
             throw new ArgumentNullException(nameof(input));
 
         input.signatoryId = signatoryId;
-        return await ChangeSignatory(input).ConfigureAwait(false);
+        return await ChangeSignatory(input, cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task<SignatureOrder> ExtendSignatureOrder(ExtendSignatureOrderInput input)
+    public async Task<SignatureOrder> ExtendSignatureOrder(
+        ExtendSignatureOrderInput input,
+        CancellationToken cancellationToken = default
+    )
     {
         if (input == null)
             throw new ArgumentNullException(nameof(input));
 
         var data = await SendMutation(
                 ExtendSignatureOrderMutation.Request(new { input = input }),
-                () => new { extendSignatureOrder = new ExtendSignatureOrderOutput() }
+                () => new { extendSignatureOrder = new ExtendSignatureOrderOutput() },
+                cancellationToken
             )
             .ConfigureAwait(false);
 
@@ -231,7 +273,8 @@ public class CriiptoSignaturesClient : IDisposable
 
     public async Task<SignatureOrder> ExtendSignatureOrder(
         SignatureOrder signatureOrder,
-        ExtendSignatureOrderInput input
+        ExtendSignatureOrderInput input,
+        CancellationToken cancellationToken = default
     )
     {
         if (signatureOrder == null)
@@ -240,33 +283,41 @@ public class CriiptoSignaturesClient : IDisposable
             throw new ArgumentNullException(nameof(input));
 
         input.signatureOrderId = signatureOrder.id;
-        return await ExtendSignatureOrder(input).ConfigureAwait(false);
+        return await ExtendSignatureOrder(input, cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task<SignatureOrder> CloseSignatureOrder(CloseSignatureOrderInput input)
+    public async Task<SignatureOrder> CloseSignatureOrder(
+        CloseSignatureOrderInput input,
+        CancellationToken cancellationToken = default
+    )
     {
         var data = await SendMutation(
                 CloseSignatureOrderMutation.Request(new { input = input }),
-                () => new { closeSignatureOrder = new CloseSignatureOrderOutput() }
+                () => new { closeSignatureOrder = new CloseSignatureOrderOutput() },
+                cancellationToken
             )
             .ConfigureAwait(false);
 
         return data.closeSignatureOrder.signatureOrder;
     }
 
-    public async Task<SignatureOrder> CloseSignatureOrder(SignatureOrder signatureOrder)
+    public async Task<SignatureOrder> CloseSignatureOrder(
+        SignatureOrder signatureOrder,
+        CancellationToken cancellationToken = default
+    )
     {
         if (signatureOrder == null)
             throw new ArgumentNullException(nameof(signatureOrder));
 
         var input = new CloseSignatureOrderInput();
         input.signatureOrderId = signatureOrder.id;
-        return await CloseSignatureOrder(input).ConfigureAwait(false);
+        return await CloseSignatureOrder(input, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<SignatureOrder> CloseSignatureOrder(
         SignatureOrder signatureOrder,
-        CloseSignatureOrderInput input
+        CloseSignatureOrderInput input,
+        CancellationToken cancellationToken = default
     )
     {
         if (signatureOrder == null)
@@ -275,22 +326,26 @@ public class CriiptoSignaturesClient : IDisposable
             throw new ArgumentNullException(nameof(input));
 
         input.signatureOrderId = signatureOrder.id;
-        return await CloseSignatureOrder(input).ConfigureAwait(false);
+        return await CloseSignatureOrder(input, cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task<SignatureOrder> CloseSignatureOrder(string signatureOrderId)
+    public async Task<SignatureOrder> CloseSignatureOrder(
+        string signatureOrderId,
+        CancellationToken cancellationToken = default
+    )
     {
         if (signatureOrderId == null)
             throw new ArgumentNullException(nameof(signatureOrderId));
 
         var input = new CloseSignatureOrderInput();
         input.signatureOrderId = signatureOrderId;
-        return await CloseSignatureOrder(input).ConfigureAwait(false);
+        return await CloseSignatureOrder(input, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<SignatureOrder> CloseSignatureOrder(
         string signatureOrderId,
-        CloseSignatureOrderInput input
+        CloseSignatureOrderInput input,
+        CancellationToken cancellationToken = default
     )
     {
         if (signatureOrderId == null)
@@ -299,83 +354,111 @@ public class CriiptoSignaturesClient : IDisposable
             throw new ArgumentNullException(nameof(input));
 
         input.signatureOrderId = signatureOrderId;
-        return await CloseSignatureOrder(input).ConfigureAwait(false);
+        return await CloseSignatureOrder(input, cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task<SignatureOrder> CancelSignatureOrder(CancelSignatureOrderInput input)
+    public async Task<SignatureOrder> CancelSignatureOrder(
+        CancelSignatureOrderInput input,
+        CancellationToken cancellationToken = default
+    )
     {
         var data = await SendMutation(
                 CancelSignatureOrderMutation.Request(new { input = input }),
-                () => new { cancelSignatureOrder = new CancelSignatureOrderOutput() }
+                () => new { cancelSignatureOrder = new CancelSignatureOrderOutput() },
+                cancellationToken
             )
             .ConfigureAwait(false);
 
         return data.cancelSignatureOrder.signatureOrder;
     }
 
-    public async Task<SignatureOrder> CancelSignatureOrder(SignatureOrder signatureOrder)
+    public async Task<SignatureOrder> CancelSignatureOrder(
+        SignatureOrder signatureOrder,
+        CancellationToken cancellationToken = default
+    )
     {
         if (signatureOrder == null)
             throw new ArgumentNullException(nameof(signatureOrder));
 
         var input = new CancelSignatureOrderInput();
         input.signatureOrderId = signatureOrder.id;
-        return await CancelSignatureOrder(input).ConfigureAwait(false);
+        return await CancelSignatureOrder(input, cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task<SignatureOrder> CancelSignatureOrder(string signatureOrderId)
+    public async Task<SignatureOrder> CancelSignatureOrder(
+        string signatureOrderId,
+        CancellationToken cancellationToken = default
+    )
     {
         if (signatureOrderId == null)
             throw new ArgumentNullException(nameof(signatureOrderId));
 
         var input = new CancelSignatureOrderInput();
         input.signatureOrderId = signatureOrderId;
-        return await CancelSignatureOrder(input).ConfigureAwait(false);
+        return await CancelSignatureOrder(input, cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task<SignatureOrder> CleanupSignatureOrder(CleanupSignatureOrderInput input)
+    public async Task<SignatureOrder> CleanupSignatureOrder(
+        CleanupSignatureOrderInput input,
+        CancellationToken cancellationToken = default
+    )
     {
         var data = await SendMutation(
                 CleanupSignatureOrderMutation.Request(new { input = input }),
-                () => new { cleanupSignatureOrder = new CleanupSignatureOrderOutput() }
+                () => new { cleanupSignatureOrder = new CleanupSignatureOrderOutput() },
+                cancellationToken
             )
             .ConfigureAwait(false);
 
         return data.cleanupSignatureOrder.signatureOrder;
     }
 
-    public async Task<SignatureOrder> CleanupSignatureOrder(SignatureOrder signatureOrder)
+    public async Task<SignatureOrder> CleanupSignatureOrder(
+        SignatureOrder signatureOrder,
+        CancellationToken cancellationToken = default
+    )
     {
         if (signatureOrder == null)
             throw new ArgumentNullException(nameof(signatureOrder));
 
         var input = new CleanupSignatureOrderInput();
         input.signatureOrderId = signatureOrder.id;
-        return await CleanupSignatureOrder(input).ConfigureAwait(false);
+        return await CleanupSignatureOrder(input, cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task<SignatureOrder> CleanupSignatureOrder(string signatureOrderId)
+    public async Task<SignatureOrder> CleanupSignatureOrder(
+        string signatureOrderId,
+        CancellationToken cancellationToken = default
+    )
     {
         if (signatureOrderId == null)
             throw new ArgumentNullException(nameof(signatureOrderId));
 
         var input = new CleanupSignatureOrderInput();
         input.signatureOrderId = signatureOrderId;
-        return await CleanupSignatureOrder(input).ConfigureAwait(false);
+        return await CleanupSignatureOrder(input, cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task<Signatory> SignActingAs(SignActingAsInput input)
+    public async Task<Signatory> SignActingAs(
+        SignActingAsInput input,
+        CancellationToken cancellationToken = default
+    )
     {
         var data = await SendMutation(
                 SignActingAsMutation.Request(new { input = input }),
-                () => new { SignActingAs = new SignActingAsOutput() }
+                () => new { SignActingAs = new SignActingAsOutput() },
+                cancellationToken
             )
             .ConfigureAwait(false);
 
         return data.SignActingAs.signatory;
     }
 
-    public async Task<Signatory> SignActingAs(Signatory signatory, SignActingAsInput input)
+    public async Task<Signatory> SignActingAs(
+        Signatory signatory,
+        SignActingAsInput input,
+        CancellationToken cancellationToken = default
+    )
     {
         if (signatory == null)
             throw new ArgumentNullException(nameof(signatory));
@@ -383,23 +466,31 @@ public class CriiptoSignaturesClient : IDisposable
             throw new ArgumentNullException(nameof(input));
 
         input.signatoryId = signatory.id;
-        return await SignActingAs(input).ConfigureAwait(false);
+        return await SignActingAs(input, cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task<ValidateDocumentOutput> ValidateDocument(ValidateDocumentInput input)
+    public async Task<ValidateDocumentOutput> ValidateDocument(
+        ValidateDocumentInput input,
+        CancellationToken cancellationToken = default
+    )
     {
         if (input == null)
             throw new ArgumentNullException(nameof(input));
 
         var data = await SendMutation(
                 ValidateDocumentMutation.Request(new { input = input }),
-                () => new { ValidateDocument = new ValidateDocumentOutput() }
+                () => new { ValidateDocument = new ValidateDocumentOutput() },
+                cancellationToken
             )
             .ConfigureAwait(false);
         return data.ValidateDocument;
     }
 
-    public async Task<Signatory> SignActingAs(string signatoryId, SignActingAsInput input)
+    public async Task<Signatory> SignActingAs(
+        string signatoryId,
+        SignActingAsInput input,
+        CancellationToken cancellationToken = default
+    )
     {
         if (signatoryId == null)
             throw new ArgumentNullException(nameof(signatoryId));
@@ -407,21 +498,29 @@ public class CriiptoSignaturesClient : IDisposable
             throw new ArgumentNullException(nameof(input));
 
         input.signatoryId = signatoryId;
-        return await SignActingAs(input).ConfigureAwait(false);
+        return await SignActingAs(input, cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task<SignatureOrder> DeleteSignatory(DeleteSignatoryInput input)
+    public async Task<SignatureOrder> DeleteSignatory(
+        DeleteSignatoryInput input,
+        CancellationToken cancellationToken = default
+    )
     {
         var data = await SendMutation(
                 DeleteSignatoryMutation.Request(new { input = input }),
-                () => new { deleteSignatory = new DeleteSignatoryOutput() }
+                () => new { deleteSignatory = new DeleteSignatoryOutput() },
+                cancellationToken
             )
             .ConfigureAwait(false);
 
         return data.deleteSignatory.signatureOrder;
     }
 
-    public async Task<SignatureOrder> DeleteSignatory(string signatureOrderId, string signatoryId)
+    public async Task<SignatureOrder> DeleteSignatory(
+        string signatureOrderId,
+        string signatoryId,
+        CancellationToken cancellationToken = default
+    )
     {
         if (signatureOrderId == null)
             throw new ArgumentNullException(nameof(signatureOrderId));
@@ -431,10 +530,13 @@ public class CriiptoSignaturesClient : IDisposable
         var input = new DeleteSignatoryInput();
         input.signatureOrderId = signatureOrderId;
         input.signatoryId = signatoryId;
-        return await DeleteSignatory(input).ConfigureAwait(false);
+        return await DeleteSignatory(input, cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task<SignatureOrder> DeleteSignatory(Signatory signatory)
+    public async Task<SignatureOrder> DeleteSignatory(
+        Signatory signatory,
+        CancellationToken cancellationToken = default
+    )
     {
         if (signatory == null)
             throw new ArgumentNullException(nameof(signatory));
@@ -442,17 +544,21 @@ public class CriiptoSignaturesClient : IDisposable
         var input = new DeleteSignatoryInput();
         input.signatureOrderId = signatory.signatureOrder.id;
         input.signatoryId = signatory.id;
-        return await DeleteSignatory(input).ConfigureAwait(false);
+        return await DeleteSignatory(input, cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task<BatchSignatory> CreateBatchSignatory(CreateBatchSignatoryInput input)
+    public async Task<BatchSignatory> CreateBatchSignatory(
+        CreateBatchSignatoryInput input,
+        CancellationToken cancellationToken = default
+    )
     {
         if (input == null)
             throw new ArgumentNullException(nameof(input));
 
         var data = await SendMutation(
                 CreateBatchSignatoryMutation.Request(new { input = input }),
-                () => new { createBatchSignatory = new CreateBatchSignatoryOutput() }
+                () => new { createBatchSignatory = new CreateBatchSignatoryOutput() },
+                cancellationToken
             )
             .ConfigureAwait(false);
 
@@ -461,7 +567,8 @@ public class CriiptoSignaturesClient : IDisposable
 
     public async Task<SignatureOrder?> QuerySignatureOrder(
         string signatureOrderId,
-        bool includeDocuments = false
+        bool includeDocuments = false,
+        CancellationToken cancellationToken = default
     )
     {
         if (signatureOrderId == null)
@@ -472,7 +579,9 @@ public class CriiptoSignaturesClient : IDisposable
                 ? SignatureOrderWithDocumentsQuery.Request(new { id = signatureOrderId })
                 : SignatureOrderQuery.Request(new { id = signatureOrderId });
 
-        var response = await graphQLClient.SendQueryAsync<Query>(request).ConfigureAwait(false);
+        var response = await graphQLClient
+            .SendQueryAsync<Query>(request, cancellationToken)
+            .ConfigureAwait(false);
 
         if (response.Errors?.Length > 0)
         {
@@ -482,14 +591,19 @@ public class CriiptoSignaturesClient : IDisposable
         return response.Data.signatureOrder;
     }
 
-    public async Task<Signatory?> QuerySignatory(string signatoryId)
+    public async Task<Signatory?> QuerySignatory(
+        string signatoryId,
+        CancellationToken cancellationToken = default
+    )
     {
         if (signatoryId == null)
             throw new ArgumentNullException(nameof(signatoryId));
 
         var request = SignatoryQuery.Request(new { id = signatoryId });
 
-        var response = await graphQLClient.SendQueryAsync<Query>(request).ConfigureAwait(false);
+        var response = await graphQLClient
+            .SendQueryAsync<Query>(request, cancellationToken)
+            .ConfigureAwait(false);
 
         if (response.Errors?.Length > 0)
         {
@@ -499,14 +613,19 @@ public class CriiptoSignaturesClient : IDisposable
         return response.Data.signatory;
     }
 
-    public async Task<BatchSignatory?> QueryBatchSignatory(string batchSignatoryId)
+    public async Task<BatchSignatory?> QueryBatchSignatory(
+        string batchSignatoryId,
+        CancellationToken cancellationToken = default
+    )
     {
         if (batchSignatoryId == null)
             throw new ArgumentNullException(nameof(batchSignatoryId));
 
         var request = BatchSignatoryQuery.Request(new { id = batchSignatoryId });
 
-        var response = await graphQLClient.SendQueryAsync<Query>(request).ConfigureAwait(false);
+        var response = await graphQLClient
+            .SendQueryAsync<Query>(request, cancellationToken)
+            .ConfigureAwait(false);
 
         if (response.Errors?.Length > 0)
         {


### PR DESCRIPTION
Previously, it wasn't possible to pass cancellation tokens to GraphQL client, which meant unnecessary could be perform as a cancellation wouldn't be respected before the SDK work was done.