### PR TITLE
Refactor version bumping procedure

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -12,12 +12,17 @@ The process aims to eliminate human interaction and reduce point-of-failures (or
 After having merged new commits - either via PR or directly on default branch - run the following NPM scripts on default branch to publish new version tags:
 
 ```sh
-npm version <major | minor | patch>
-npm run tag
+./bump-versions.sh <major | minor | patch>
 ```
 
 The commit log should now contain the updated `Criipto.Signatures.csproj` and `package.json` version.
-When the commit log is satisfying, the version commit and tags can then be pushed by `npm run tag:post`, which ensures that the commits and tag is pushed to remote.
+The version commit and tags can then be pushed by running
+
+```sh
+npm run tag:post
+```
+
+which ensures that the commits and tag is pushed to remote.
 
 ## Create release
 

--- a/bump-versions.sh
+++ b/bump-versions.sh
@@ -15,6 +15,24 @@ then
     exit 1
 fi
 
+if [[ $# != 1 ]];
+then
+    echo "Incorrect number of arguments provided. Usage: ./bump-versions.sh <major | minor | patch>"
+    exit 1
+fi
+
+# validate the version argument
+case "$1" in
+    major|minor|patch)
+        ;;
+    *)  echo "Invalid version bump argument provided. Usage ./bump-versions.sh <major | minor | patch>"
+        exit 1
+        ;;
+esac
+
+# bump overarching package version
+npm version $1
+
 # extract overaching package version
 export VERSION=$(npm pkg get version | tr -d \")
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "build": "npm run build:nodejs && npm run build:dotnet",
     "build:nodejs": "cd packages/nodejs && npm run build && cd ../..",
     "build:dotnet": "npm run format:dotnet && cd packages/dotnet && dotnet build Criipto.Signatures.sln && cd ../..",
-    "tag": "source bump-versions.sh",
     "tag:post": "git push --follow-tags --atomic"
   },
   "repository": {


### PR DESCRIPTION
Current procedure was flawed as the `git status` check would always failed as it happened after `npm version <major | minor | patch>`.