### PR TITLE
Migrate to ESM

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -4,7 +4,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [16, 18, 20, 22]
+        version: [20, 22, 24]
     steps:
       - uses: actions/checkout@v4
       - name: Setup kernel for build, increase watchers

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -4,7 +4,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [16, 18, 20, 22]
+        version: [20, 22, 24]
     steps:
       - uses: actions/checkout@v4
       - name: Setup kernel for build, increase watchers

--- a/codegen.ts
+++ b/codegen.ts
@@ -3,6 +3,7 @@ import type { CodegenConfig } from '@graphql-codegen/cli';
 const config: CodegenConfig = {
   schema: 'https://signatures-api.criipto.com/v1/graphql',
   documents: './*.graphql',
+  emitLegacyCommonJSImports: false,
   generates: {
     'packages/nodejs/src/graphql-sdk.ts': {
       plugins: ['typescript', 'typescript-operations', 'typescript-graphql-request'],
@@ -11,6 +12,7 @@ const config: CodegenConfig = {
         namingConvention: {
           enumValues: 'keep',
         },
+        gqlImport: 'graphql-tag#gql',
         enumsAsTypes: true,
         futureProofEnums: true,
         scalars: {

--- a/fix-dotnet-typings.mjs
+++ b/fix-dotnet-typings.mjs
@@ -1,4 +1,4 @@
-const fs = require('fs');
+import fs from 'node:fs';
 const typesSupressions = [
   'CS8601',
   'CS8603',
@@ -24,7 +24,7 @@ const typesSupressions = [
 
 const operationsSupressions = ['CS8625', 'CA1052', 'CA2211'];
 
-const dotnetDirName = `${__dirname}/packages/dotnet`;
+const dotnetDirName = `${import.meta.dirname}/packages/dotnet`;
 
 let types = fs.readFileSync(dotnetDirName + '/Criipto.Signatures/Models.cs').toString();
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "A SDK repository for Criipto Signatures",
   "scripts": {
     "codegen": "graphql-codegen && npm run codegen:dotnet",
-    "codegen:dotnet": "node fix-dotnet-typings.cjs && npm run format:dotnet",
+    "codegen:dotnet": "node fix-dotnet-typings.mjs && npm run format:dotnet",
     "test": "npm run test:unit && npm run test:integration",
     "test:integration": "npm run test:integration:nodejs && npm run test:integration:dotnet",
     "test:integration:nodejs": "cd packages/nodejs && npm run test:integration && cd ../..",
@@ -50,7 +50,7 @@
     "prettier": "^3.6.2"
   },
   "lint-staged": {
-    "*.{ts,cjs,json,md,graphql,yml}": "prettier --write",
+    "*.{ts,mjs,json,md,graphql,yml}": "prettier --write",
     "*.cs": [
       "dotnet format style ./packages/dotnet/Criipto.Signatures.sln --include",
       "dotnet format analyzers ./packages/dotnet/Criipto.Signatures.sln --include",

--- a/packages/nodejs/README.md
+++ b/packages/nodejs/README.md
@@ -10,7 +10,8 @@ Sign PAdeS-LTA documents using MitID, BankID or any other eID supported by Criip
 
 ### Requirements
 
-This library supports Node 16 and later.
+The library is published as ESM only. On node 20.19.0, 22.12.0 and ^24 `require(esm)` works out of the box, even if your code is using CommonJS. On
+older versions, you will need to run with `--experimental-require-module`. See https://nodejs.org/api/modules.html#loading-ecmascript-modules-using-require for more details.
 
 ### Installation
 

--- a/packages/nodejs/package-lock.json
+++ b/packages/nodejs/package-lock.json
@@ -15,10 +15,13 @@
       },
       "devDependencies": {
         "@ava/typescript": "^4.0.0",
-        "@tsconfig/node16": "^1.0.3",
+        "@tsconfig/node20": "^20.1.6",
         "ava": "^5.2.0",
         "ts-node": "^10.9.1",
         "typescript": "^5.0.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || ^24"
       }
     },
     "node_modules/@ava/typescript": {
@@ -139,6 +142,13 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node20": {
+      "version": "20.1.6",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node20/-/node20-20.1.6.tgz",
+      "integrity": "sha512-sz+Hqx9zwZDpZIV871WSbUzSqNIsXzghZydypnfgzPKLltVJfkINfUeTct31n/tTSa9ZE1ZOfKdRre1uHHquYQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/packages/nodejs/package.json
+++ b/packages/nodejs/package.json
@@ -38,7 +38,7 @@
   "homepage": "https://github.com/criipto/criipto-signatures-sdk#readme",
   "devDependencies": {
     "@ava/typescript": "^4.0.0",
-    "@tsconfig/node16": "^1.0.3",
+    "@tsconfig/node20": "^20.1.6",
     "ava": "^5.2.0",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.4"

--- a/packages/nodejs/package.json
+++ b/packages/nodejs/package.json
@@ -2,6 +2,7 @@
   "name": "@criipto/signatures",
   "version": "1.22.3",
   "private": false,
+  "type": "module",
   "description": "A Node.JS SDK for Criipto Signatures",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -17,6 +18,9 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/criipto/criipto-signatures-sdk.git"
+  },
+  "engines": {
+    "node": "^20.19.0 || ^22.12.0 || ^24"
   },
   "keywords": [
     "criipto",

--- a/packages/nodejs/src/graphql-sdk.ts
+++ b/packages/nodejs/src/graphql-sdk.ts
@@ -1,6 +1,6 @@
 import { GraphQLClient } from 'graphql-request';
-import * as Dom from 'graphql-request/dist/types.dom';
-import gql from 'graphql-tag';
+import * as Dom from 'graphql-request/dist/types.dom.js';
+import { gql } from 'graphql-tag';
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };

--- a/packages/nodejs/src/index.ts
+++ b/packages/nodejs/src/index.ts
@@ -11,10 +11,10 @@ import {
   Sdk,
   SignActingAsInput,
   ChangeSignatureOrderInput,
-} from './graphql-sdk';
+} from './graphql-sdk.js';
 
-import * as Types from './graphql-sdk';
-import jsonSerializer from './json-serializer';
+import * as Types from './graphql-sdk.js';
+import jsonSerializer from './json-serializer.js';
 export { Types as CriiptoSignaturesTypes };
 
 export class CriiptoSignatures {

--- a/packages/nodejs/src/index.ts
+++ b/packages/nodejs/src/index.ts
@@ -1,16 +1,16 @@
 import { GraphQLClient } from 'graphql-request';
 import {
-  AddSignatoriesInput,
-  AddSignatoryInput,
-  ChangeSignatoryInput,
-  ExtendSignatureOrderInput,
-  CloseSignatureOrderInput,
-  CreateSignatureOrderInput,
-  CreateBatchSignatoryInput,
+  type AddSignatoriesInput,
+  type AddSignatoryInput,
+  type ChangeSignatoryInput,
+  type ExtendSignatureOrderInput,
+  type CloseSignatureOrderInput,
+  type CreateSignatureOrderInput,
+  type CreateBatchSignatoryInput,
   getSdk,
-  Sdk,
-  SignActingAsInput,
-  ChangeSignatureOrderInput,
+  type Sdk,
+  type SignActingAsInput,
+  type ChangeSignatureOrderInput,
 } from './graphql-sdk.js';
 
 import * as Types from './graphql-sdk.js';

--- a/packages/nodejs/src/json-serializer.ts
+++ b/packages/nodejs/src/json-serializer.ts
@@ -1,4 +1,4 @@
-import { JsonSerializer } from 'graphql-request/dist/types.dom';
+import type { JsonSerializer } from 'graphql-request/dist/types.dom.js';
 
 function tryBase64Decode(input: string) {
   try {
@@ -39,7 +39,7 @@ function parseBlobs(input: any): any {
 }
 
 const jsonSerializer: JsonSerializer = {
-  stringify(obj) {
+  stringify(obj: any) {
     return JSON.stringify(obj, (key, value) => {
       if (value instanceof Object && !Array.isArray(value)) {
         return Object.keys(value).reduce(

--- a/packages/nodejs/src/test/integration/basic.test.ts
+++ b/packages/nodejs/src/test/integration/basic.test.ts
@@ -2,7 +2,7 @@ import test from 'ava';
 import fs from 'fs';
 
 import CriiptoSignatures from '../../index.js';
-import { DocumentStorageMode } from '../../graphql-sdk.js';
+import type { DocumentStorageMode } from '../../graphql-sdk.js';
 
 const sample = fs.readFileSync(import.meta.dirname + '/sample.pdf');
 const sampleForm = fs.readFileSync(import.meta.dirname + '/sample-form.pdf');

--- a/packages/nodejs/src/test/integration/basic.test.ts
+++ b/packages/nodejs/src/test/integration/basic.test.ts
@@ -1,11 +1,11 @@
 import test from 'ava';
 import fs from 'fs';
 
-import CriiptoSignatures from '../../';
-import { DocumentStorageMode } from '../../graphql-sdk';
+import CriiptoSignatures from '../../index.js';
+import { DocumentStorageMode } from '../../graphql-sdk.js';
 
-const sample = fs.readFileSync(__dirname + '/sample.pdf');
-const sampleForm = fs.readFileSync(__dirname + '/sample-form.pdf');
+const sample = fs.readFileSync(import.meta.dirname + '/sample.pdf');
+const sampleForm = fs.readFileSync(import.meta.dirname + '/sample-form.pdf');
 
 const documentFixture = {
   pdf: {

--- a/packages/nodejs/src/test/unit/json-serializer.test.ts
+++ b/packages/nodejs/src/test/unit/json-serializer.test.ts
@@ -1,6 +1,6 @@
 import test from 'ava';
 
-import jsonSerializer from '../../json-serializer';
+import jsonSerializer from '../../json-serializer.js';
 
 test('jsonSerializer is pass through', t => {
   const expected = { title: 'title' };

--- a/packages/nodejs/tsconfig.json
+++ b/packages/nodejs/tsconfig.json
@@ -1,9 +1,9 @@
 {
-  "extends": "@tsconfig/node16/tsconfig.json",
+  "extends": ["@tsconfig/node20/tsconfig.json"],
   "compilerOptions": {
-    "moduleResolution": "node16",
     "declaration": true,
-    "outDir": "dist/"
+    "outDir": "dist/",
+    "verbatimModuleSyntax": true
   },
   "include": ["src/"]
 }


### PR DESCRIPTION
Continuation of https://github.com/criipto/criipto-signatures-sdk/pull/11

Splitting the linked PR into smaller parts. This PR migrates the nodejs SDK and a few scripts around it to ESM only.

Before starting to work on this, I actually wanted to convert the package to ESM, but publish both CJS and ESM versions. However, I don't think the extra work in that is feasible:

* We have to compile twice, either with two tsconfigs or using `tsup` or similar.
* We have to maintain several entrypoints in package.json (both `main` and `exports`)

This doesn't seem like a terrible amount of extra work, but I don't see any reason to do it. Even if consumers are on CJS, `require(esm)` is supported on all [currently supported version of nodejs](https://nodejs.org/en/about/previous-releases), without any runtime flags. (node 20 is in maintenance mode, 22 is active LTS, while 24 is active)

Older minor versions of node 20 and 22 require the`--experimental-require-module` flag, but newer versions do not.

sindresorhus has [been arguing](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c#file-esm-package-md) for the esm only approach for _years_, and the author or vitest do so as well [earlier this year[(https://antfu.me/posts/move-on-to-esm-only)

I created a small sample project (using the example from the docs), and was able to run it without issues using `v20.19.4`