### PR TITLE
change(codegen/python) Generate specific return types for each operation

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,7 +1,7 @@
 on: [push]
 
 jobs:
-  nodejs-test:
+  nodejs-sdk-test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -18,6 +18,21 @@ jobs:
       - run: npm run check
         working-directory: packages/nodejs
       - run: npm run test:unit:nodejs
+
+  codegen-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+      - run: npm ci
+      - name: Check (codegen-shared)
+        run: npm run check && npm run lint
+        working-directory: codegen/graphql-codegen-shared
+      - name: Test (codegen-shared)
+        run: npm run test
+        working-directory: codegen/graphql-codegen-shared
 
   dotnet-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -76,8 +76,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/workflows/python-setup
-      - name: Run checks
+      - name: Ruff (linter)
         run: uv run ruff check
+      - name: ty (type-checking)
+        run: uv run ty check
 
   python-formatting:
     runs-on: ubuntu-latest

--- a/codegen.ts
+++ b/codegen.ts
@@ -68,7 +68,6 @@ const config: CodegenConfig = {
       plugins: ['graphql-codegen-plugin-python'],
       config: {
         mode: 'types',
-        everythingIsOptional: true,
       } satisfies PythonPluginConfig,
       ...pythonCommonConfig,
     },

--- a/codegen/graphql-codegen-plugin-python/src/PythonOperationsVisitor.ts
+++ b/codegen/graphql-codegen-plugin-python/src/PythonOperationsVisitor.ts
@@ -30,17 +30,11 @@ import {
 } from 'graphql-codegen-shared';
 import { PythonTypesVisitor } from './PythonTypesVisitor.ts';
 
-export interface PythonOperationsRawConfig extends RawConfig {}
-
-export class PythonOperationsVisitor extends ClientSideBaseVisitor<PythonOperationsRawConfig> {
+export class PythonOperationsVisitor extends ClientSideBaseVisitor {
   modelImports: Set<string> = new Set<string>();
   fragments: FragmentDefinitionNode[];
 
-  constructor(
-    config: PythonOperationsRawConfig,
-    schema: GraphQLSchema,
-    fragments: LoadedFragment[],
-  ) {
+  constructor(config: RawConfig, schema: GraphQLSchema, fragments: LoadedFragment[]) {
     // Rebuild schema from string, in order to populate AST nodes
     // https://github.com/graphql/graphql-js/issues/1575
     schema = buildSchema(printSchema(schema));

--- a/codegen/graphql-codegen-plugin-python/src/PythonOperationsVisitor.ts
+++ b/codegen/graphql-codegen-plugin-python/src/PythonOperationsVisitor.ts
@@ -14,23 +14,39 @@ import {
   isInterfaceType,
   isObjectType,
   isScalarType,
+  isEnumType,
+  buildSchema,
+  printSchema,
   isInputObjectType,
   OperationTypeNode,
+  visit,
 } from 'graphql';
 import assert from 'node:assert';
 import { upperCaseFirst } from 'change-case-all';
+import {
+  assertIsNotUndefined,
+  operationSelectionsToAstTree,
+  type AstTreeNode,
+} from 'graphql-codegen-shared';
+import { PythonTypesVisitor } from './PythonTypesVisitor.ts';
 
 export interface PythonOperationsRawConfig extends RawConfig {}
 
 export class PythonOperationsVisitor extends ClientSideBaseVisitor<PythonOperationsRawConfig> {
-  modelImports: Set<string> = new Set();
+  modelImports: Set<string> = new Set<string>();
+  fragments: FragmentDefinitionNode[];
 
   constructor(
     config: PythonOperationsRawConfig,
     schema: GraphQLSchema,
     fragments: LoadedFragment[],
   ) {
+    // Rebuild schema from string, in order to populate AST nodes
+    // https://github.com/graphql/graphql-js/issues/1575
+    schema = buildSchema(printSchema(schema));
+
     super(schema, fragments, config, {});
+    this.fragments = fragments.map(fragment => fragment.node);
   }
 
   static stringVariable(variableName: string, body: string, expressions?: string[]) {
@@ -52,7 +68,7 @@ ${expressions.map(expression => `{${expression}}`).join('\n')}"""`;
   };
 
   private getOperationName(node: OperationDefinitionNode) {
-    assert(node.name != undefined);
+    assertIsNotUndefined(node.name);
     return node.operation === OperationTypeNode.QUERY
       ? `query${upperCaseFirst(node.name.value)}`
       : node.name.value;
@@ -68,16 +84,80 @@ ${expressions.map(expression => `{${expression}}`).join('\n')}"""`;
       // Save the operation for later, when we build the actual SDK operations
       this._collectedOperations.push(node);
 
-      const name =
-        node.operation === 'query'
-          ? `query${upperCaseFirst(node.name?.value ?? '')}`
-          : node.name?.value;
+      const name = this.getOperationName(node);
+      const result: string[] = [];
+
+      // We want to build the most accurate output type for each operation
+      // In order to do that, we need to take the selection set (the specification
+      // of which fields were selected), and translate that to a concrete type.
+
+      // First, we convert the selection set to a tree of GraphQL AST nodes
+      const astTree = operationSelectionsToAstTree({
+        node,
+        schema: this._schema,
+        fragments: this.fragments,
+      });
+
+      // Then, we run a breadth-first traversal of the tree. For each node
+      // we keep track of the prefix of the parent node.
+      const nodesToProcess: { treeNode: AstTreeNode; parentPrefix: string }[] = [
+        { treeNode: astTree, parentPrefix: upperCaseFirst(name) },
+      ];
+
+      while (nodesToProcess.length > 0) {
+        // We checked the length in the line above, so the non-null assertion is safe here
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const { parentPrefix, treeNode } = nodesToProcess.shift()!;
+
+        const nodePrefix = `${parentPrefix}_${treeNode.astNode.name.value}`;
+        // For each AST node, we use the PythonTypesVisitor to generate a specialized
+        // python class definition for the specific selection. The class definition
+        // differs from the general output type classes defined in the schema in
+        // three ways:
+        // 1. The class only includes the fields actually selected by the operation
+        //    (as opposed to all fields defined by the output type)
+        // 2. The names of the classes are prefixed with the name of their parent type
+        //    (by overriding node.name.value before passing the node to `oldVisit`)
+        // 3. All field types are prefixed with the name of their parent type, using
+        //    the `typesPrefix` option. So for a type called `Foo`, with a field `bar` of type
+        //    `Bar`, the type of `Foo.bar` will be `Foo_Bar`
+        const typesVisitor = new PythonTypesVisitor(
+          {
+            typesPrefix: nodePrefix + '_',
+          },
+          this._schema,
+        );
+
+        const visitorResult = visit(
+          {
+            ...treeNode.astNode,
+            name: {
+              ...treeNode.astNode.name,
+              value: nodePrefix,
+            },
+          },
+          typesVisitor,
+        );
+        assert(typeof visitorResult === 'string');
+        result.push(visitorResult);
+
+        nodesToProcess.push(
+          ...treeNode.children.map(child => ({
+            parentPrefix: nodePrefix,
+            treeNode: child,
+          })),
+        );
+      }
 
       // Recursively extracts the names of all fragments used in the operation
       const fragments = this._extractFragments(node, true).map(node => this.getFragmentName(node));
 
-      // Return just the GraphQL document variable definition for now, the actual operation is built in `getAdditionalContent`
-      return PythonOperationsVisitor.stringVariable(`${name}Document`, print(node), fragments);
+      return [
+        ...result,
+        // Return just the GraphQL document variable definition for now, the actual operation is built
+        // in `getAdditionalContent`
+        PythonOperationsVisitor.stringVariable(`${name}Document`, print(node), fragments),
+      ].join('\n');
     },
   };
 
@@ -110,7 +190,7 @@ class CriiptoSignaturesSDK:
                 ? this._schema.getMutationType()
                 : this._schema.getSubscriptionType();
           const selectionNode = operations?.getFields()[node.selectionSet.selections[0].name.value];
-          assert(selectionNode != undefined, 'Top level selection type not found in schema');
+          assertIsNotUndefined(selectionNode, 'Top level selection type not found in schema');
 
           const outputTypeNode = getNullableType(selectionNode.type);
 
@@ -119,7 +199,7 @@ class CriiptoSignaturesSDK:
             'Expected output type for operation to be either interface or object',
           );
 
-          const outputTypeName = upperCaseFirst(outputTypeNode.name);
+          const outputTypeName = upperCaseFirst(operationName) + '_' + outputTypeNode.name;
 
           const functionArguments = (node.variableDefinitions ?? []).reduce<Record<string, string>>(
             (functionArguments, variableDefinitionNode) => {
@@ -188,8 +268,17 @@ return parsed`,
   }
 
   getPrepend(): string[] {
+    const typeMap = this._schema.getTypeMap();
+    const scalars = Object.values(typeMap).filter(type => isScalarType(type));
+    const enums = Object.values(typeMap)
+      .filter(type => isEnumType(type))
+      .filter(e => !['__DirectiveLocation', '__TypeKind'].includes(e.name));
+
     return [
+      ...PythonTypesVisitor.getImports(),
       `from .models import ${Array.from(this.modelImports).join(',')}`,
+      `from .models import ${scalars.map(scalar => `${scalar.name}Scalar`).join(',')}`,
+      `from .models import ${enums.map(e => e.name).join(',')}`,
       'from gql import Client, gql',
       'from gql.transport.aiohttp import AIOHTTPTransport, BasicAuth',
     ];

--- a/codegen/graphql-codegen-plugin-python/src/PythonTypesVisitor.test.ts
+++ b/codegen/graphql-codegen-plugin-python/src/PythonTypesVisitor.test.ts
@@ -4,12 +4,7 @@ import { buildSchema, type GraphQLSchema } from 'graphql';
 import { plugin } from './index.ts';
 
 const runPlugin = async (schema: GraphQLSchema) => {
-  const result = await plugin(
-    schema,
-    [],
-    { mode: 'types', everythingIsOptional: false },
-    { outputFile: '' },
-  );
+  const result = await plugin(schema, [], { mode: 'types' }, { outputFile: '' });
   if (typeof result === 'object') {
     return result.content;
   }

--- a/codegen/graphql-codegen-plugin-python/src/PythonTypesVisitor.ts
+++ b/codegen/graphql-codegen-plugin-python/src/PythonTypesVisitor.ts
@@ -103,7 +103,7 @@ export class PythonTypesVisitor extends BaseVisitor<PythonTypesRawConfig, Python
       return new PythonDeclarationBlock(node)
         .asKind('class')
         .withExtends('BaseModel')
-        .withContent(node.fields?.map(node => this.asString(node)) ?? 'pass')
+        .withContent(node.fields?.map(node => this.asString(node)))
         .toString();
     },
   };

--- a/codegen/graphql-codegen-plugin-python/src/PythonTypesVisitor.ts
+++ b/codegen/graphql-codegen-plugin-python/src/PythonTypesVisitor.ts
@@ -64,7 +64,7 @@ export class PythonTypesVisitor extends BaseVisitor<PythonTypesRawConfig, Python
     this.schema = schema;
   }
 
-  getImports() {
+  static getImports() {
     return [
       'from enum import StrEnum',
       'from typing import Optional',
@@ -267,7 +267,7 @@ export class PythonTypesVisitor extends BaseVisitor<PythonTypesRawConfig, Python
   }
 
   getPrepend() {
-    return [...this.getImports(), this.getScalarsTypes()];
+    return [...PythonTypesVisitor.getImports(), this.getScalarsTypes()];
   }
 
   getAppend() {

--- a/codegen/graphql-codegen-plugin-python/src/index.ts
+++ b/codegen/graphql-codegen-plugin-python/src/index.ts
@@ -4,22 +4,21 @@ import {
   type PluginFunction,
   type Types,
 } from '@graphql-codegen/plugin-helpers';
-import { PythonTypesVisitor, type PythonTypesRawConfig } from './PythonTypesVisitor.ts';
-import { type LoadedFragment } from '@graphql-codegen/visitor-plugin-common';
-import {
-  PythonOperationsVisitor,
-  type PythonOperationsRawConfig,
-} from './PythonOperationsVisitor.ts';
+import { PythonTypesVisitor } from './PythonTypesVisitor.ts';
+import { type LoadedFragment, type RawConfig } from '@graphql-codegen/visitor-plugin-common';
+import { PythonOperationsVisitor } from './PythonOperationsVisitor.ts';
 
 function isNotNullish<T>(arg: T): arg is Exclude<T, null | undefined> {
   return arg !== null;
 }
 
-export type PythonPluginConfig =
-  | ({
+export type PythonPluginConfig = (
+  | {
       mode: 'types';
-    } & PythonTypesRawConfig)
-  | ({ mode: 'operations' } & PythonOperationsRawConfig);
+    }
+  | { mode: 'operations' }
+) &
+  RawConfig;
 
 export const plugin: PluginFunction<PythonPluginConfig> = (
   schema: GraphQLSchema,

--- a/codegen/graphql-codegen-plugin-python/src/pythonDeclarationBlock.ts
+++ b/codegen/graphql-codegen-plugin-python/src/pythonDeclarationBlock.ts
@@ -1,4 +1,4 @@
-import { indentMultiline } from '@graphql-codegen/visitor-plugin-common';
+import { indentMultiline, indent } from '@graphql-codegen/visitor-plugin-common';
 import { type ASTNode } from 'graphql';
 
 function ensureArray<T>(item: undefined | T | T[]): T[] {
@@ -51,10 +51,10 @@ export class PythonDeclarationBlock {
       result += `# ${this._comment}\n`;
     }
 
-    let indent = 0;
+    let indentation = 0;
     switch (this._kind) {
       case 'class':
-        indent = 1;
+        indentation = 1;
         if (!this._name) {
           throw new Error('Naming is missing for class definition');
         }
@@ -75,8 +75,11 @@ export class PythonDeclarationBlock {
     }
 
     if (this._content) {
+      if (this._kind === 'class' && this._content.length === 0) {
+        result += indent('pass');
+      }
       for (const item of this._content) {
-        result += indentMultiline(item, indent) + '\n';
+        result += indentMultiline(item, indentation) + '\n';
       }
     }
 

--- a/codegen/graphql-codegen-shared/.npmrc
+++ b/codegen/graphql-codegen-shared/.npmrc
@@ -1,0 +1,3 @@
+# Installing peer deps here means we would have graphql-js installed in both the root package and this package.
+# graphql-js expects there to be only one instance of the package, so we avoid installing it here, and rely on it being installed in the root package.
+omit=peer

--- a/codegen/graphql-codegen-shared/eslint.config.ts
+++ b/codegen/graphql-codegen-shared/eslint.config.ts
@@ -1,0 +1,16 @@
+import eslint from '@eslint/js';
+import tseslint from 'typescript-eslint';
+
+export default tseslint.config(
+  eslint.configs.recommended,
+  tseslint.configs.strictTypeChecked,
+  tseslint.configs.stylisticTypeChecked,
+  {
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+);

--- a/codegen/graphql-codegen-shared/package-lock.json
+++ b/codegen/graphql-codegen-shared/package-lock.json
@@ -1,41 +1,11 @@
 {
-  "name": "graphql-codegen-plugin-python",
+  "name": "graphql-codegen-shared",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "graphql-codegen-plugin-python",
-      "version": "1.0.0",
-      "dependencies": {
-        "@graphql-codegen/plugin-helpers": "^5.1.1",
-        "@graphql-codegen/visitor-plugin-common": "^5.8.0",
-        "change-case-all": "^2.1.0",
-        "graphql-codegen-shared": "file:../graphql-codegen-shared"
-      },
-      "devDependencies": {
-        "@eslint/js": "^9.32.0",
-        "@tsconfig/node24": "^24.0.1",
-        "@tsconfig/strictest": "^2.0.5",
-        "@types/node": "^24.2.0",
-        "ava": "^6.4.1",
-        "eslint": "^9.32.0",
-        "typescript": "^5.9.2",
-        "typescript-eslint": "^8.39.0"
-      },
-      "engines": {
-        "node": "^22.18 || ^24"
-      }
-    },
-    "../../node_modules/graphql": {
-      "version": "16.10.0",
-      "extraneous": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
-      }
-    },
-    "../graphql-codegen-shared": {
+      "name": "graphql-codegen-shared",
       "version": "1.0.0",
       "devDependencies": {
         "@eslint/js": "^9.32.0",
@@ -52,132 +22,6 @@
       },
       "peerDependencies": {
         "graphql": "^16.11.0"
-      }
-    },
-    "node_modules/@ardatan/relay-compiler": {
-      "version": "12.0.3",
-      "resolved": "https://registry.npmjs.org/@ardatan/relay-compiler/-/relay-compiler-12.0.3.tgz",
-      "integrity": "sha512-mBDFOGvAoVlWaWqs3hm1AciGHSQE1rqFc/liZTyYz/Oek9yZdT5H26pH2zAFuEiTiBVPPyMuqf5VjOFPI2DGsQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/generator": "^7.26.10",
-        "@babel/parser": "^7.26.10",
-        "@babel/runtime": "^7.26.10",
-        "chalk": "^4.0.0",
-        "fb-watchman": "^2.0.0",
-        "immutable": "~3.7.6",
-        "invariant": "^2.2.4",
-        "nullthrows": "^1.1.1",
-        "relay-runtime": "12.0.0",
-        "signedsource": "^1.0.0"
-      },
-      "bin": {
-        "relay-compiler": "bin/relay-compiler"
-      },
-      "peerDependencies": {
-        "graphql": "*"
-      }
-    },
-    "node_modules/@ardatan/relay-compiler/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@ardatan/relay-compiler/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@babel/generator": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.0.tgz",
-      "integrity": "sha512-lJjzvrbEeWrhB4P3QBsH7tey117PjLZnDbLiQEKjQ/fNJTjuq4HSqgFA+UNSwZT8D7dxxbnuSBMsa1lrWzKlQg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.28.0",
-        "@babel/types": "^7.28.0",
-        "@jridgewell/gen-mapping": "^0.3.12",
-        "@jridgewell/trace-mapping": "^0.3.28",
-        "jsesc": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/parser": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.0.tgz",
-      "integrity": "sha512-jVZGvOxOuNSsuQuLRTh13nU0AogFlw32w/MT+LV6D3sP5WdbW61E77RnkbaO2dUvmPAYrBDJXGn5gGS6tH4j8g==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.28.0"
-      },
-      "bin": {
-        "parser": "bin/babel-parser.js"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@babel/runtime": {
-      "version": "7.28.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.2.tgz",
-      "integrity": "sha512-KHp2IflsnGywDjBWDkR9iEqiWSpc8GIi0lgTT3mOElT0PP1tG26P4tmFI2YvAdzgq9RGyoHZQEIEdZy6Ec5xCA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/types": {
-      "version": "7.28.2",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.2.tgz",
-      "integrity": "sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -238,9 +82,9 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.3.0.tgz",
-      "integrity": "sha512-ViuymvFmcJi04qdZeDc2whTHryouGcDlaxPqarTD0ZE10ISpxGUVZGZDx4w01upyIynL3iu6IXH2bS1NhclQMw==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.3.1.tgz",
+      "integrity": "sha512-xR93k9WhrDYpXHORXpxVL5oHj3Era7wo6k/Wd8/IsQNnZUTzkGS29lyn3nAT05v6ltUuTFVCCYDEGfy2Or/sPA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -248,9 +92,9 @@
       }
     },
     "node_modules/@eslint/core": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.1.tgz",
-      "integrity": "sha512-bkOp+iumZCCbt1K1CmWf0R9pM5yKpDv+ZXtvSyQpudrI9kuFLp+bM2WOPXImuD/ceQuaa8f5pj93Y7zyECIGNA==",
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.2.tgz",
+      "integrity": "sha512-78Md3/Rrxh83gCxoUc0EiciuOHsIITzLy53m3d9UyiW8y9Dj2D29FeETqyKA+BRK76tnTp6RXWb3pCay8Oyomg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -285,9 +129,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.32.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.32.0.tgz",
-      "integrity": "sha512-BBpRFZK3eX6uMLKz8WxFOBIFFcGFJ/g8XuwjTHCqHROSIsopI+ddn/d5Cfh36+7+e5edVS8dbSHnBNhrLEX0zg==",
+      "version": "9.33.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.33.0.tgz",
+      "integrity": "sha512-5K1/mKhWaMfreBGJTwval43JJmkip0RmM+3+IuqupeSKNC/Th2Kc7ucaq5ovTSra/OOKB9c58CGSz3QMVbWt0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -308,233 +152,17 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.4.tgz",
-      "integrity": "sha512-Ul5l+lHEcw3L5+k8POx6r74mxEYKG5kOb6Xpy2gCRW6zweT6TEhAf8vhxGgjhqrd/VO/Dirhsb+1hNpD1ue9hw==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.5.tgz",
+      "integrity": "sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.15.1",
+        "@eslint/core": "^0.15.2",
         "levn": "^0.4.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@graphql-codegen/plugin-helpers": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-5.1.1.tgz",
-      "integrity": "sha512-28GHODK2HY1NhdyRcPP3sCz0Kqxyfiz7boIZ8qIxFYmpLYnlDgiYok5fhFLVSZihyOpCs4Fa37gVHf/Q4I2FEg==",
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-tools/utils": "^10.0.0",
-        "change-case-all": "1.0.15",
-        "common-tags": "1.8.2",
-        "import-from": "4.0.0",
-        "lodash": "~4.17.0",
-        "tslib": "~2.6.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
-      }
-    },
-    "node_modules/@graphql-codegen/plugin-helpers/node_modules/change-case": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
-      "integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
-      "license": "MIT",
-      "dependencies": {
-        "camel-case": "^4.1.2",
-        "capital-case": "^1.0.4",
-        "constant-case": "^3.0.4",
-        "dot-case": "^3.0.4",
-        "header-case": "^2.0.4",
-        "no-case": "^3.0.4",
-        "param-case": "^3.0.4",
-        "pascal-case": "^3.1.2",
-        "path-case": "^3.0.4",
-        "sentence-case": "^3.0.4",
-        "snake-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/@graphql-codegen/plugin-helpers/node_modules/change-case-all": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/change-case-all/-/change-case-all-1.0.15.tgz",
-      "integrity": "sha512-3+GIFhk3sNuvFAJKU46o26OdzudQlPNBCu1ZQi3cMeMHhty1bhDxu2WrEilVNYaGvqUtR1VSigFcJOiS13dRhQ==",
-      "license": "MIT",
-      "dependencies": {
-        "change-case": "^4.1.2",
-        "is-lower-case": "^2.0.2",
-        "is-upper-case": "^2.0.2",
-        "lower-case": "^2.0.2",
-        "lower-case-first": "^2.0.2",
-        "sponge-case": "^1.0.1",
-        "swap-case": "^2.0.2",
-        "title-case": "^3.0.3",
-        "upper-case": "^2.0.2",
-        "upper-case-first": "^2.0.2"
-      }
-    },
-    "node_modules/@graphql-codegen/plugin-helpers/node_modules/sponge-case": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/sponge-case/-/sponge-case-1.0.1.tgz",
-      "integrity": "sha512-dblb9Et4DAtiZ5YSUZHLl4XhH4uK80GhAZrVXdN4O2P4gQ40Wa5UIOPUHlA/nFd2PLblBZWUioLMMAVrgpoYcA==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/@graphql-codegen/plugin-helpers/node_modules/swap-case": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-2.0.2.tgz",
-      "integrity": "sha512-kc6S2YS/2yXbtkSMunBtKdah4VFETZ8Oh6ONSmSd9bRxhqTrtARUCBUiWXH3xVPpvR7tz2CSnkuXVE42EcGnMw==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/@graphql-codegen/visitor-plugin-common": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-5.8.0.tgz",
-      "integrity": "sha512-lC1E1Kmuzi3WZUlYlqB4fP6+CvbKH9J+haU1iWmgsBx5/sO2ROeXJG4Dmt8gP03bI2BwjiwV5WxCEMlyeuzLnA==",
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-codegen/plugin-helpers": "^5.1.0",
-        "@graphql-tools/optimize": "^2.0.0",
-        "@graphql-tools/relay-operation-optimizer": "^7.0.0",
-        "@graphql-tools/utils": "^10.0.0",
-        "auto-bind": "~4.0.0",
-        "change-case-all": "1.0.15",
-        "dependency-graph": "^0.11.0",
-        "graphql-tag": "^2.11.0",
-        "parse-filepath": "^1.0.2",
-        "tslib": "~2.6.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
-      }
-    },
-    "node_modules/@graphql-codegen/visitor-plugin-common/node_modules/change-case": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
-      "integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
-      "license": "MIT",
-      "dependencies": {
-        "camel-case": "^4.1.2",
-        "capital-case": "^1.0.4",
-        "constant-case": "^3.0.4",
-        "dot-case": "^3.0.4",
-        "header-case": "^2.0.4",
-        "no-case": "^3.0.4",
-        "param-case": "^3.0.4",
-        "pascal-case": "^3.1.2",
-        "path-case": "^3.0.4",
-        "sentence-case": "^3.0.4",
-        "snake-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/@graphql-codegen/visitor-plugin-common/node_modules/change-case-all": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/change-case-all/-/change-case-all-1.0.15.tgz",
-      "integrity": "sha512-3+GIFhk3sNuvFAJKU46o26OdzudQlPNBCu1ZQi3cMeMHhty1bhDxu2WrEilVNYaGvqUtR1VSigFcJOiS13dRhQ==",
-      "license": "MIT",
-      "dependencies": {
-        "change-case": "^4.1.2",
-        "is-lower-case": "^2.0.2",
-        "is-upper-case": "^2.0.2",
-        "lower-case": "^2.0.2",
-        "lower-case-first": "^2.0.2",
-        "sponge-case": "^1.0.1",
-        "swap-case": "^2.0.2",
-        "title-case": "^3.0.3",
-        "upper-case": "^2.0.2",
-        "upper-case-first": "^2.0.2"
-      }
-    },
-    "node_modules/@graphql-codegen/visitor-plugin-common/node_modules/sponge-case": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/sponge-case/-/sponge-case-1.0.1.tgz",
-      "integrity": "sha512-dblb9Et4DAtiZ5YSUZHLl4XhH4uK80GhAZrVXdN4O2P4gQ40Wa5UIOPUHlA/nFd2PLblBZWUioLMMAVrgpoYcA==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/@graphql-codegen/visitor-plugin-common/node_modules/swap-case": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-2.0.2.tgz",
-      "integrity": "sha512-kc6S2YS/2yXbtkSMunBtKdah4VFETZ8Oh6ONSmSd9bRxhqTrtARUCBUiWXH3xVPpvR7tz2CSnkuXVE42EcGnMw==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/@graphql-tools/optimize": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/optimize/-/optimize-2.0.0.tgz",
-      "integrity": "sha512-nhdT+CRGDZ+bk68ic+Jw1OZ99YCDIKYA5AlVAnBHJvMawSx9YQqQAIj4refNc1/LRieGiuWvhbG3jvPVYho0Dg==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-tools/relay-operation-optimizer": {
-      "version": "7.0.21",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/relay-operation-optimizer/-/relay-operation-optimizer-7.0.21.tgz",
-      "integrity": "sha512-vMdU0+XfeBh9RCwPqRsr3A05hPA3MsahFn/7OAwXzMySA5EVnSH5R4poWNs3h1a0yT0tDPLhxORhK7qJdSWj2A==",
-      "license": "MIT",
-      "dependencies": {
-        "@ardatan/relay-compiler": "^12.0.3",
-        "@graphql-tools/utils": "^10.9.1",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-tools/utils": {
-      "version": "10.9.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.9.1.tgz",
-      "integrity": "sha512-B1wwkXk9UvU7LCBkPs8513WxOQ2H8Fo5p8HR1+Id9WmYE5+bd51vqN+MbrqvWczHCH2gwkREgHJN88tE0n1FCw==",
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-typed-document-node/core": "^3.1.1",
-        "@whatwg-node/promise-helpers": "^1.0.0",
-        "cross-inspect": "1.0.1",
-        "dset": "^3.1.4",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-typed-document-node/core": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
-      "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/@humanfs/core": {
@@ -657,41 +285,6 @@
       },
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.12.tgz",
-      "integrity": "sha512-OuLGC46TjB5BbN1dH8JULVVZY4WTdkF7tV9Ys6wLL1rubZnCMstOhNHueU5bLCrnRuDhKPDM4g6sw4Bel5Gzqg==",
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.0",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      }
-    },
-    "node_modules/@jridgewell/resolve-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
-      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.4.tgz",
-      "integrity": "sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==",
-      "license": "MIT"
-    },
-    "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.29",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.29.tgz",
-      "integrity": "sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.1.0",
-        "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
     "node_modules/@mapbox/node-pre-gyp": {
@@ -830,9 +423,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.2.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.2.0.tgz",
-      "integrity": "sha512-3xyG3pMCq3oYCNg7/ZP+E1ooTaGB4cG8JWRsqqOYQdbWNY4zbaV0Ennrd7stjiJEFZCaybcIgpTjJWHRfBSIDw==",
+      "version": "24.2.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.2.1.tgz",
+      "integrity": "sha512-DRh5K+ka5eJic8CjH7td8QpYEV6Zo10gfRkjHCO3weqZHWDtAaSTFtl4+VMqOJ4N5jcuhZ9/l+yy8rVgw7BQeQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -840,17 +433,17 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.39.0.tgz",
-      "integrity": "sha512-bhEz6OZeUR+O/6yx9Jk6ohX6H9JSFTaiY0v9/PuKT3oGK0rn0jNplLmyFUGV+a9gfYnVNwGDwS/UkLIuXNb2Rw==",
+      "version": "8.39.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.39.1.tgz",
+      "integrity": "sha512-yYegZ5n3Yr6eOcqgj2nJH8cH/ZZgF+l0YIdKILSDjYFRjgYQMgv/lRjV5Z7Up04b9VYUondt8EPMqg7kTWgJ2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.39.0",
-        "@typescript-eslint/type-utils": "8.39.0",
-        "@typescript-eslint/utils": "8.39.0",
-        "@typescript-eslint/visitor-keys": "8.39.0",
+        "@typescript-eslint/scope-manager": "8.39.1",
+        "@typescript-eslint/type-utils": "8.39.1",
+        "@typescript-eslint/utils": "8.39.1",
+        "@typescript-eslint/visitor-keys": "8.39.1",
         "graphemer": "^1.4.0",
         "ignore": "^7.0.0",
         "natural-compare": "^1.4.0",
@@ -864,7 +457,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.39.0",
+        "@typescript-eslint/parser": "^8.39.1",
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
@@ -880,16 +473,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.39.0.tgz",
-      "integrity": "sha512-g3WpVQHngx0aLXn6kfIYCZxM6rRJlWzEkVpqEFLT3SgEDsp9cpCbxxgwnE504q4H+ruSDh/VGS6nqZIDynP+vg==",
+      "version": "8.39.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.39.1.tgz",
+      "integrity": "sha512-pUXGCuHnnKw6PyYq93lLRiZm3vjuslIy7tus1lIQTYVK9bL8XBgJnCWm8a0KcTtHC84Yya1Q6rtll+duSMj0dg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.39.0",
-        "@typescript-eslint/types": "8.39.0",
-        "@typescript-eslint/typescript-estree": "8.39.0",
-        "@typescript-eslint/visitor-keys": "8.39.0",
+        "@typescript-eslint/scope-manager": "8.39.1",
+        "@typescript-eslint/types": "8.39.1",
+        "@typescript-eslint/typescript-estree": "8.39.1",
+        "@typescript-eslint/visitor-keys": "8.39.1",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -905,14 +498,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.39.0.tgz",
-      "integrity": "sha512-CTzJqaSq30V/Z2Og9jogzZt8lJRR5TKlAdXmWgdu4hgcC9Kww5flQ+xFvMxIBWVNdxJO7OifgdOK4PokMIWPew==",
+      "version": "8.39.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.39.1.tgz",
+      "integrity": "sha512-8fZxek3ONTwBu9ptw5nCKqZOSkXshZB7uAxuFF0J/wTMkKydjXCzqqga7MlFMpHi9DoG4BadhmTkITBcg8Aybw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.39.0",
-        "@typescript-eslint/types": "^8.39.0",
+        "@typescript-eslint/tsconfig-utils": "^8.39.1",
+        "@typescript-eslint/types": "^8.39.1",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -927,14 +520,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.39.0.tgz",
-      "integrity": "sha512-8QOzff9UKxOh6npZQ/4FQu4mjdOCGSdO3p44ww0hk8Vu+IGbg0tB/H1LcTARRDzGCC8pDGbh2rissBuuoPgH8A==",
+      "version": "8.39.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.39.1.tgz",
+      "integrity": "sha512-RkBKGBrjgskFGWuyUGz/EtD8AF/GW49S21J8dvMzpJitOF1slLEbbHnNEtAHtnDAnx8qDEdRrULRnWVx27wGBw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.39.0",
-        "@typescript-eslint/visitor-keys": "8.39.0"
+        "@typescript-eslint/types": "8.39.1",
+        "@typescript-eslint/visitor-keys": "8.39.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -945,9 +538,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.39.0.tgz",
-      "integrity": "sha512-Fd3/QjmFV2sKmvv3Mrj8r6N8CryYiCS8Wdb/6/rgOXAWGcFuc+VkQuG28uk/4kVNVZBQuuDHEDUpo/pQ32zsIQ==",
+      "version": "8.39.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.39.1.tgz",
+      "integrity": "sha512-ePUPGVtTMR8XMU2Hee8kD0Pu4NDE1CN9Q1sxGSGd/mbOtGZDM7pnhXNJnzW63zk/q+Z54zVzj44HtwXln5CvHA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -962,15 +555,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.39.0.tgz",
-      "integrity": "sha512-6B3z0c1DXVT2vYA9+z9axjtc09rqKUPRmijD5m9iv8iQpHBRYRMBcgxSiKTZKm6FwWw1/cI4v6em35OsKCiN5Q==",
+      "version": "8.39.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.39.1.tgz",
+      "integrity": "sha512-gu9/ahyatyAdQbKeHnhT4R+y3YLtqqHyvkfDxaBYk97EcbfChSJXyaJnIL3ygUv7OuZatePHmQvuH5ru0lnVeA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.39.0",
-        "@typescript-eslint/typescript-estree": "8.39.0",
-        "@typescript-eslint/utils": "8.39.0",
+        "@typescript-eslint/types": "8.39.1",
+        "@typescript-eslint/typescript-estree": "8.39.1",
+        "@typescript-eslint/utils": "8.39.1",
         "debug": "^4.3.4",
         "ts-api-utils": "^2.1.0"
       },
@@ -987,9 +580,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.39.0.tgz",
-      "integrity": "sha512-ArDdaOllnCj3yn/lzKn9s0pBQYmmyme/v1HbGIGB0GB/knFI3fWMHloC+oYTJW46tVbYnGKTMDK4ah1sC2v0Kg==",
+      "version": "8.39.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.39.1.tgz",
+      "integrity": "sha512-7sPDKQQp+S11laqTrhHqeAbsCfMkwJMrV7oTDvtDds4mEofJYir414bYKUEb8YPUm9QL3U+8f6L6YExSoAGdQw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1001,16 +594,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.39.0.tgz",
-      "integrity": "sha512-ndWdiflRMvfIgQRpckQQLiB5qAKQ7w++V4LlCHwp62eym1HLB/kw7D9f2e8ytONls/jt89TEasgvb+VwnRprsw==",
+      "version": "8.39.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.39.1.tgz",
+      "integrity": "sha512-EKkpcPuIux48dddVDXyQBlKdeTPMmALqBUbEk38McWv0qVEZwOpVJBi7ugK5qVNgeuYjGNQxrrnoM/5+TI/BPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.39.0",
-        "@typescript-eslint/tsconfig-utils": "8.39.0",
-        "@typescript-eslint/types": "8.39.0",
-        "@typescript-eslint/visitor-keys": "8.39.0",
+        "@typescript-eslint/project-service": "8.39.1",
+        "@typescript-eslint/tsconfig-utils": "8.39.1",
+        "@typescript-eslint/types": "8.39.1",
+        "@typescript-eslint/visitor-keys": "8.39.1",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -1056,16 +649,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.39.0.tgz",
-      "integrity": "sha512-4GVSvNA0Vx1Ktwvf4sFE+exxJ3QGUorQG1/A5mRfRNZtkBT2xrA/BCO2H0eALx/PnvCS6/vmYwRdDA41EoffkQ==",
+      "version": "8.39.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.39.1.tgz",
+      "integrity": "sha512-VF5tZ2XnUSTuiqZFXCZfZs1cgkdd3O/sSYmdo2EpSyDlC86UM/8YytTmKnehOW3TGAlivqTDT6bS87B/GQ/jyg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.7.0",
-        "@typescript-eslint/scope-manager": "8.39.0",
-        "@typescript-eslint/types": "8.39.0",
-        "@typescript-eslint/typescript-estree": "8.39.0"
+        "@typescript-eslint/scope-manager": "8.39.1",
+        "@typescript-eslint/types": "8.39.1",
+        "@typescript-eslint/typescript-estree": "8.39.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1080,13 +673,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.39.0.tgz",
-      "integrity": "sha512-ldgiJ+VAhQCfIjeOgu8Kj5nSxds0ktPOSO9p4+0VDH2R2pLvQraaM5Oen2d7NxzMCm+Sn/vJT+mv2H5u6b/3fA==",
+      "version": "8.39.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.39.1.tgz",
+      "integrity": "sha512-W8FQi6kEh2e8zVhQ0eeRnxdvIoOkAp/CPAahcNio6nO9dsIwb9b34z90KOlheoyuVf6LSOEdjlkxSkapNEc+4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.39.0",
+        "@typescript-eslint/types": "8.39.1",
         "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
@@ -1122,18 +715,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@whatwg-node/promise-helpers": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@whatwg-node/promise-helpers/-/promise-helpers-1.3.2.tgz",
-      "integrity": "sha512-Nst5JdK47VIl9UcGwtv2Rcgyn5lWtZ0/mhRQ4G8NN2isxpq2TO30iqHzmwoJycjWuyUfg3GFXqP/gFHXeV57IA==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.6.3"
-      },
-      "engines": {
-        "node": ">=16.0.0"
       }
     },
     "node_modules/abbrev": {
@@ -1285,30 +866,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/asap": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
-      "license": "MIT"
-    },
     "node_modules/async-sema": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/async-sema/-/async-sema-3.1.1.tgz",
       "integrity": "sha512-tLRNUXati5MFePdAk8dw7Qt7DpxPB60ofAgn8WRhW6a2rcimZnYBP9oxHiv0OHy+Wz7kPMG+t4LGdt31+4EmGg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/auto-bind": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-4.0.0.tgz",
-      "integrity": "sha512-Hdw8qdNiqdJ8LqT0iK0sVzkFbzg6fhnQqqfWhBDxcHZvU75+B+ayzTy8x+k5Ix0Y92XOhOUlx74ps+bA6BeYMQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/ava": {
       "version": "6.4.1",
@@ -1421,15 +984,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/bser": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
-      "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "node-int64": "^0.4.0"
-      }
-    },
     "node_modules/callsites": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-4.2.0.tgz",
@@ -1441,27 +995,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/camel-case": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
-      "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
-      "license": "MIT",
-      "dependencies": {
-        "pascal-case": "^3.1.2",
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/capital-case": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/capital-case/-/capital-case-1.0.4.tgz",
-      "integrity": "sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==",
-      "license": "MIT",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3",
-        "upper-case-first": "^2.0.2"
       }
     },
     "node_modules/cbor": {
@@ -1488,24 +1021,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/change-case": {
-      "version": "5.4.4",
-      "resolved": "https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz",
-      "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
-      "license": "MIT"
-    },
-    "node_modules/change-case-all": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/change-case-all/-/change-case-all-2.1.0.tgz",
-      "integrity": "sha512-v6b0WWWkZUMHVuYk82l+WROgkUm4qEN2w5hKRNWtEOYwWqUGoi8C6xH0l1RLF1EoWqDFK6MFclmN3od6ws3/uw==",
-      "license": "MIT",
-      "dependencies": {
-        "change-case": "^5.2.0",
-        "sponge-case": "^2.0.2",
-        "swap-case": "^3.0.2",
-        "title-case": "^3.0.3"
       }
     },
     "node_modules/chownr": {
@@ -1686,6 +1201,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -1698,6 +1214,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/common-path-prefix": {
@@ -1706,15 +1223,6 @@
       "integrity": "sha512-QE33hToZseCH3jS0qN96O/bSh3kaw/h+Tq7ngyY9eWDUnTlTNUyqfqvCXioLe5Na5jFsL78ra/wuBU4iuEgd4w==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/common-tags": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz",
-      "integrity": "sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0.0"
-      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -1753,17 +1261,6 @@
         "node": "^14.18.0 || >=16.10.0"
       }
     },
-    "node_modules/constant-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
-      "integrity": "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==",
-      "license": "MIT",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3",
-        "upper-case": "^2.0.2"
-      }
-    },
     "node_modules/convert-to-spaces": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/convert-to-spaces/-/convert-to-spaces-2.0.1.tgz",
@@ -1772,27 +1269,6 @@
       "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      }
-    },
-    "node_modules/cross-fetch": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.2.0.tgz",
-      "integrity": "sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==",
-      "license": "MIT",
-      "dependencies": {
-        "node-fetch": "^2.7.0"
-      }
-    },
-    "node_modules/cross-inspect": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/cross-inspect/-/cross-inspect-1.0.1.tgz",
-      "integrity": "sha512-Pcw1JTvZLSJH83iiGWt6fRcT+BjZlCDRVwYLbUcHzv/CRpB7r0MlSrGbIyQvVSNyGnbt7G4AXuyCiDR3POvZ1A==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
       }
     },
     "node_modules/cross-spawn": {
@@ -1861,15 +1337,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/dependency-graph": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-0.11.0.tgz",
-      "integrity": "sha512-JeMq7fEshyepOWDfcfHK06N3MhyPhz++vtqWhMT5O9A3K42rdsEDpfdVqjaqaAhsw6a+ZqeDvQVtD0hFHQWrzg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6.0"
-      }
-    },
     "node_modules/detect-libc": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
@@ -1878,25 +1345,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/dot-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
-      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
-      "license": "MIT",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/dset": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.4.tgz",
-      "integrity": "sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/eastasianwidth": {
@@ -1950,20 +1398,20 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.32.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.32.0.tgz",
-      "integrity": "sha512-LSehfdpgMeWcTZkWZVIJl+tkZ2nuSkyyB9C27MZqFWXuph7DvaowgcTvKqxvpLW1JZIk8PN7hFY3Rj9LQ7m7lg==",
+      "version": "9.33.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.33.0.tgz",
+      "integrity": "sha512-TS9bTNIryDzStCpJN93aC5VRSW3uTx9sClUn4B87pwiCaJh220otoI0X8mJKr+VcPtniMdN8GKjlwgWGUv5ZKA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
         "@eslint/config-array": "^0.21.0",
-        "@eslint/config-helpers": "^0.3.0",
-        "@eslint/core": "^0.15.0",
+        "@eslint/config-helpers": "^0.3.1",
+        "@eslint/core": "^0.15.2",
         "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.32.0",
-        "@eslint/plugin-kit": "^0.3.4",
+        "@eslint/js": "9.33.0",
+        "@eslint/plugin-kit": "^0.3.5",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
@@ -2225,36 +1673,6 @@
       "dependencies": {
         "reusify": "^1.0.4"
       }
-    },
-    "node_modules/fb-watchman": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
-      "integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bser": "2.1.1"
-      }
-    },
-    "node_modules/fbjs": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-3.0.5.tgz",
-      "integrity": "sha512-ztsSx77JBtkuMrEypfhgc3cI0+0h+svqeie7xHbh1k/IKdcydnvadp/mUaGgjAOXQmQSxsqgaRhS3q9fy+1kxg==",
-      "license": "MIT",
-      "dependencies": {
-        "cross-fetch": "^3.1.5",
-        "fbjs-css-vars": "^1.0.0",
-        "loose-envify": "^1.0.0",
-        "object-assign": "^4.1.0",
-        "promise": "^7.1.1",
-        "setimmediate": "^1.0.5",
-        "ua-parser-js": "^1.0.35"
-      }
-    },
-    "node_modules/fbjs-css-vars": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz",
-      "integrity": "sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ==",
-      "license": "MIT"
     },
     "node_modules/figures": {
       "version": "6.1.0",
@@ -2524,42 +1942,14 @@
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
     },
-    "node_modules/graphql-codegen-shared": {
-      "resolved": "../graphql-codegen-shared",
-      "link": true
-    },
-    "node_modules/graphql-tag": {
-      "version": "2.12.6",
-      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.6.tgz",
-      "integrity": "sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
-      }
-    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/header-case": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.4.tgz",
-      "integrity": "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==",
-      "license": "MIT",
-      "dependencies": {
-        "capital-case": "^1.0.4",
-        "tslib": "^2.0.3"
       }
     },
     "node_modules/https-proxy-agent": {
@@ -2596,15 +1986,6 @@
         "node": ">=10 <11 || >=12 <13 || >=14"
       }
     },
-    "node_modules/immutable": {
-      "version": "3.7.6",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.7.6.tgz",
-      "integrity": "sha512-AizQPcaofEtO11RZhPPHBOJRdo/20MKQF9mBLnVkBoyHi1/zXK8fzVdnEpSV9gxqtnh6Qomfp3F0xT5qP/vThw==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -2632,18 +2013,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/import-from": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/import-from/-/import-from-4.0.0.tgz",
-      "integrity": "sha512-P9J71vT5nLlDeV8FHs5nNxaLbrpfAV5cF5srvbZfpwpcJoM/xZR3hiv+q+SAnuSmuGbXMWud063iIMx/V/EWZQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -2667,15 +2036,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/invariant": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.0.0"
-      }
-    },
     "node_modules/irregular-plurals": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-3.5.0.tgz",
@@ -2684,19 +2044,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/is-absolute": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
-      "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
-      "license": "MIT",
-      "dependencies": {
-        "is-relative": "^1.0.0",
-        "is-windows": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/is-extglob": {
@@ -2735,15 +2082,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-lower-case": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-2.0.2.tgz",
-      "integrity": "sha512-bVcMJy4X5Og6VZfdOZstSexlEy20Sr0k/p/b2IlQJlfdKAQuMpiv5w2Ccxb8sKdRUNAG1PnHVHjFSdRDVS6NlQ==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.3"
-      }
-    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -2771,30 +2109,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/is-relative": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
-      "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
-      "license": "MIT",
-      "dependencies": {
-        "is-unc-path": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-unc-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
-      "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
-      "license": "MIT",
-      "dependencies": {
-        "unc-path-regex": "^0.1.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/is-unicode-supported": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
@@ -2806,24 +2120,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is-upper-case": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-2.0.2.tgz",
-      "integrity": "sha512-44pxmxAvnnAOwBg4tHPnkfvgjPwbc5QIsSstNU+YcJ1ovxVzCWpSGosPJOZh/a1tdl81fbgnLc9LLv+x2ywbPQ==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/is-windows": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/isexe": {
@@ -2859,12 +2155,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "license": "MIT"
-    },
     "node_modules/js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -2876,18 +2166,6 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/jsesc": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
-      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
-      "license": "MIT",
-      "bin": {
-        "jsesc": "bin/jsesc"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/json-buffer": {
@@ -2968,6 +2246,7 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.merge": {
@@ -2977,51 +2256,12 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "license": "MIT",
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
-      }
-    },
-    "node_modules/lower-case": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
-      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/lower-case-first": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/lower-case-first/-/lower-case-first-2.0.2.tgz",
-      "integrity": "sha512-EVm/rR94FJTZi3zefZ82fLWab+GX14LJN4HrWBcuo6Evmsl9hEfnqxgcHCKb9q+mNf6EVdsjx/qucYFIIB84pg==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.3"
-      }
-    },
     "node_modules/lru-cache": {
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/map-cache": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
-      "integrity": "sha512-8y/eV9QQZCiyn1SprXSrCmqJN0yNRATe+PO8ztwqrvrbdRLA3eYJF0yaR0YayLWkMbsQSKWS9N2gPcGEc4UsZg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/matcher": {
       "version": "5.0.0",
@@ -3197,20 +2437,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/no-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
-      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
-      "license": "MIT",
-      "dependencies": {
-        "lower-case": "^2.0.2",
-        "tslib": "^2.0.3"
-      }
-    },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-url": "^5.0.0"
@@ -3239,12 +2470,6 @@
         "node-gyp-build-test": "build-test.js"
       }
     },
-    "node_modules/node-int64": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
-      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
-      "license": "MIT"
-    },
     "node_modules/nofilter": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/nofilter/-/nofilter-3.1.0.tgz",
@@ -3269,21 +2494,6 @@
       },
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/nullthrows": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/nullthrows/-/nullthrows-1.1.1.tgz",
-      "integrity": "sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==",
-      "license": "MIT"
-    },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/optionator": {
@@ -3373,16 +2583,6 @@
       "dev": true,
       "license": "BlueOak-1.0.0"
     },
-    "node_modules/param-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
-      "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
-      "license": "MIT",
-      "dependencies": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -3406,20 +2606,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/parse-filepath": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.2.tgz",
-      "integrity": "sha512-FwdRXKCohSVeXqwtYonZTXtbGJKrn+HNyWDYVcp5yuJlesTwNH4rsmRZ+GrKAPJ5bLpRxESMeS+Rl0VCHRvB2Q==",
-      "license": "MIT",
-      "dependencies": {
-        "is-absolute": "^1.0.0",
-        "map-cache": "^0.2.0",
-        "path-root": "^0.1.1"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/parse-ms": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
@@ -3431,26 +2617,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/pascal-case": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
-      "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
-      "license": "MIT",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/path-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
-      "integrity": "sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==",
-      "license": "MIT",
-      "dependencies": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
       }
     },
     "node_modules/path-exists": {
@@ -3471,27 +2637,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/path-root": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
-      "integrity": "sha512-QLcPegTHF11axjfojBIoDygmS2E3Lf+8+jI6wOVmNVenrKSo3mFdSGiIgdSHenczw3wPtlVMQaFVwGmM7BJdtg==",
-      "license": "MIT",
-      "dependencies": {
-        "path-root-regex": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/path-root-regex": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
-      "integrity": "sha512-4GlJ6rZDhQZFE0DPVKh0e9jmZ5egZfxTkp7bcRDuPlJXbAwhxcl2dINPUAsjLdejqaLsCeg8axcLjIbvBjN4pQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/path-scurry": {
@@ -3579,15 +2724,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/promise": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-      "license": "MIT",
-      "dependencies": {
-        "asap": "~2.0.3"
-      }
-    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3618,17 +2754,6 @@
         }
       ],
       "license": "MIT"
-    },
-    "node_modules/relay-runtime": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/relay-runtime/-/relay-runtime-12.0.0.tgz",
-      "integrity": "sha512-QU6JKr1tMsry22DXNy9Whsq5rmvwr3LSZiiWV/9+DFpuTWvp+WFhobWMc8TC4OjKFfNhEZy7mOiqUAn5atQtug==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.0.0",
-        "fbjs": "^3.0.0",
-        "invariant": "^2.2.4"
-      }
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -3711,17 +2836,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/sentence-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz",
-      "integrity": "sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==",
-      "license": "MIT",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3",
-        "upper-case-first": "^2.0.2"
-      }
-    },
     "node_modules/serialize-error": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
@@ -3737,12 +2851,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/setimmediate": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
-      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -3780,12 +2888,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/signedsource": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/signedsource/-/signedsource-1.0.0.tgz",
-      "integrity": "sha512-6+eerH9fEnNmi/hyM1DXcRK3pWdoMQtlkQ+ns0ntzunjKqp5i3sKCc80ym8Fib3iaYhdJUOPdhlJWj1tvge2Ww==",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/slash": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
@@ -3815,22 +2917,6 @@
       "funding": {
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
-    },
-    "node_modules/snake-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
-      "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
-      "license": "MIT",
-      "dependencies": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/sponge-case": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/sponge-case/-/sponge-case-2.0.3.tgz",
-      "integrity": "sha512-i4h9ZGRfxV6Xw3mpZSFOfbXjf0cQcYmssGWutgNIfFZ2VM+YIWfD71N/kjjwK6X/AAHzBr+rciEcn/L34S8TGw==",
-      "license": "MIT"
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
@@ -4033,6 +3119,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -4040,12 +3127,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/swap-case": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-3.0.3.tgz",
-      "integrity": "sha512-6p4op8wE9CQv7uDFzulI6YXUw4lD9n4oQierdbFThEKVWVQcbQcUjdP27W8XE7V4QnWmnq9jueSHceyyQnqQVA==",
-      "license": "MIT"
     },
     "node_modules/tar": {
       "version": "7.4.3",
@@ -4085,15 +3166,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/title-case": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/title-case/-/title-case-3.0.3.tgz",
-      "integrity": "sha512-e1zGYRvbffpcHIrnuqT0Dh+gEJtDaxDSoG4JAIpq4oDFyooziLBIiYQv0GBT4FUAnUop5uZ1hiIAj7oAF6sOCA==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.3"
-      }
-    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -4111,6 +3183,7 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/ts-api-utils": {
@@ -4125,12 +3198,6 @@
       "peerDependencies": {
         "typescript": ">=4.8.4"
       }
-    },
-    "node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -4173,16 +3240,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.39.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.39.0.tgz",
-      "integrity": "sha512-lH8FvtdtzcHJCkMOKnN73LIn6SLTpoojgJqDAxPm1jCR14eWSGPX8ul/gggBdPMk/d5+u9V854vTYQ8T5jF/1Q==",
+      "version": "8.39.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.39.1.tgz",
+      "integrity": "sha512-GDUv6/NDYngUlNvwaHM1RamYftxf782IyEDbdj3SeaIHHv8fNQVRC++fITT7kUJV/5rIA/tkoRSSskt6osEfqg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.39.0",
-        "@typescript-eslint/parser": "8.39.0",
-        "@typescript-eslint/typescript-estree": "8.39.0",
-        "@typescript-eslint/utils": "8.39.0"
+        "@typescript-eslint/eslint-plugin": "8.39.1",
+        "@typescript-eslint/parser": "8.39.1",
+        "@typescript-eslint/typescript-estree": "8.39.1",
+        "@typescript-eslint/utils": "8.39.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4194,41 +3261,6 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "node_modules/ua-parser-js": {
-      "version": "1.0.40",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.40.tgz",
-      "integrity": "sha512-z6PJ8Lml+v3ichVojCiB8toQJBuwR42ySM4ezjXIqXK3M0HczmKQ3LF4rhU55PfD99KEEXQG6yb7iOMyvYuHew==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/ua-parser-js"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/faisalman"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/faisalman"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "ua-parser-js": "script/cli.js"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/unc-path-regex": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
-      "integrity": "sha512-eXL4nmJT7oCpkZsHZUOJo8hcX3GbsiDOa0Qu9F646fi8dT3XuSVopVqAcEiVzSKKH7UoDti23wNX3qGFxcW5Qg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/undici-types": {
@@ -4251,24 +3283,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/upper-case": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
-      "integrity": "sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/upper-case-first": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
-      "integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.3"
-      }
-    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -4283,6 +3297,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/well-known-symbols": {
@@ -4299,6 +3314,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tr46": "~0.0.3",

--- a/codegen/graphql-codegen-shared/package.json
+++ b/codegen/graphql-codegen-shared/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "graphql-codegen-plugin-python",
+  "name": "graphql-codegen-shared",
   "version": "1.0.0",
   "private": true,
   "type": "module",
@@ -22,11 +22,9 @@
     "typescript": "^5.9.2",
     "typescript-eslint": "^8.39.0"
   },
-  "dependencies": {
-    "@graphql-codegen/plugin-helpers": "^5.1.1",
-    "@graphql-codegen/visitor-plugin-common": "^5.8.0",
-    "change-case-all": "^2.1.0",
-    "graphql-codegen-shared": "file:../graphql-codegen-shared"
+  "dependencies": {},
+  "peerDependencies": {
+    "graphql": "^16.11.0"
   },
   "ava": {
     "files": [

--- a/codegen/graphql-codegen-shared/src/assertIsNotUndefined.ts
+++ b/codegen/graphql-codegen-shared/src/assertIsNotUndefined.ts
@@ -1,7 +1,10 @@
 import { AssertionError } from 'assert';
 
-export function assertIsNotUndefined<T>(value: T | undefined): asserts value is T {
+export function assertIsNotUndefined<T>(
+  value: T | undefined,
+  message?: string,
+): asserts value is T {
   if (value === undefined) {
-    throw new AssertionError({ message: 'Value is undefined' });
+    throw new AssertionError({ message: message ?? 'Value is undefined' });
   }
 }

--- a/codegen/graphql-codegen-shared/src/assertIsNotUndefined.ts
+++ b/codegen/graphql-codegen-shared/src/assertIsNotUndefined.ts
@@ -1,0 +1,7 @@
+import { AssertionError } from 'assert';
+
+export function assertIsNotUndefined<T>(value: T | undefined): asserts value is T {
+  if (value === undefined) {
+    throw new AssertionError({ message: 'Value is undefined' });
+  }
+}

--- a/codegen/graphql-codegen-shared/src/collect-selected-fields-from-operation.test.ts
+++ b/codegen/graphql-codegen-shared/src/collect-selected-fields-from-operation.test.ts
@@ -1,0 +1,255 @@
+import test from 'ava';
+import { buildSchema, Kind, parse, validate } from 'graphql';
+import { assertIsNotUndefined } from './assertIsNotUndefined.ts';
+import { collectSelectedFieldsFromOperation } from './collect-selected-fields-from-operation.ts';
+
+const schema = buildSchema(/* GraphQL */ `
+  type NestedType {
+    fieldA: String
+    fieldB: String
+    fieldC: String
+    deeplyNested: DeeplyNestedType
+  }
+
+  type DeeplyNestedType {
+    fieldD: String
+    fieldE: String
+    recursive: DeeplyNestedType
+  }
+
+  type MutationOutput {
+    nested: NestedType
+  }
+  type Mutation {
+    mutate: MutationOutput
+  }
+  type Query {
+    void: String
+  }
+`);
+
+test('Multiple selections on the same field', t => {
+  // Arrange
+  const documents = parse(/* GraphQL */ `
+    mutation mutate {
+      mutate {
+        nested {
+          fieldA
+        }
+        nested {
+          fieldB
+        }
+      }
+    }
+  `);
+
+  const validationErrors = validate(schema, documents);
+  if (validationErrors.length !== 0) {
+    throw new AggregateError(validationErrors, 'GraphQL Schema validation errors');
+  }
+
+  const operation = documents.definitions.find(
+    definition => definition.kind === Kind.OPERATION_DEFINITION,
+  );
+  assertIsNotUndefined(operation);
+
+  // Act
+  const res = collectSelectedFieldsFromOperation(operation, []);
+
+  // Assert
+  t.deepEqual(res, {
+    type: 'object',
+    name: 'mutate',
+    fields: [
+      {
+        type: 'object',
+        name: 'nested',
+        fields: [
+          { type: 'scalar', name: 'fieldA' },
+          { type: 'scalar', name: 'fieldB' },
+        ],
+      },
+    ],
+  });
+});
+
+test('Deeply nested selection', t => {
+  // Arrange
+  const documents = parse(/* GraphQL */ `
+    mutation mutate {
+      mutate {
+        nested {
+          fieldA
+          deeplyNested {
+            fieldD
+            recursive {
+              fieldE
+            }
+          }
+        }
+      }
+    }
+  `);
+
+  const validationErrors = validate(schema, documents);
+  if (validationErrors.length !== 0) {
+    throw new AggregateError(
+      validationErrors,
+      `GraphQL Schema validation errors ${validationErrors.map(e => e.message).join('\n')}`,
+    );
+  }
+
+  const operation = documents.definitions.find(
+    definition => definition.kind === Kind.OPERATION_DEFINITION,
+  );
+  assertIsNotUndefined(operation);
+  const fragments = documents.definitions.filter(
+    definition => definition.kind === Kind.FRAGMENT_DEFINITION,
+  );
+
+  // Act
+  const res = collectSelectedFieldsFromOperation(operation, fragments);
+
+  // Assert
+  t.deepEqual(res, {
+    type: 'object',
+    name: 'mutate',
+    fields: [
+      {
+        type: 'object',
+        name: 'nested',
+        fields: [
+          { type: 'scalar', name: 'fieldA' },
+          {
+            type: 'object',
+            name: 'deeplyNested',
+            fields: [
+              {
+                type: 'scalar',
+                name: 'fieldD',
+              },
+              {
+                type: 'object',
+                name: 'recursive',
+                fields: [
+                  {
+                    type: 'scalar',
+                    name: 'fieldE',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  });
+});
+
+test('Multiple selections on the same field, with fragments', t => {
+  // Arrange
+  const documents = parse(/* GraphQL */ `
+    fragment Foo on NestedType {
+      fieldB
+    }
+    mutation mutate {
+      mutate {
+        nested {
+          fieldA
+          ...Foo
+        }
+      }
+    }
+  `);
+
+  const validationErrors = validate(schema, documents);
+  if (validationErrors.length !== 0) {
+    throw new AggregateError(
+      validationErrors,
+      `GraphQL Schema validation errors ${validationErrors.map(e => e.message).join('\n')}`,
+    );
+  }
+
+  const operation = documents.definitions.find(
+    definition => definition.kind === Kind.OPERATION_DEFINITION,
+  );
+  assertIsNotUndefined(operation);
+  const fragments = documents.definitions.filter(
+    definition => definition.kind === Kind.FRAGMENT_DEFINITION,
+  );
+
+  // Act
+  const res = collectSelectedFieldsFromOperation(operation, fragments);
+
+  // Assert
+  t.deepEqual(res, {
+    type: 'object',
+    name: 'mutate',
+    fields: [
+      {
+        type: 'object',
+        name: 'nested',
+        fields: [
+          { type: 'scalar', name: 'fieldA' },
+          { type: 'scalar', name: 'fieldB' },
+        ],
+      },
+    ],
+  });
+});
+
+test('Multiple fragments', t => {
+  // Arrange
+  const documents = parse(/* GraphQL */ `
+    fragment Foo on NestedType {
+      fieldB
+    }
+    fragment Bar on NestedType {
+      fieldA
+      fieldB
+    }
+    mutation mutate {
+      mutate {
+        nested {
+          ...Bar
+          ...Foo
+        }
+      }
+    }
+  `);
+
+  const validationErrors = validate(schema, documents);
+  if (validationErrors.length !== 0) {
+    throw new AggregateError(
+      validationErrors,
+      `GraphQL Schema validation errors ${validationErrors.map(e => e.message).join('.\n')}`,
+    );
+  }
+
+  const operation = documents.definitions.find(
+    definition => definition.kind === Kind.OPERATION_DEFINITION,
+  );
+  assertIsNotUndefined(operation);
+  const fragments = documents.definitions.filter(
+    definition => definition.kind === Kind.FRAGMENT_DEFINITION,
+  );
+
+  // Act
+  const res = collectSelectedFieldsFromOperation(operation, fragments);
+
+  // Assert
+  t.deepEqual(res, {
+    type: 'object',
+    name: 'mutate',
+    fields: [
+      {
+        type: 'object',
+        name: 'nested',
+        fields: [
+          { type: 'scalar', name: 'fieldA' },
+          { type: 'scalar', name: 'fieldB' },
+        ],
+      },
+    ],
+  });
+});

--- a/codegen/graphql-codegen-shared/src/collect-selected-fields-from-operation.ts
+++ b/codegen/graphql-codegen-shared/src/collect-selected-fields-from-operation.ts
@@ -1,0 +1,111 @@
+import {
+  Kind,
+  type FieldNode,
+  type FragmentDefinitionNode,
+  type OperationDefinitionNode,
+} from 'graphql';
+import assert, { strictEqual } from 'assert';
+
+interface Scalar {
+  type: 'scalar';
+  name: string;
+}
+export interface SelectedFieldsObject {
+  type: 'object';
+  name: string;
+  fields: (Scalar | SelectedFieldsObject)[];
+}
+
+/**
+ * Given an operation definition (query or mutation), recursively traverse through the selection set,
+ * and collect the selected fields into a tree structure.
+ *
+ * If a field is selected multiple times at the same level in the tree, it will only be present in
+ * the output once.
+ *
+ * This method handles fragment spreads in the selection set, and converts them to their actual
+ * selected fields.
+ *
+ * Does not handle conditional selections
+ * Does not handle inline fragments
+ *
+ * @param operationNode
+ * @param fragments An array of all fragments used in the operation
+ * @returns
+ */
+export function collectSelectedFieldsFromOperation(
+  operationNode: OperationDefinitionNode,
+  fragments: FragmentDefinitionNode[],
+): SelectedFieldsObject {
+  strictEqual(
+    operationNode.selectionSet.selections.length,
+    1,
+    'Operation should have exactly one top-level selection',
+  );
+  strictEqual(
+    operationNode.selectionSet.selections[0]?.kind,
+    Kind.FIELD,
+    'Top-level selection should be a field',
+  );
+  const root: SelectedFieldsObject = {
+    name: operationNode.selectionSet.selections[0].name.value,
+    fields: [],
+    type: 'object',
+  };
+
+  collectFieldsRecursive(root, operationNode.selectionSet.selections[0], fragments);
+  return root;
+}
+
+function collectFieldsRecursive(
+  node: SelectedFieldsObject,
+  selectionNode: FieldNode | FragmentDefinitionNode,
+  fragments: FragmentDefinitionNode[],
+): void {
+  if (!selectionNode.selectionSet) {
+    return;
+  }
+
+  for (const selection of selectionNode.selectionSet.selections) {
+    switch (selection.kind) {
+      case Kind.FIELD: {
+        const name = selection.name.value;
+        if (selection.selectionSet == undefined) {
+          if (!node.fields.find(field => field.type === 'scalar' && field.name === name)) {
+            node.fields.push({ type: 'scalar', name });
+          }
+        } else {
+          let fieldNode = node.fields
+            .filter(field => field.type === 'object')
+            .find(field => field.name === name);
+
+          if (fieldNode == undefined) {
+            fieldNode = {
+              name,
+              type: 'object',
+              fields: [],
+            };
+            node.fields.push(fieldNode);
+          }
+
+          collectFieldsRecursive(fieldNode, selection, fragments);
+        }
+        break;
+      }
+      case Kind.FRAGMENT_SPREAD: {
+        const fragmentDefinition = fragments.find(
+          fragment => fragment.name.value === selection.name.value,
+        );
+        assert(fragmentDefinition, `No definition found for fragment ${selection.name.value}`);
+        collectFieldsRecursive(node, fragmentDefinition, fragments);
+        break;
+      }
+      case Kind.INLINE_FRAGMENT: {
+        // TODO
+        break;
+      }
+      default:
+        selection satisfies never;
+    }
+  }
+}

--- a/codegen/graphql-codegen-shared/src/index.ts
+++ b/codegen/graphql-codegen-shared/src/index.ts
@@ -1,0 +1,1 @@
+export { operationSelectionsToAstTree } from './selection-set-to-ast.ts';

--- a/codegen/graphql-codegen-shared/src/index.ts
+++ b/codegen/graphql-codegen-shared/src/index.ts
@@ -1,1 +1,2 @@
-export { operationSelectionsToAstTree } from './selection-set-to-ast.ts';
+export { operationSelectionsToAstTree, type AstTreeNode } from './selection-set-to-ast.ts';
+export { assertIsNotUndefined } from './assertIsNotUndefined.ts';

--- a/codegen/graphql-codegen-shared/src/selection-set-to-ast.test.ts
+++ b/codegen/graphql-codegen-shared/src/selection-set-to-ast.test.ts
@@ -1,0 +1,289 @@
+import { strictEqual } from 'node:assert';
+import test from 'ava';
+import { buildSchema, parse, validate, Kind } from 'graphql';
+import { operationSelectionsToAstTree } from './selection-set-to-ast.ts';
+import { assertIsNotUndefined } from './assertIsNotUndefined.ts';
+
+test('selecting fields from mutation output type', t => {
+  // Arrange
+  const schema = buildSchema(/* GraphQL */ `
+    type MutationOutput {
+      id: ID!
+      otherField: String
+    }
+    type Mutation {
+      mutate: MutationOutput
+    }
+    type Query {
+      void: String
+    }
+  `);
+
+  const documents = parse(/* GraphQL */ `
+    mutation mutate {
+      mutate {
+        id
+      }
+    }
+  `);
+
+  const validationErrors = validate(schema, documents);
+  if (validationErrors.length !== 0) {
+    throw new AggregateError(validationErrors, 'GraphQL Schema validation errors');
+  }
+
+  const operation = documents.definitions.find(
+    definition => definition.kind === Kind.OPERATION_DEFINITION,
+  );
+  assertIsNotUndefined(operation);
+
+  // Act
+  const astTree = operationSelectionsToAstTree({
+    node: operation,
+    fragments: [],
+    schema,
+  });
+
+  // Assert
+  strictEqual(astTree.astNode.kind, Kind.OBJECT_TYPE_DEFINITION);
+  strictEqual(astTree.children.length, 0);
+
+  strictEqual(astTree.astNode.fields?.length, 1);
+  t.is(astTree.astNode.fields[0]?.name.value, 'id');
+});
+
+test('selecting fields from query output type', t => {
+  // Arrange
+  const schema = buildSchema(/* GraphQL */ `
+    type QueryResponse {
+      fieldA: String!
+      fieldB: String
+      fieldC: String
+    }
+    type Mutation {
+      void: String
+    }
+    type Query {
+      query: QueryResponse
+    }
+  `);
+
+  const documents = parse(/* GraphQL */ `
+    query mutate {
+      query {
+        fieldA
+        fieldB
+      }
+    }
+  `);
+
+  const validationErrors = validate(schema, documents);
+  if (validationErrors.length !== 0) {
+    throw new AggregateError(validationErrors, 'GraphQL Schema validation errors');
+  }
+
+  const operation = documents.definitions.find(
+    definition => definition.kind === Kind.OPERATION_DEFINITION,
+  );
+  assertIsNotUndefined(operation);
+
+  // Act
+  const astTree = operationSelectionsToAstTree({
+    node: operation,
+    fragments: [],
+    schema,
+  });
+
+  // Assert
+  strictEqual(astTree.astNode.kind, Kind.OBJECT_TYPE_DEFINITION);
+  strictEqual(astTree.children.length, 0);
+
+  strictEqual(astTree.astNode.fields?.length, 2);
+
+  t.deepEqual(
+    astTree.astNode.fields.map(field => field.name.value),
+    ['fieldA', 'fieldB'],
+  );
+});
+
+test('selecting fields on nested types', t => {
+  // Arrange
+  const schema = buildSchema(/* GraphQL */ `
+    type Foo {
+      fieldA: String!
+      fieldB: String
+      fieldC: String
+    }
+    type QueryResponse {
+      foo: Foo!
+    }
+    type Mutation {
+      void: String
+    }
+    type Query {
+      query: QueryResponse
+    }
+  `);
+
+  const documents = parse(/* GraphQL */ `
+    query queryIt {
+      query {
+        foo {
+          fieldA
+          fieldB
+        }
+      }
+    }
+  `);
+
+  const validationErrors = validate(schema, documents);
+  if (validationErrors.length !== 0) {
+    throw new AggregateError(validationErrors, 'GraphQL Schema validation errors');
+  }
+
+  const operation = documents.definitions.find(
+    definition => definition.kind === Kind.OPERATION_DEFINITION,
+  );
+  assertIsNotUndefined(operation);
+
+  // Act
+  const astTree = operationSelectionsToAstTree({
+    node: operation,
+    fragments: [],
+    schema,
+  });
+
+  // Assert
+  strictEqual(astTree.astNode.kind, Kind.OBJECT_TYPE_DEFINITION);
+  strictEqual(astTree.astNode.name.value, 'QueryResponse');
+  strictEqual(astTree.astNode.fields?.length, 1);
+  assertIsNotUndefined(astTree.astNode.fields[0]);
+  strictEqual(astTree.astNode.fields[0].name.value, 'foo');
+  strictEqual(astTree.astNode.fields[0].type.kind, Kind.NON_NULL_TYPE);
+  strictEqual(astTree.astNode.fields[0].type.type.kind, Kind.NAMED_TYPE);
+  strictEqual(astTree.astNode.fields[0].type.type.name.value, 'Foo');
+
+  strictEqual(astTree.children.length, 1);
+  assertIsNotUndefined(astTree.children[0]);
+  strictEqual(astTree.children[0].astNode.kind, Kind.OBJECT_TYPE_DEFINITION);
+  strictEqual(astTree.children[0].astNode.name.value, 'Foo');
+  strictEqual(astTree.children[0].astNode.fields?.length, 2);
+  t.deepEqual(
+    astTree.children[0].astNode.fields.map(field => field.name.value),
+    ['fieldA', 'fieldB'],
+  );
+});
+
+test('works for fragments', t => {
+  // Arrange
+  const schema = buildSchema(/* GraphQL */ `
+    type MutationOutput {
+      fieldA: String!
+      fieldB: String
+      fieldC: String
+      fieldD: String
+    }
+    type Mutation {
+      myMutation: MutationOutput
+    }
+    type Query {
+      void: String
+    }
+  `);
+
+  const documents = parse(/* GraphQL */ `
+    fragment mutateFragment on MutationOutput {
+      fieldA
+      fieldB
+    }
+    mutation mutateIt {
+      myMutation {
+        fieldC
+        ...mutateFragment
+      }
+    }
+  `);
+
+  const validationErrors = validate(schema, documents);
+  if (validationErrors.length !== 0) {
+    throw new AggregateError(validationErrors, 'GraphQL Schema validation errors');
+  }
+
+  const operation = documents.definitions.find(
+    definition => definition.kind === Kind.OPERATION_DEFINITION,
+  );
+  assertIsNotUndefined(operation);
+  const fragments = documents.definitions.filter(
+    definition => definition.kind === Kind.FRAGMENT_DEFINITION,
+  );
+
+  // Act
+  const astTree = operationSelectionsToAstTree({
+    node: operation,
+    fragments,
+    schema,
+  });
+
+  // Assert
+  strictEqual(astTree.astNode.kind, Kind.OBJECT_TYPE_DEFINITION);
+  strictEqual(astTree.astNode.name.value, 'MutationOutput');
+  strictEqual(astTree.astNode.fields?.length, 3);
+
+  t.deepEqual(
+    astTree.astNode.fields.map(field => field.name.value),
+    ['fieldA', 'fieldB', 'fieldC'],
+  );
+});
+
+test('works on interfaces', t => {
+  // Arrange
+  const schema = buildSchema(/* GraphQL */ `
+    interface Foo {
+      fieldA: String!
+      fieldB: String
+      fieldC: String
+    }
+    type Mutation {
+      void: String
+    }
+    type Query {
+      foo: Foo
+    }
+  `);
+
+  const documents = parse(/* GraphQL */ `
+    query queryIt {
+      foo {
+        fieldA
+        fieldB
+      }
+    }
+  `);
+
+  const validationErrors = validate(schema, documents);
+  if (validationErrors.length !== 0) {
+    throw new AggregateError(validationErrors, 'GraphQL Schema validation errors');
+  }
+
+  const operation = documents.definitions.find(
+    definition => definition.kind === Kind.OPERATION_DEFINITION,
+  );
+  assertIsNotUndefined(operation);
+
+  // Act
+  const astTree = operationSelectionsToAstTree({
+    node: operation,
+    fragments: [],
+    schema,
+  });
+
+  // Assert
+  strictEqual(astTree.astNode.kind, Kind.OBJECT_TYPE_DEFINITION);
+  strictEqual(astTree.astNode.name.value, 'Foo');
+  strictEqual(astTree.astNode.fields?.length, 2);
+
+  t.deepEqual(
+    astTree.astNode.fields.map(field => field.name.value),
+    ['fieldA', 'fieldB'],
+  );
+});

--- a/codegen/graphql-codegen-shared/src/selection-set-to-ast.ts
+++ b/codegen/graphql-codegen-shared/src/selection-set-to-ast.ts
@@ -1,0 +1,153 @@
+import assert, { strictEqual } from 'node:assert';
+import {
+  type GraphQLOutputType,
+  type ObjectTypeDefinitionNode,
+  type FieldDefinitionNode,
+  type TypeNode,
+  type NamedTypeNode,
+  type FragmentDefinitionNode,
+  type InterfaceTypeDefinitionNode,
+  type OperationDefinitionNode,
+  OperationTypeNode,
+  isInterfaceType,
+  GraphQLSchema,
+  Kind,
+  isObjectType,
+  getNullableType,
+} from 'graphql';
+import {
+  collectSelectedFieldsFromOperation,
+  type SelectedFieldsObject,
+} from './collect-selected-fields-from-operation.ts';
+import { assertIsNotUndefined } from './assertIsNotUndefined.ts';
+
+export interface AstTreeNode {
+  astNode: ObjectTypeDefinitionNode;
+  children: AstTreeNode[];
+}
+
+/**
+ * Given an operation definition (mutation or query), returns a tree of AST nodes queried by
+ * the operations.
+ *
+ * The fields on the AST nodes are filtered by the selection set defined by the operation
+ */
+export function operationSelectionsToAstTree({
+  node,
+  fragments,
+  schema,
+}: {
+  node: OperationDefinitionNode;
+  fragments: FragmentDefinitionNode[];
+  schema: GraphQLSchema;
+}): AstTreeNode {
+  strictEqual(
+    node.selectionSet.selections.length,
+    1,
+    'Operation should have exactly one top-level selection',
+  );
+  strictEqual(
+    node.selectionSet.selections[0]?.kind,
+    Kind.FIELD,
+    'Top-level selection should be a field',
+  );
+  const typeName = node.selectionSet.selections[0].name.value;
+
+  let rootType: GraphQLOutputType | undefined;
+  switch (node.operation) {
+    case OperationTypeNode.MUTATION:
+      rootType = schema.getMutationType()?.getFields()[typeName]?.type;
+      break;
+    case OperationTypeNode.QUERY:
+      rootType = schema.getQueryType()?.getFields()[typeName]?.type;
+      break;
+    case OperationTypeNode.SUBSCRIPTION:
+      throw new Error('Subscriptions are not supported');
+    default:
+      node.operation satisfies never;
+  }
+
+  assert(rootType, 'Root type not found in schema');
+  rootType = getNullableType(rootType);
+  assert(
+    isObjectType(rootType) || isInterfaceType(rootType),
+    'Root type should be object or interface type',
+  );
+  assert(rootType.astNode, 'astNode missing on root type');
+
+  const selections = collectSelectedFieldsFromOperation(node, fragments);
+
+  return createAstTreeNodeFromSelection({
+    schema,
+    astNode: rootType.astNode,
+    fragments,
+    selections,
+  });
+}
+
+function createAstTreeNodeFromSelection({
+  schema,
+  astNode,
+  selections,
+  fragments,
+}: {
+  schema: GraphQLSchema;
+  fragments: FragmentDefinitionNode[];
+  astNode: ObjectTypeDefinitionNode | InterfaceTypeDefinitionNode;
+  selections: SelectedFieldsObject;
+}): AstTreeNode {
+  const children: AstTreeNode[] = [];
+  const filteredFields: FieldDefinitionNode[] = [];
+
+  for (const field of astNode.fields ?? []) {
+    const fieldSelection = selections.fields.find(selection => selection.name === field.name.value);
+    if (!fieldSelection) {
+      continue;
+    }
+
+    filteredFields.push(field);
+
+    const fieldType = unwrapTypeNode(field.type);
+    const schemaType = schema.getType(fieldType.name.value);
+
+    assertIsNotUndefined(schemaType);
+    if (isObjectType(schemaType) || isInterfaceType(schemaType)) {
+      assert(
+        schemaType.astNode?.kind === Kind.OBJECT_TYPE_DEFINITION ||
+          schemaType.astNode?.kind === Kind.INTERFACE_TYPE_DEFINITION,
+      );
+      strictEqual(fieldSelection.type, 'object');
+
+      children.push(
+        createAstTreeNodeFromSelection({
+          schema,
+          fragments,
+          astNode: schemaType.astNode,
+          selections: fieldSelection,
+        }),
+      );
+    }
+  }
+
+  return {
+    astNode: {
+      ...astNode,
+      // For now, we convert interfaces to objects, in order to output concrete types for interfaces
+      // this will probably change once we add support for inline fragments
+      kind: Kind.OBJECT_TYPE_DEFINITION,
+      fields: filteredFields,
+    },
+    children,
+  };
+}
+
+/**
+ * Named types can be wrapped in both non-nullable and list nodes (such as foo: [Bar!]!),
+ * which translates to NonNullType(ListType(NonNullType(Bar))))
+ */
+function unwrapTypeNode(node: TypeNode): NamedTypeNode {
+  while (node.kind === Kind.LIST_TYPE || node.kind == Kind.NON_NULL_TYPE) {
+    node = node.type;
+  }
+  return node;
+}

--- a/codegen/graphql-codegen-shared/tsconfig.json
+++ b/codegen/graphql-codegen-shared/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": ["@tsconfig/node24/tsconfig.json", "@tsconfig/strictest"],
+  "compilerOptions": {
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "exactOptionalPropertyTypes": false,
+    "verbatimModuleSyntax": true
+  },
+  "include": ["src", "eslint.config.ts"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,8 @@
       "dependencies": {
         "@graphql-codegen/plugin-helpers": "^5.1.1",
         "@graphql-codegen/visitor-plugin-common": "^5.8.0",
-        "change-case-all": "^2.1.0"
+        "change-case-all": "^2.1.0",
+        "graphql-codegen-shared": "file:../graphql-codegen-shared"
       },
       "devDependencies": {
         "@eslint/js": "^9.32.0",
@@ -76,6 +77,26 @@
       "integrity": "sha512-6p4op8wE9CQv7uDFzulI6YXUw4lD9n4oQierdbFThEKVWVQcbQcUjdP27W8XE7V4QnWmnq9jueSHceyyQnqQVA==",
       "dev": true,
       "license": "MIT"
+    },
+    "codegen/graphql-codegen-shared": {
+      "version": "1.0.0",
+      "dev": true,
+      "devDependencies": {
+        "@eslint/js": "^9.32.0",
+        "@tsconfig/node24": "^24.0.1",
+        "@tsconfig/strictest": "^2.0.5",
+        "@types/node": "^24.2.0",
+        "ava": "^6.4.1",
+        "eslint": "^9.32.0",
+        "typescript": "^5.9.2",
+        "typescript-eslint": "^8.39.0"
+      },
+      "engines": {
+        "node": "^22.18 || ^24"
+      },
+      "peerDependencies": {
+        "graphql": "^16.11.0"
+      }
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",
@@ -6371,9 +6392,9 @@
       "license": "MIT"
     },
     "node_modules/graphql": {
-      "version": "16.10.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.10.0.tgz",
-      "integrity": "sha512-AjqGKbDGUFRKIRCP9tCKiIGHyriz2oHEbPIbEtcSLSs4YjReZOIPQQWek4+6hjw62H9QShXHyaGivGiYVLeYFQ==",
+      "version": "16.11.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.11.0.tgz",
+      "integrity": "sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -6383,6 +6404,10 @@
     },
     "node_modules/graphql-codegen-plugin-python": {
       "resolved": "codegen/graphql-codegen-plugin-python",
+      "link": true
+    },
+    "node_modules/graphql-codegen-shared": {
+      "resolved": "codegen/graphql-codegen-shared",
       "link": true
     },
     "node_modules/graphql-config": {

--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -3,25 +3,21 @@ name = "criipto-signatures"
 version = "0.1.0"
 description = "A library for interacting with the Criipto signatures GraphQL API."
 readme = "README.md"
-authors = [
-    { name = "Jan Aagaard Meier", email = "jan.meier@criipto.com" }
-]
+authors = [{ name = "Jan Aagaard Meier", email = "jan.meier@criipto.com" }]
 requires-python = ">=3.13"
-dependencies = [
-    "gql[aiohttp]>=3.5.3",
-    "pydantic>=2.11.7",
-]
+dependencies = ["gql[aiohttp]>=3.5.3", "pydantic>=2.11.7"]
 
 [build-system]
 requires = ["uv_build>=0.8.4,<0.9.0"]
 build-backend = "uv_build"
 
 [dependency-groups]
-dev = [
-    "pytest>=8.4.1",
-    "ruff>=0.12.7",
-]
+dev = ["pytest>=8.4.1", "ruff>=0.12.7", "ty>=0.0.1a17"]
 test = []
 
 [tool.ruff]
 indent-width = 2
+
+[tool.ruff.lint.per-file-ignores]
+# operations bulk-import all enums and scalars. So we don't want to worry about unused imports
+"src/criipto_signatures/operations.py" = ["F401"]

--- a/packages/python/src/criipto_signatures/models.py
+++ b/packages/python/src/criipto_signatures/models.py
@@ -14,24 +14,24 @@ type URIScalar = str
 
 
 class AddSignatoriesInput(BaseModel):
-  signatories: "list[Optional[CreateSignatureOrderSignatoryInput]]"
+  signatories: "list[CreateSignatureOrderSignatoryInput]"
   signatureOrderId: "IDScalar"
 
 
 class AddSignatoriesOutput(BaseModel):
-  signatories: "Optional[list[Optional[Signatory]]]" = Field(default=None)
-  signatureOrder: "Optional[SignatureOrder]" = Field(default=None)
+  signatories: "list[Signatory]"
+  signatureOrder: "SignatureOrder"
 
 
 class AddSignatoryInput(BaseModel):
   # Define a subset of documents for the signatory. Must be a non-empty list. Leave null for all documents.
-  documents: "Optional[list[Optional[SignatoryDocumentInput]]]" = Field(default=None)
+  documents: "Optional[list[SignatoryDocumentInput]]" = Field(default=None)
   # Selectively enable evidence providers for this signatory.
-  evidenceProviders: "Optional[list[Optional[SignatoryEvidenceProviderInput]]]" = Field(
+  evidenceProviders: "Optional[list[SignatoryEvidenceProviderInput]]" = Field(
     default=None
   )
-  evidenceValidation: "Optional[list[Optional[SignatoryEvidenceValidationInput]]]" = (
-    Field(default=None)
+  evidenceValidation: "Optional[list[SignatoryEvidenceValidationInput]]" = Field(
+    default=None
   )
   # Will not be displayed to signatories, can be used as a reference to your own system.
   reference: "Optional[StringScalar]" = Field(default=None)
@@ -44,42 +44,40 @@ class AddSignatoryInput(BaseModel):
 
 
 class AddSignatoryOutput(BaseModel):
-  signatory: "Optional[Signatory]" = Field(default=None)
-  signatureOrder: "Optional[SignatureOrder]" = Field(default=None)
+  signatory: "Signatory"
+  signatureOrder: "SignatureOrder"
 
 
 class AllOfEvidenceProviderInput(BaseModel):
-  providers: "list[Optional[SingleEvidenceProviderInput]]"
+  providers: "list[SingleEvidenceProviderInput]"
 
 
 class AllOfSignatureEvidenceProvider(BaseModel):
-  id: "Optional[IDScalar]" = Field(default=None)
-  providers: "Optional[list[Optional[SingleSignatureEvidenceProvider]]]" = Field(
-    default=None
-  )
+  id: "IDScalar"
+  providers: "list[SingleSignatureEvidenceProvider]"
 
 
 class AnonymousViewer(BaseModel):
-  authenticated: "Optional[BooleanScalar]" = Field(default=None)
-  id: "Optional[IDScalar]" = Field(default=None)
+  authenticated: "BooleanScalar"
+  id: "IDScalar"
 
 
 class Application(BaseModel):
-  apiKeys: "Optional[list[Optional[ApplicationApiKey]]]" = Field(default=None)
-  id: "Optional[IDScalar]" = Field(default=None)
-  name: "Optional[StringScalar]" = Field(default=None)
-  signatureOrders: "Optional[SignatureOrderConnection]" = Field(default=None)
+  apiKeys: "list[ApplicationApiKey]"
+  id: "IDScalar"
+  name: "StringScalar"
+  signatureOrders: "SignatureOrderConnection"
   # Tenants are only accessable from user viewers
   tenant: "Optional[Tenant]" = Field(default=None)
-  verifyApplication: "Optional[VerifyApplication]" = Field(default=None)
-  webhookLogs: "Optional[list[Optional[WebhookInvocation]]]" = Field(default=None)
+  verifyApplication: "VerifyApplication"
+  webhookLogs: "list[WebhookInvocation]"
 
 
 class ApplicationApiKey(BaseModel):
-  clientId: "Optional[StringScalar]" = Field(default=None)
+  clientId: "StringScalar"
   clientSecret: "Optional[StringScalar]" = Field(default=None)
-  id: "Optional[IDScalar]" = Field(default=None)
-  mode: "Optional[ApplicationApiKeyMode]" = Field(default=None)
+  id: "IDScalar"
+  mode: "ApplicationApiKeyMode"
   note: "Optional[StringScalar]" = Field(default=None)
 
 
@@ -89,18 +87,18 @@ class ApplicationApiKeyMode(StrEnum):
 
 
 class BatchSignatory(BaseModel):
-  href: "Optional[StringScalar]" = Field(default=None)
-  id: "Optional[IDScalar]" = Field(default=None)
-  items: "Optional[list[Optional[BatchSignatoryItem]]]" = Field(default=None)
+  href: "StringScalar"
+  id: "IDScalar"
+  items: "list[BatchSignatoryItem]"
   # The authentication token required for performing batch operations.
-  token: "Optional[StringScalar]" = Field(default=None)
-  traceId: "Optional[StringScalar]" = Field(default=None)
-  ui: "Optional[SignatureOrderUI]" = Field(default=None)
+  token: "StringScalar"
+  traceId: "StringScalar"
+  ui: "SignatureOrderUI"
 
 
 class BatchSignatoryItem(BaseModel):
-  signatory: "Optional[Signatory]" = Field(default=None)
-  signatureOrder: "Optional[SignatureOrder]" = Field(default=None)
+  signatory: "Signatory"
+  signatureOrder: "SignatureOrder"
 
 
 class BatchSignatoryItemInput(BaseModel):
@@ -109,16 +107,14 @@ class BatchSignatoryItemInput(BaseModel):
 
 
 class BatchSignatoryViewer(BaseModel):
-  authenticated: "Optional[BooleanScalar]" = Field(default=None)
-  batchSignatoryId: "Optional[IDScalar]" = Field(default=None)
-  documents: "Optional[SignatoryDocumentConnection]" = Field(default=None)
-  evidenceProviders: "Optional[list[Optional[SignatureEvidenceProvider]]]" = Field(
-    default=None
-  )
-  id: "Optional[IDScalar]" = Field(default=None)
-  signer: "Optional[BooleanScalar]" = Field(default=None)
-  status: "Optional[SignatoryStatus]" = Field(default=None)
-  ui: "Optional[SignatureOrderUI]" = Field(default=None)
+  authenticated: "BooleanScalar"
+  batchSignatoryId: "IDScalar"
+  documents: "SignatoryDocumentConnection"
+  evidenceProviders: "list[SignatureEvidenceProvider]"
+  id: "IDScalar"
+  signer: "BooleanScalar"
+  status: "SignatoryStatus"
+  ui: "SignatureOrderUI"
 
 
 class CancelSignatureOrderInput(BaseModel):
@@ -126,18 +122,18 @@ class CancelSignatureOrderInput(BaseModel):
 
 
 class CancelSignatureOrderOutput(BaseModel):
-  signatureOrder: "Optional[SignatureOrder]" = Field(default=None)
+  signatureOrder: "SignatureOrder"
 
 
 class ChangeSignatoryInput(BaseModel):
   # Define a subset of documents for the signatory. Must be a non-empty list. Leave null for all documents.
-  documents: "Optional[list[Optional[SignatoryDocumentInput]]]" = Field(default=None)
+  documents: "Optional[list[SignatoryDocumentInput]]" = Field(default=None)
   # Selectively enable evidence providers for this signatory.
-  evidenceProviders: "Optional[list[Optional[SignatoryEvidenceProviderInput]]]" = Field(
+  evidenceProviders: "Optional[list[SignatoryEvidenceProviderInput]]" = Field(
     default=None
   )
-  evidenceValidation: "Optional[list[Optional[SignatoryEvidenceValidationInput]]]" = (
-    Field(default=None)
+  evidenceValidation: "Optional[list[SignatoryEvidenceValidationInput]]" = Field(
+    default=None
   )
   # Will not be displayed to signatories, can be used as a reference to your own system.
   reference: "Optional[StringScalar]" = Field(default=None)
@@ -150,8 +146,8 @@ class ChangeSignatoryInput(BaseModel):
 
 
 class ChangeSignatoryOutput(BaseModel):
-  signatory: "Optional[Signatory]" = Field(default=None)
-  signatureOrder: "Optional[SignatureOrder]" = Field(default=None)
+  signatory: "Signatory"
+  signatureOrder: "SignatureOrder"
 
 
 class ChangeSignatureOrderInput(BaseModel):
@@ -163,7 +159,7 @@ class ChangeSignatureOrderInput(BaseModel):
 
 
 class ChangeSignatureOrderOutput(BaseModel):
-  signatureOrder: "Optional[SignatureOrder]" = Field(default=None)
+  signatureOrder: "SignatureOrder"
 
 
 class CleanupSignatureOrderInput(BaseModel):
@@ -171,7 +167,7 @@ class CleanupSignatureOrderInput(BaseModel):
 
 
 class CleanupSignatureOrderOutput(BaseModel):
-  signatureOrder: "Optional[SignatureOrder]" = Field(default=None)
+  signatureOrder: "SignatureOrder"
 
 
 class CloseSignatureOrderInput(BaseModel):
@@ -181,7 +177,7 @@ class CloseSignatureOrderInput(BaseModel):
 
 
 class CloseSignatureOrderOutput(BaseModel):
-  signatureOrder: "Optional[SignatureOrder]" = Field(default=None)
+  signatureOrder: "SignatureOrder"
 
 
 class CompleteCriiptoVerifyEvidenceProviderInput(BaseModel):
@@ -190,12 +186,12 @@ class CompleteCriiptoVerifyEvidenceProviderInput(BaseModel):
 
 
 class CompleteCriiptoVerifyEvidenceProviderOutput(BaseModel):
-  jwt: "Optional[StringScalar]" = Field(default=None)
+  jwt: "StringScalar"
 
 
 class CompositeSignature(BaseModel):
   signatory: "Optional[Signatory]" = Field(default=None)
-  signatures: "Optional[list[Optional[SingleSignature]]]" = Field(default=None)
+  signatures: "list[SingleSignature]"
 
 
 class CreateApplicationApiKeyInput(BaseModel):
@@ -205,8 +201,8 @@ class CreateApplicationApiKeyInput(BaseModel):
 
 
 class CreateApplicationApiKeyOutput(BaseModel):
-  apiKey: "Optional[ApplicationApiKey]" = Field(default=None)
-  application: "Optional[Application]" = Field(default=None)
+  apiKey: "ApplicationApiKey"
+  application: "Application"
 
 
 class CreateApplicationInput(BaseModel):
@@ -218,31 +214,29 @@ class CreateApplicationInput(BaseModel):
 
 
 class CreateApplicationOutput(BaseModel):
-  apiKey: "Optional[ApplicationApiKey]" = Field(default=None)
-  application: "Optional[Application]" = Field(default=None)
-  tenant: "Optional[Tenant]" = Field(default=None)
+  apiKey: "ApplicationApiKey"
+  application: "Application"
+  tenant: "Tenant"
 
 
 class CreateBatchSignatoryInput(BaseModel):
-  items: "list[Optional[BatchSignatoryItemInput]]"
+  items: "list[BatchSignatoryItemInput]"
   # UI settings for batch signatory, will use defaults otherwise (will not use UI settings from sub signatories)
   ui: "Optional[SignatoryUIInput]" = Field(default=None)
 
 
 class CreateBatchSignatoryOutput(BaseModel):
-  batchSignatory: "Optional[BatchSignatory]" = Field(default=None)
+  batchSignatory: "BatchSignatory"
 
 
 class CreateSignatureOrderInput(BaseModel):
   # By default signatories will be prompted to sign with a Criipto Verify based e-ID, this setting disables it.
   disableVerifyEvidenceProvider: "Optional[BooleanScalar]" = Field(default=None)
-  documents: "list[Optional[DocumentInput]]"
+  documents: "list[DocumentInput]"
   # Define evidence providers for signature order if not using built-in Criipto Verify for e-IDs
-  evidenceProviders: "Optional[list[Optional[EvidenceProviderInput]]]" = Field(
-    default=None
-  )
+  evidenceProviders: "Optional[list[EvidenceProviderInput]]" = Field(default=None)
   # Defines when a signatory must be validated, default is when signing, but can be expanded to also be required when viewing documents.
-  evidenceValidationStages: "Optional[list[Optional[EvidenceValidationStage]]]" = Field(
+  evidenceValidationStages: "Optional[list[EvidenceValidationStage]]" = Field(
     default=None
   )
   # When this signature order will auto-close/expire at exactly in one of the following ISO-8601 formats: yyyy-MM-ddTHH:mm:ssZ, yyyy-MM-ddTHH:mm:ss.ffZ, yyyy-MM-ddTHH:mm:ss.fffZ, yyyy-MM-ddTHH:mm:ssK, yyyy-MM-ddTHH:mm:ss.ffK, yyyy-MM-ddTHH:mm:ss.fffK. Cannot be provided with `expiresInDays`.
@@ -253,7 +247,7 @@ class CreateSignatureOrderInput(BaseModel):
   fixDocumentFormattingErrors: "Optional[BooleanScalar]" = Field(default=None)
   # Max allowed signatories (as it influences pages needed for seals). Default 14.
   maxSignatories: "Optional[IntScalar]" = Field(default=None)
-  signatories: "Optional[list[Optional[CreateSignatureOrderSignatoryInput]]]" = Field(
+  signatories: "Optional[list[CreateSignatureOrderSignatoryInput]]" = Field(
     default=None
   )
   # Configure appearance of signatures inside documents
@@ -268,19 +262,19 @@ class CreateSignatureOrderInput(BaseModel):
 
 
 class CreateSignatureOrderOutput(BaseModel):
-  application: "Optional[Application]" = Field(default=None)
-  signatureOrder: "Optional[SignatureOrder]" = Field(default=None)
+  application: "Application"
+  signatureOrder: "SignatureOrder"
 
 
 class CreateSignatureOrderSignatoryInput(BaseModel):
   # Define a subset of documents for the signatory. Must be a non-empty list. Leave null for all documents.
-  documents: "Optional[list[Optional[SignatoryDocumentInput]]]" = Field(default=None)
+  documents: "Optional[list[SignatoryDocumentInput]]" = Field(default=None)
   # Selectively enable evidence providers for this signatory.
-  evidenceProviders: "Optional[list[Optional[SignatoryEvidenceProviderInput]]]" = Field(
+  evidenceProviders: "Optional[list[SignatoryEvidenceProviderInput]]" = Field(
     default=None
   )
-  evidenceValidation: "Optional[list[Optional[SignatoryEvidenceValidationInput]]]" = (
-    Field(default=None)
+  evidenceValidation: "Optional[list[SignatoryEvidenceValidationInput]]" = Field(
+    default=None
   )
   # Will not be displayed to signatories, can be used as a reference to your own system.
   reference: "Optional[StringScalar]" = Field(default=None)
@@ -316,16 +310,16 @@ class CreateSignatureOrderWebhookInput(BaseModel):
 
 
 class CriiptoVerifyEvidenceProviderRedirect(BaseModel):
-  redirectUri: "Optional[StringScalar]" = Field(default=None)
-  state: "Optional[StringScalar]" = Field(default=None)
+  redirectUri: "StringScalar"
+  state: "StringScalar"
 
 
 # Criipto Verify based evidence for signatures.
 class CriiptoVerifyProviderInput(BaseModel):
-  acrValues: "Optional[list[Optional[StringScalar]]]" = Field(default=None)
+  acrValues: "Optional[list[StringScalar]]" = Field(default=None)
   alwaysRedirect: "Optional[BooleanScalar]" = Field(default=None)
   # Define additional valid audiences (besides the main client_id) for the Criipto Verify domain/issuer underlying the application.
-  audiences: "Optional[list[Optional[StringScalar]]]" = Field(default=None)
+  audiences: "Optional[list[StringScalar]]" = Field(default=None)
   # Set a custom login_hint for the underlying authentication request.
   loginHint: "Optional[StringScalar]" = Field(default=None)
   # Messages displayed when performing authentication (only supported by DKMitID currently).
@@ -337,17 +331,17 @@ class CriiptoVerifyProviderInput(BaseModel):
 
 
 class CriiptoVerifySignatureEvidenceProvider(BaseModel):
-  acrValues: "Optional[list[Optional[StringScalar]]]" = Field(default=None)
-  alwaysRedirect: "Optional[BooleanScalar]" = Field(default=None)
-  audience: "Optional[StringScalar]" = Field(default=None)
-  audiences: "Optional[list[Optional[StringScalar]]]" = Field(default=None)
-  clientID: "Optional[StringScalar]" = Field(default=None)
-  domain: "Optional[StringScalar]" = Field(default=None)
+  acrValues: "list[StringScalar]"
+  alwaysRedirect: "BooleanScalar"
+  audience: "StringScalar"
+  audiences: "list[StringScalar]"
+  clientID: "StringScalar"
+  domain: "StringScalar"
   environment: "Optional[VerifyApplicationEnvironment]" = Field(default=None)
-  id: "Optional[IDScalar]" = Field(default=None)
+  id: "IDScalar"
   loginHint: "Optional[StringScalar]" = Field(default=None)
   message: "Optional[StringScalar]" = Field(default=None)
-  name: "Optional[StringScalar]" = Field(default=None)
+  name: "StringScalar"
   scope: "Optional[StringScalar]" = Field(default=None)
 
 
@@ -357,7 +351,7 @@ class DeleteApplicationApiKeyInput(BaseModel):
 
 
 class DeleteApplicationApiKeyOutput(BaseModel):
-  application: "Optional[Application]" = Field(default=None)
+  application: "Application"
 
 
 class DeleteSignatoryInput(BaseModel):
@@ -366,7 +360,7 @@ class DeleteSignatoryInput(BaseModel):
 
 
 class DeleteSignatoryOutput(BaseModel):
-  signatureOrder: "Optional[SignatureOrder]" = Field(default=None)
+  signatureOrder: "SignatureOrder"
 
 
 type Document = PdfDocument | XmlDocument
@@ -417,16 +411,16 @@ class DrawableEvidenceProviderInput(BaseModel):
 
 
 class DrawableSignature(BaseModel):
-  image: "Optional[BlobScalar]" = Field(default=None)
+  image: "BlobScalar"
   name: "Optional[StringScalar]" = Field(default=None)
   signatory: "Optional[Signatory]" = Field(default=None)
 
 
 class DrawableSignatureEvidenceProvider(BaseModel):
-  id: "Optional[IDScalar]" = Field(default=None)
+  id: "IDScalar"
   minimumHeight: "Optional[IntScalar]" = Field(default=None)
   minimumWidth: "Optional[IntScalar]" = Field(default=None)
-  requireName: "Optional[BooleanScalar]" = Field(default=None)
+  requireName: "BooleanScalar"
 
 
 class EmptySignature(BaseModel):
@@ -460,18 +454,18 @@ class ExtendSignatureOrderInput(BaseModel):
 
 
 class ExtendSignatureOrderOutput(BaseModel):
-  signatureOrder: "Optional[SignatureOrder]" = Field(default=None)
+  signatureOrder: "SignatureOrder"
 
 
 class JWTClaim(BaseModel):
-  name: "Optional[StringScalar]" = Field(default=None)
-  value: "Optional[StringScalar]" = Field(default=None)
+  name: "StringScalar"
+  value: "StringScalar"
 
 
 class JWTSignature(BaseModel):
-  claims: "Optional[list[Optional[JWTClaim]]]" = Field(default=None)
-  jwks: "Optional[StringScalar]" = Field(default=None)
-  jwt: "Optional[StringScalar]" = Field(default=None)
+  claims: "list[JWTClaim]"
+  jwks: "StringScalar"
+  jwt: "StringScalar"
   signatory: "Optional[Signatory]" = Field(default=None)
 
 
@@ -551,13 +545,13 @@ class NoopEvidenceProviderInput(BaseModel):
 
 
 class NoopSignatureEvidenceProvider(BaseModel):
-  id: "Optional[IDScalar]" = Field(default=None)
-  name: "Optional[StringScalar]" = Field(default=None)
+  id: "IDScalar"
+  name: "StringScalar"
 
 
 # OIDC/JWT based evidence for signatures.
 class OidcEvidenceProviderInput(BaseModel):
-  acrValues: "Optional[list[Optional[StringScalar]]]" = Field(default=None)
+  acrValues: "Optional[list[StringScalar]]" = Field(default=None)
   alwaysRedirect: "Optional[BooleanScalar]" = Field(default=None)
   audience: "StringScalar"
   clientID: "StringScalar"
@@ -568,12 +562,12 @@ class OidcEvidenceProviderInput(BaseModel):
 
 
 class OidcJWTSignatureEvidenceProvider(BaseModel):
-  acrValues: "Optional[list[Optional[StringScalar]]]" = Field(default=None)
-  alwaysRedirect: "Optional[BooleanScalar]" = Field(default=None)
-  clientID: "Optional[StringScalar]" = Field(default=None)
-  domain: "Optional[StringScalar]" = Field(default=None)
-  id: "Optional[IDScalar]" = Field(default=None)
-  name: "Optional[StringScalar]" = Field(default=None)
+  acrValues: "list[StringScalar]"
+  alwaysRedirect: "BooleanScalar"
+  clientID: "StringScalar"
+  domain: "StringScalar"
+  id: "IDScalar"
+  name: "StringScalar"
 
 
 class PadesDocumentFormInput(BaseModel):
@@ -610,9 +604,9 @@ class PageInfo(BaseModel):
   # When paginating forwards, the cursor to continue.
   endCursor: "Optional[StringScalar]" = Field(default=None)
   # When paginating forwards, are there more items?
-  hasNextPage: "Optional[BooleanScalar]" = Field(default=None)
+  hasNextPage: "BooleanScalar"
   # When paginating backwards, are there more items?
-  hasPreviousPage: "Optional[BooleanScalar]" = Field(default=None)
+  hasPreviousPage: "BooleanScalar"
   # When paginating backwards, the cursor to continue.
   startCursor: "Optional[StringScalar]" = Field(default=None)
 
@@ -627,18 +621,18 @@ class PdfBoundingBoxInput(BaseModel):
 class PdfDocument(BaseModel):
   blob: "Optional[BlobScalar]" = Field(default=None)
   # Same value as stamped on document when using displayDocumentID
-  documentID: "Optional[StringScalar]" = Field(default=None)
+  documentID: "StringScalar"
   form: "Optional[PdfDocumentForm]" = Field(default=None)
-  id: "Optional[IDScalar]" = Field(default=None)
+  id: "IDScalar"
   originalBlob: "Optional[BlobScalar]" = Field(default=None)
   reference: "Optional[StringScalar]" = Field(default=None)
   signatoryViewerStatus: "Optional[SignatoryDocumentStatus]" = Field(default=None)
-  signatures: "Optional[list[Optional[Signature]]]" = Field(default=None)
-  title: "Optional[StringScalar]" = Field(default=None)
+  signatures: "Optional[list[Signature]]" = Field(default=None)
+  title: "StringScalar"
 
 
 class PdfDocumentForm(BaseModel):
-  enabled: "Optional[BooleanScalar]" = Field(default=None)
+  enabled: "BooleanScalar"
 
 
 class PdfSealPosition(BaseModel):
@@ -656,8 +650,8 @@ class Query(BaseModel):
   signatureOrder: "Optional[SignatureOrder]" = Field(default=None)
   # Tenants are only accessable from user viewers
   tenant: "Optional[Tenant]" = Field(default=None)
-  timezones: "Optional[list[Optional[StringScalar]]]" = Field(default=None)
-  viewer: "Optional[Viewer]" = Field(default=None)
+  timezones: "list[StringScalar]"
+  viewer: "Viewer"
 
 
 class RefreshApplicationApiKeyInput(BaseModel):
@@ -666,8 +660,8 @@ class RefreshApplicationApiKeyInput(BaseModel):
 
 
 class RefreshApplicationApiKeyOutput(BaseModel):
-  apiKey: "Optional[ApplicationApiKey]" = Field(default=None)
-  application: "Optional[Application]" = Field(default=None)
+  apiKey: "ApplicationApiKey"
+  application: "Application"
 
 
 class RejectSignatureOrderInput(BaseModel):
@@ -676,7 +670,7 @@ class RejectSignatureOrderInput(BaseModel):
 
 
 class RejectSignatureOrderOutput(BaseModel):
-  viewer: "Optional[Viewer]" = Field(default=None)
+  viewer: "Viewer"
 
 
 class RetrySignatureOrderWebhookInput(BaseModel):
@@ -685,7 +679,7 @@ class RetrySignatureOrderWebhookInput(BaseModel):
 
 
 class RetrySignatureOrderWebhookOutput(BaseModel):
-  invocation: "Optional[WebhookInvocation]" = Field(default=None)
+  invocation: "WebhookInvocation"
 
 
 class SignActingAsInput(BaseModel):
@@ -694,8 +688,8 @@ class SignActingAsInput(BaseModel):
 
 
 class SignActingAsOutput(BaseModel):
-  signatory: "Optional[Signatory]" = Field(default=None)
-  signatureOrder: "Optional[SignatureOrder]" = Field(default=None)
+  signatory: "Signatory"
+  signatureOrder: "SignatureOrder"
 
 
 class SignAllOfInput(BaseModel):
@@ -715,7 +709,7 @@ class SignDocumentFormFieldInput(BaseModel):
 
 
 class SignDocumentFormInput(BaseModel):
-  fields: "list[Optional[SignDocumentFormFieldInput]]"
+  fields: "list[SignDocumentFormFieldInput]"
 
 
 class SignDocumentInput(BaseModel):
@@ -731,7 +725,7 @@ class SignDrawableInput(BaseModel):
 class SignInput(BaseModel):
   allOf: "Optional[SignAllOfInput]" = Field(default=None)
   criiptoVerify: "Optional[SignCriiptoVerifyInput]" = Field(default=None)
-  documents: "Optional[list[Optional[SignDocumentInput]]]" = Field(default=None)
+  documents: "Optional[list[SignDocumentInput]]" = Field(default=None)
   drawable: "Optional[SignDrawableInput]" = Field(default=None)
   # EvidenceProvider id
   id: "IDScalar"
@@ -744,32 +738,30 @@ class SignOidcInput(BaseModel):
 
 
 class SignOutput(BaseModel):
-  viewer: "Optional[Viewer]" = Field(default=None)
+  viewer: "Viewer"
 
 
 class Signatory(BaseModel):
-  documents: "Optional[SignatoryDocumentConnection]" = Field(default=None)
+  documents: "SignatoryDocumentConnection"
   # A download link for signatories to download their signed documents. Signatories must verify their identity before downloading. Can be used when signature order is closed with document retention.
   downloadHref: "Optional[StringScalar]" = Field(default=None)
-  evidenceProviders: "Optional[list[Optional[SignatureEvidenceProvider]]]" = Field(
-    default=None
-  )
+  evidenceProviders: "list[SignatureEvidenceProvider]"
   # A link to the signatures frontend, you can send this link to your users to enable them to sign your documents.
-  href: "Optional[StringScalar]" = Field(default=None)
-  id: "Optional[IDScalar]" = Field(default=None)
+  href: "StringScalar"
+  id: "IDScalar"
   reference: "Optional[StringScalar]" = Field(default=None)
   role: "Optional[StringScalar]" = Field(default=None)
   # Signature order for the signatory.
-  signatureOrder: "Optional[SignatureOrder]" = Field(default=None)
-  spanId: "Optional[StringScalar]" = Field(default=None)
+  signatureOrder: "SignatureOrder"
+  spanId: "StringScalar"
   # The current status of the signatory.
-  status: "Optional[SignatoryStatus]" = Field(default=None)
+  status: "SignatoryStatus"
   # The reason for the signatory status (rejection reason when rejected).
   statusReason: "Optional[StringScalar]" = Field(default=None)
   # The signature frontend authentication token, only required if you need to build a custom url.
-  token: "Optional[StringScalar]" = Field(default=None)
-  traceId: "Optional[StringScalar]" = Field(default=None)
-  ui: "Optional[SignatureOrderUI]" = Field(default=None)
+  token: "StringScalar"
+  traceId: "StringScalar"
+  ui: "SignatureOrderUI"
 
 
 class SignatoryBeaconInput(BaseModel):
@@ -777,15 +769,15 @@ class SignatoryBeaconInput(BaseModel):
 
 
 class SignatoryBeaconOutput(BaseModel):
-  viewer: "Optional[Viewer]" = Field(default=None)
+  viewer: "Viewer"
 
 
 class SignatoryDocumentConnection(BaseModel):
-  edges: "Optional[list[Optional[SignatoryDocumentEdge]]]" = Field(default=None)
+  edges: "list[SignatoryDocumentEdge]"
 
 
 class SignatoryDocumentEdge(BaseModel):
-  node: "Optional[Document]" = Field(default=None)
+  node: "Document"
   status: "Optional[SignatoryDocumentStatus]" = Field(default=None)
 
 
@@ -852,27 +844,25 @@ class SignatoryUIInput(BaseModel):
 
 
 class SignatoryViewer(BaseModel):
-  authenticated: "Optional[BooleanScalar]" = Field(default=None)
-  documents: "Optional[SignatoryDocumentConnection]" = Field(default=None)
+  authenticated: "BooleanScalar"
+  documents: "SignatoryDocumentConnection"
   download: "Optional[SignatoryViewerDownload]" = Field(default=None)
-  evidenceProviders: "Optional[list[Optional[SignatureEvidenceProvider]]]" = Field(
-    default=None
-  )
-  id: "Optional[IDScalar]" = Field(default=None)
-  signatoryId: "Optional[IDScalar]" = Field(default=None)
-  signatureOrderStatus: "Optional[SignatureOrderStatus]" = Field(default=None)
-  signer: "Optional[BooleanScalar]" = Field(default=None)
-  status: "Optional[SignatoryStatus]" = Field(default=None)
-  ui: "Optional[SignatureOrderUI]" = Field(default=None)
+  evidenceProviders: "list[SignatureEvidenceProvider]"
+  id: "IDScalar"
+  signatoryId: "IDScalar"
+  signatureOrderStatus: "SignatureOrderStatus"
+  signer: "BooleanScalar"
+  status: "SignatoryStatus"
+  ui: "SignatureOrderUI"
 
 
 class SignatoryViewerDownload(BaseModel):
   documents: "Optional[SignatoryDocumentConnection]" = Field(default=None)
-  expired: "Optional[BooleanScalar]" = Field(default=None)
+  expired: "BooleanScalar"
   verificationEvidenceProvider: "Optional[SignatureEvidenceProvider]" = Field(
     default=None
   )
-  verificationRequired: "Optional[BooleanScalar]" = Field(default=None)
+  verificationRequired: "BooleanScalar"
 
 
 # Represents a signature on a document.
@@ -880,28 +870,22 @@ type Signature = CompositeSignature | DrawableSignature | EmptySignature | JWTSi
 
 
 class SignatureAppearanceInput(BaseModel):
-  displayName: "Optional[list[Optional[SignatureAppearanceTemplateInput]]]" = Field(
-    default=None
-  )
-  footer: "Optional[list[Optional[SignatureAppearanceTemplateInput]]]" = Field(
-    default=None
-  )
-  headerLeft: "Optional[list[Optional[SignatureAppearanceTemplateInput]]]" = Field(
-    default=None
-  )
+  displayName: "Optional[list[SignatureAppearanceTemplateInput]]" = Field(default=None)
+  footer: "Optional[list[SignatureAppearanceTemplateInput]]" = Field(default=None)
+  headerLeft: "Optional[list[SignatureAppearanceTemplateInput]]" = Field(default=None)
   # Render evidence claim as identifier in the signature appearance inside the document. You can supply multiple keys and they will be tried in order. If no key is found a GUID will be rendered.
-  identifierFromEvidence: "list[Optional[StringScalar]]"
+  identifierFromEvidence: "list[StringScalar]"
 
 
 class SignatureAppearanceTemplateInput(BaseModel):
-  replacements: "Optional[list[Optional[SignatureAppearanceTemplateReplacementInput]]]" = Field(
+  replacements: "Optional[list[SignatureAppearanceTemplateReplacementInput]]" = Field(
     default=None
   )
   template: "StringScalar"
 
 
 class SignatureAppearanceTemplateReplacementInput(BaseModel):
-  fromEvidence: "list[Optional[StringScalar]]"
+  fromEvidence: "list[StringScalar]"
   placeholder: "StringScalar"
 
 
@@ -917,33 +901,31 @@ type SignatureEvidenceProvider = (
 class SignatureOrder(BaseModel):
   application: "Optional[Application]" = Field(default=None)
   closedAt: "Optional[DateTimeScalar]" = Field(default=None)
-  createdAt: "Optional[DateTimeScalar]" = Field(default=None)
-  documents: "Optional[list[Optional[Document]]]" = Field(default=None)
-  evidenceProviders: "Optional[list[Optional[SignatureEvidenceProvider]]]" = Field(
-    default=None
-  )
-  expiresAt: "Optional[DateTimeScalar]" = Field(default=None)
-  id: "Optional[IDScalar]" = Field(default=None)
+  createdAt: "DateTimeScalar"
+  documents: "list[Document]"
+  evidenceProviders: "list[SignatureEvidenceProvider]"
+  expiresAt: "DateTimeScalar"
+  id: "IDScalar"
   # Number of max signatories for the signature order
-  maxSignatories: "Optional[IntScalar]" = Field(default=None)
+  maxSignatories: "IntScalar"
   # List of signatories for the signature order.
-  signatories: "Optional[list[Optional[Signatory]]]" = Field(default=None)
-  status: "Optional[SignatureOrderStatus]" = Field(default=None)
+  signatories: "list[Signatory]"
+  status: "SignatureOrderStatus"
   # Tenants are only accessable from user viewers
   tenant: "Optional[Tenant]" = Field(default=None)
-  timezone: "Optional[StringScalar]" = Field(default=None)
+  timezone: "StringScalar"
   title: "Optional[StringScalar]" = Field(default=None)
-  traceId: "Optional[StringScalar]" = Field(default=None)
-  ui: "Optional[SignatureOrderUI]" = Field(default=None)
+  traceId: "StringScalar"
+  ui: "SignatureOrderUI"
   webhook: "Optional[SignatureOrderWebhook]" = Field(default=None)
 
 
 # A connection from an object to a list of objects of type SignatureOrder
 class SignatureOrderConnection(BaseModel):
   # Information to aid in pagination.
-  edges: "Optional[list[Optional[SignatureOrderEdge]]]" = Field(default=None)
+  edges: "list[SignatureOrderEdge]"
   # Information to aid in pagination.
-  pageInfo: "Optional[PageInfo]" = Field(default=None)
+  pageInfo: "PageInfo"
   # A count of the total number of objects in this connection, ignoring pagination. This allows a client to fetch the first five objects by passing \"5\" as the argument to `first`, then fetch the total count so it could display \"5 of 83\", for example. In cases where we employ infinite scrolling or don't have an exact count of entries, this field will return `null`.
   totalCount: "Optional[IntScalar]" = Field(default=None)
 
@@ -951,9 +933,9 @@ class SignatureOrderConnection(BaseModel):
 # An edge in a connection from an object to another object of type SignatureOrder
 class SignatureOrderEdge(BaseModel):
   # A cursor for use in pagination
-  cursor: "Optional[StringScalar]" = Field(default=None)
+  cursor: "StringScalar"
   # The item at the end of the edge. Must NOT be an enumerable collection.
-  node: "Optional[SignatureOrder]" = Field(default=None)
+  node: "SignatureOrder"
 
 
 class SignatureOrderStatus(StrEnum):
@@ -964,17 +946,17 @@ class SignatureOrderStatus(StrEnum):
 
 
 class SignatureOrderUI(BaseModel):
-  disableRejection: "Optional[BooleanScalar]" = Field(default=None)
-  language: "Optional[Language]" = Field(default=None)
+  disableRejection: "BooleanScalar"
+  language: "Language"
   logo: "Optional[SignatureOrderUILogo]" = Field(default=None)
-  renderPdfAnnotationLayer: "Optional[BooleanScalar]" = Field(default=None)
+  renderPdfAnnotationLayer: "BooleanScalar"
   signatoryRedirectUri: "Optional[StringScalar]" = Field(default=None)
   stylesheet: "Optional[StringScalar]" = Field(default=None)
 
 
 class SignatureOrderUILogo(BaseModel):
   href: "Optional[StringScalar]" = Field(default=None)
-  src: "Optional[StringScalar]" = Field(default=None)
+  src: "StringScalar"
 
 
 class SignatureOrderUILogoInput(BaseModel):
@@ -985,8 +967,8 @@ class SignatureOrderUILogoInput(BaseModel):
 
 
 class SignatureOrderWebhook(BaseModel):
-  logs: "Optional[list[Optional[WebhookInvocation]]]" = Field(default=None)
-  url: "Optional[StringScalar]" = Field(default=None)
+  logs: "list[WebhookInvocation]"
+  url: "StringScalar"
 
 
 # Must define a evidence provider subsection.
@@ -1022,9 +1004,9 @@ type StartCriiptoVerifyEvidenceProviderOutput = CriiptoVerifyEvidenceProviderRed
 
 
 class Tenant(BaseModel):
-  applications: "Optional[list[Optional[Application]]]" = Field(default=None)
-  id: "Optional[IDScalar]" = Field(default=None)
-  webhookLogs: "Optional[list[Optional[WebhookInvocation]]]" = Field(default=None)
+  applications: "list[Application]"
+  id: "IDScalar"
+  webhookLogs: "list[WebhookInvocation]"
 
 
 class TrackSignatoryInput(BaseModel):
@@ -1032,18 +1014,16 @@ class TrackSignatoryInput(BaseModel):
 
 
 class TrackSignatoryOutput(BaseModel):
-  viewer: "Optional[Viewer]" = Field(default=None)
+  viewer: "Viewer"
 
 
 class UnvalidatedSignatoryViewer(BaseModel):
-  authenticated: "Optional[BooleanScalar]" = Field(default=None)
+  authenticated: "BooleanScalar"
   download: "Optional[SignatoryViewerDownload]" = Field(default=None)
-  evidenceProviders: "Optional[list[Optional[SignatureEvidenceProvider]]]" = Field(
-    default=None
-  )
-  id: "Optional[IDScalar]" = Field(default=None)
-  signatoryId: "Optional[IDScalar]" = Field(default=None)
-  ui: "Optional[SignatureOrderUI]" = Field(default=None)
+  evidenceProviders: "list[SignatureEvidenceProvider]"
+  id: "IDScalar"
+  signatoryId: "IDScalar"
+  ui: "SignatureOrderUI"
 
 
 class UpdateSignatoryDocumentStatusInput(BaseModel):
@@ -1052,14 +1032,14 @@ class UpdateSignatoryDocumentStatusInput(BaseModel):
 
 
 class UpdateSignatoryDocumentStatusOutput(BaseModel):
-  documentEdge: "Optional[SignatoryDocumentEdge]" = Field(default=None)
-  viewer: "Optional[Viewer]" = Field(default=None)
+  documentEdge: "SignatoryDocumentEdge"
+  viewer: "Viewer"
 
 
 class UserViewer(BaseModel):
-  authenticated: "Optional[BooleanScalar]" = Field(default=None)
-  id: "Optional[IDScalar]" = Field(default=None)
-  tenants: "Optional[list[Optional[Tenant]]]" = Field(default=None)
+  authenticated: "BooleanScalar"
+  id: "IDScalar"
+  tenants: "list[Tenant]"
 
 
 class ValidateDocumentInput(BaseModel):
@@ -1068,18 +1048,18 @@ class ValidateDocumentInput(BaseModel):
 
 
 class ValidateDocumentOutput(BaseModel):
-  errors: "Optional[list[Optional[StringScalar]]]" = Field(default=None)
+  errors: "Optional[list[StringScalar]]" = Field(default=None)
   # Whether or not the errors are fixable using 'fixDocumentFormattingErrors'
   fixable: "Optional[BooleanScalar]" = Field(default=None)
   # `true` if the document contains signatures. If value is `null`, we were unable to determine whether the document has been previously signed.
   previouslySigned: "Optional[BooleanScalar]" = Field(default=None)
-  valid: "Optional[BooleanScalar]" = Field(default=None)
+  valid: "BooleanScalar"
 
 
 class VerifyApplication(BaseModel):
-  domain: "Optional[StringScalar]" = Field(default=None)
-  environment: "Optional[VerifyApplicationEnvironment]" = Field(default=None)
-  realm: "Optional[StringScalar]" = Field(default=None)
+  domain: "StringScalar"
+  environment: "VerifyApplicationEnvironment"
+  realm: "StringScalar"
 
 
 class VerifyApplicationEnvironment(StrEnum):
@@ -1104,29 +1084,29 @@ type Viewer = (
 
 
 class WebhookExceptionInvocation(BaseModel):
-  correlationId: "Optional[StringScalar]" = Field(default=None)
+  correlationId: "StringScalar"
   event: "Optional[WebhookInvocationEvent]" = Field(default=None)
-  exception: "Optional[StringScalar]" = Field(default=None)
-  requestBody: "Optional[StringScalar]" = Field(default=None)
+  exception: "StringScalar"
+  requestBody: "StringScalar"
   responseBody: "Optional[StringScalar]" = Field(default=None)
-  retryPayload: "Optional[StringScalar]" = Field(default=None)
+  retryPayload: "StringScalar"
   retryingAt: "Optional[StringScalar]" = Field(default=None)
   signatureOrderId: "Optional[StringScalar]" = Field(default=None)
-  timestamp: "Optional[StringScalar]" = Field(default=None)
-  url: "Optional[StringScalar]" = Field(default=None)
+  timestamp: "StringScalar"
+  url: "StringScalar"
 
 
 class WebhookHttpErrorInvocation(BaseModel):
-  correlationId: "Optional[StringScalar]" = Field(default=None)
+  correlationId: "StringScalar"
   event: "Optional[WebhookInvocationEvent]" = Field(default=None)
-  requestBody: "Optional[StringScalar]" = Field(default=None)
+  requestBody: "StringScalar"
   responseBody: "Optional[StringScalar]" = Field(default=None)
-  responseStatusCode: "Optional[IntScalar]" = Field(default=None)
-  retryPayload: "Optional[StringScalar]" = Field(default=None)
+  responseStatusCode: "IntScalar"
+  retryPayload: "StringScalar"
   retryingAt: "Optional[StringScalar]" = Field(default=None)
   signatureOrderId: "Optional[StringScalar]" = Field(default=None)
-  timestamp: "Optional[StringScalar]" = Field(default=None)
-  url: "Optional[StringScalar]" = Field(default=None)
+  timestamp: "StringScalar"
+  url: "StringScalar"
 
 
 type WebhookInvocation = (
@@ -1148,27 +1128,27 @@ class WebhookInvocationEvent(StrEnum):
 
 
 class WebhookSuccessfulInvocation(BaseModel):
-  correlationId: "Optional[StringScalar]" = Field(default=None)
+  correlationId: "StringScalar"
   event: "Optional[WebhookInvocationEvent]" = Field(default=None)
-  requestBody: "Optional[StringScalar]" = Field(default=None)
+  requestBody: "StringScalar"
   responseBody: "Optional[StringScalar]" = Field(default=None)
-  responseStatusCode: "Optional[IntScalar]" = Field(default=None)
+  responseStatusCode: "IntScalar"
   signatureOrderId: "Optional[StringScalar]" = Field(default=None)
-  timestamp: "Optional[StringScalar]" = Field(default=None)
-  url: "Optional[StringScalar]" = Field(default=None)
+  timestamp: "StringScalar"
+  url: "StringScalar"
 
 
 class WebhookTimeoutInvocation(BaseModel):
-  correlationId: "Optional[StringScalar]" = Field(default=None)
+  correlationId: "StringScalar"
   event: "Optional[WebhookInvocationEvent]" = Field(default=None)
-  requestBody: "Optional[StringScalar]" = Field(default=None)
+  requestBody: "StringScalar"
   responseBody: "Optional[StringScalar]" = Field(default=None)
-  responseTimeout: "Optional[IntScalar]" = Field(default=None)
-  retryPayload: "Optional[StringScalar]" = Field(default=None)
+  responseTimeout: "IntScalar"
+  retryPayload: "StringScalar"
   retryingAt: "Optional[StringScalar]" = Field(default=None)
   signatureOrderId: "Optional[StringScalar]" = Field(default=None)
-  timestamp: "Optional[StringScalar]" = Field(default=None)
-  url: "Optional[StringScalar]" = Field(default=None)
+  timestamp: "StringScalar"
+  url: "StringScalar"
 
 
 class XadesDocumentInput(BaseModel):
@@ -1181,12 +1161,12 @@ class XadesDocumentInput(BaseModel):
 
 class XmlDocument(BaseModel):
   blob: "Optional[BlobScalar]" = Field(default=None)
-  id: "Optional[IDScalar]" = Field(default=None)
+  id: "IDScalar"
   originalBlob: "Optional[BlobScalar]" = Field(default=None)
   reference: "Optional[StringScalar]" = Field(default=None)
   signatoryViewerStatus: "Optional[SignatoryDocumentStatus]" = Field(default=None)
-  signatures: "Optional[list[Optional[Signature]]]" = Field(default=None)
-  title: "Optional[StringScalar]" = Field(default=None)
+  signatures: "Optional[list[Signature]]" = Field(default=None)
+  title: "StringScalar"
 
 
 AddSignatoriesInput.model_rebuild()

--- a/packages/python/src/criipto_signatures/operations.py
+++ b/packages/python/src/criipto_signatures/operations.py
@@ -1,38 +1,44 @@
+from enum import StrEnum
+from typing import Optional
+from pydantic import BaseModel, Field
 from .models import (
-  CreateSignatureOrderOutput,
   CreateSignatureOrderInput,
-  CleanupSignatureOrderOutput,
   CleanupSignatureOrderInput,
-  AddSignatoryOutput,
   AddSignatoryInput,
-  AddSignatoriesOutput,
   AddSignatoriesInput,
-  ChangeSignatoryOutput,
   ChangeSignatoryInput,
-  CloseSignatureOrderOutput,
   CloseSignatureOrderInput,
-  CancelSignatureOrderOutput,
   CancelSignatureOrderInput,
-  SignActingAsOutput,
   SignActingAsInput,
-  ValidateDocumentOutput,
   ValidateDocumentInput,
-  ExtendSignatureOrderOutput,
   ExtendSignatureOrderInput,
-  DeleteSignatoryOutput,
   DeleteSignatoryInput,
-  CreateBatchSignatoryOutput,
   CreateBatchSignatoryInput,
-  ChangeSignatureOrderOutput,
   ChangeSignatureOrderInput,
-  SignatureOrder,
+)
+from .models import (
   IDScalar,
-  Signatory,
-  Viewer,
-  SignatureOrderStatus,
-  IntScalar,
   StringScalar,
-  BatchSignatory,
+  BooleanScalar,
+  IntScalar,
+  BlobScalar,
+  DateScalar,
+  DateTimeScalar,
+  FloatScalar,
+  URIScalar,
+)
+from .models import (
+  ApplicationApiKeyMode,
+  DocumentIDLocation,
+  DocumentStorageMode,
+  EvidenceValidationStage,
+  Language,
+  SignatoryDocumentStatus,
+  SignatoryFrontendEvent,
+  SignatoryStatus,
+  SignatureOrderStatus,
+  VerifyApplicationEnvironment,
+  WebhookInvocationEvent,
 )
 from gql import Client, gql
 from gql.transport.aiohttp import AIOHTTPTransport, BasicAuth
@@ -119,6 +125,98 @@ BasicBatchSignatoryFragment = """fragment BasicBatchSignatory on BatchSignatory 
   token
   href
 }"""
+
+
+class CreateSignatureOrder_CreateSignatureOrderOutput(BaseModel):
+  signatureOrder: "CreateSignatureOrder_CreateSignatureOrderOutput_SignatureOrder"
+
+
+class CreateSignatureOrder_CreateSignatureOrderOutput_SignatureOrder(BaseModel):
+  closedAt: "Optional[DateTimeScalar]" = Field(default=None)
+  documents: (
+    "list[CreateSignatureOrder_CreateSignatureOrderOutput_SignatureOrder_Document]"
+  )
+  evidenceProviders: "list[CreateSignatureOrder_CreateSignatureOrderOutput_SignatureOrder_SignatureEvidenceProvider]"
+  expiresAt: "DateTimeScalar"
+  id: "IDScalar"
+  # Number of max signatories for the signature order
+  maxSignatories: "IntScalar"
+  # List of signatories for the signature order.
+  signatories: (
+    "list[CreateSignatureOrder_CreateSignatureOrderOutput_SignatureOrder_Signatory]"
+  )
+  status: "SignatureOrderStatus"
+  title: "Optional[StringScalar]" = Field(default=None)
+
+
+class CreateSignatureOrder_CreateSignatureOrderOutput_SignatureOrder_Document(
+  BaseModel
+):
+  id: "IDScalar"
+  reference: "Optional[StringScalar]" = Field(default=None)
+  title: "StringScalar"
+
+
+class CreateSignatureOrder_CreateSignatureOrderOutput_SignatureOrder_SignatureEvidenceProvider(
+  BaseModel
+):
+  id: "IDScalar"
+
+
+class CreateSignatureOrder_CreateSignatureOrderOutput_SignatureOrder_Signatory(
+  BaseModel
+):
+  documents: "CreateSignatureOrder_CreateSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection"
+  # A download link for signatories to download their signed documents. Signatories must verify their identity before downloading. Can be used when signature order is closed with document retention.
+  downloadHref: "Optional[StringScalar]" = Field(default=None)
+  evidenceProviders: "list[CreateSignatureOrder_CreateSignatureOrderOutput_SignatureOrder_Signatory_SignatureEvidenceProvider]"
+  # A link to the signatures frontend, you can send this link to your users to enable them to sign your documents.
+  href: "StringScalar"
+  id: "IDScalar"
+  reference: "Optional[StringScalar]" = Field(default=None)
+  role: "Optional[StringScalar]" = Field(default=None)
+  # Signature order for the signatory.
+  signatureOrder: "CreateSignatureOrder_CreateSignatureOrderOutput_SignatureOrder_Signatory_SignatureOrder"
+  # The current status of the signatory.
+  status: "SignatoryStatus"
+  # The reason for the signatory status (rejection reason when rejected).
+  statusReason: "Optional[StringScalar]" = Field(default=None)
+
+
+class CreateSignatureOrder_CreateSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection(
+  BaseModel
+):
+  edges: "list[CreateSignatureOrder_CreateSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge]"
+
+
+class CreateSignatureOrder_CreateSignatureOrderOutput_SignatureOrder_Signatory_SignatureEvidenceProvider(
+  BaseModel
+):
+  id: "IDScalar"
+
+
+class CreateSignatureOrder_CreateSignatureOrderOutput_SignatureOrder_Signatory_SignatureOrder(
+  BaseModel
+):
+  closedAt: "Optional[DateTimeScalar]" = Field(default=None)
+  expiresAt: "DateTimeScalar"
+  id: "IDScalar"
+  status: "SignatureOrderStatus"
+
+
+class CreateSignatureOrder_CreateSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge(
+  BaseModel
+):
+  node: "CreateSignatureOrder_CreateSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document"
+  status: "Optional[SignatoryDocumentStatus]" = Field(default=None)
+
+
+class CreateSignatureOrder_CreateSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document(
+  BaseModel
+):
+  id: "IDScalar"
+
+
 createSignatureOrderDocument = f"""mutation createSignatureOrder($input: CreateSignatureOrderInput!) {{
   createSignatureOrder(input: $input) {{
     signatureOrder {{
@@ -132,6 +230,98 @@ createSignatureOrderDocument = f"""mutation createSignatureOrder($input: CreateS
 {BasicSignatureOrderFragment}
 {BasicSignatoryFragment}
 {BasicDocumentFragment}"""
+
+
+class CleanupSignatureOrder_CleanupSignatureOrderOutput(BaseModel):
+  signatureOrder: "CleanupSignatureOrder_CleanupSignatureOrderOutput_SignatureOrder"
+
+
+class CleanupSignatureOrder_CleanupSignatureOrderOutput_SignatureOrder(BaseModel):
+  closedAt: "Optional[DateTimeScalar]" = Field(default=None)
+  documents: (
+    "list[CleanupSignatureOrder_CleanupSignatureOrderOutput_SignatureOrder_Document]"
+  )
+  evidenceProviders: "list[CleanupSignatureOrder_CleanupSignatureOrderOutput_SignatureOrder_SignatureEvidenceProvider]"
+  expiresAt: "DateTimeScalar"
+  id: "IDScalar"
+  # Number of max signatories for the signature order
+  maxSignatories: "IntScalar"
+  # List of signatories for the signature order.
+  signatories: (
+    "list[CleanupSignatureOrder_CleanupSignatureOrderOutput_SignatureOrder_Signatory]"
+  )
+  status: "SignatureOrderStatus"
+  title: "Optional[StringScalar]" = Field(default=None)
+
+
+class CleanupSignatureOrder_CleanupSignatureOrderOutput_SignatureOrder_Document(
+  BaseModel
+):
+  id: "IDScalar"
+  reference: "Optional[StringScalar]" = Field(default=None)
+  title: "StringScalar"
+
+
+class CleanupSignatureOrder_CleanupSignatureOrderOutput_SignatureOrder_SignatureEvidenceProvider(
+  BaseModel
+):
+  id: "IDScalar"
+
+
+class CleanupSignatureOrder_CleanupSignatureOrderOutput_SignatureOrder_Signatory(
+  BaseModel
+):
+  documents: "CleanupSignatureOrder_CleanupSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection"
+  # A download link for signatories to download their signed documents. Signatories must verify their identity before downloading. Can be used when signature order is closed with document retention.
+  downloadHref: "Optional[StringScalar]" = Field(default=None)
+  evidenceProviders: "list[CleanupSignatureOrder_CleanupSignatureOrderOutput_SignatureOrder_Signatory_SignatureEvidenceProvider]"
+  # A link to the signatures frontend, you can send this link to your users to enable them to sign your documents.
+  href: "StringScalar"
+  id: "IDScalar"
+  reference: "Optional[StringScalar]" = Field(default=None)
+  role: "Optional[StringScalar]" = Field(default=None)
+  # Signature order for the signatory.
+  signatureOrder: "CleanupSignatureOrder_CleanupSignatureOrderOutput_SignatureOrder_Signatory_SignatureOrder"
+  # The current status of the signatory.
+  status: "SignatoryStatus"
+  # The reason for the signatory status (rejection reason when rejected).
+  statusReason: "Optional[StringScalar]" = Field(default=None)
+
+
+class CleanupSignatureOrder_CleanupSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection(
+  BaseModel
+):
+  edges: "list[CleanupSignatureOrder_CleanupSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge]"
+
+
+class CleanupSignatureOrder_CleanupSignatureOrderOutput_SignatureOrder_Signatory_SignatureEvidenceProvider(
+  BaseModel
+):
+  id: "IDScalar"
+
+
+class CleanupSignatureOrder_CleanupSignatureOrderOutput_SignatureOrder_Signatory_SignatureOrder(
+  BaseModel
+):
+  closedAt: "Optional[DateTimeScalar]" = Field(default=None)
+  expiresAt: "DateTimeScalar"
+  id: "IDScalar"
+  status: "SignatureOrderStatus"
+
+
+class CleanupSignatureOrder_CleanupSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge(
+  BaseModel
+):
+  node: "CleanupSignatureOrder_CleanupSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document"
+  status: "Optional[SignatoryDocumentStatus]" = Field(default=None)
+
+
+class CleanupSignatureOrder_CleanupSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document(
+  BaseModel
+):
+  id: "IDScalar"
+
+
 cleanupSignatureOrderDocument = f"""mutation cleanupSignatureOrder($input: CleanupSignatureOrderInput!) {{
   cleanupSignatureOrder(input: $input) {{
     signatureOrder {{
@@ -145,6 +335,60 @@ cleanupSignatureOrderDocument = f"""mutation cleanupSignatureOrder($input: Clean
 {BasicSignatureOrderFragment}
 {BasicSignatoryFragment}
 {BasicDocumentFragment}"""
+
+
+class AddSignatory_AddSignatoryOutput(BaseModel):
+  signatory: "AddSignatory_AddSignatoryOutput_Signatory"
+
+
+class AddSignatory_AddSignatoryOutput_Signatory(BaseModel):
+  documents: "AddSignatory_AddSignatoryOutput_Signatory_SignatoryDocumentConnection"
+  # A download link for signatories to download their signed documents. Signatories must verify their identity before downloading. Can be used when signature order is closed with document retention.
+  downloadHref: "Optional[StringScalar]" = Field(default=None)
+  evidenceProviders: (
+    "list[AddSignatory_AddSignatoryOutput_Signatory_SignatureEvidenceProvider]"
+  )
+  # A link to the signatures frontend, you can send this link to your users to enable them to sign your documents.
+  href: "StringScalar"
+  id: "IDScalar"
+  reference: "Optional[StringScalar]" = Field(default=None)
+  role: "Optional[StringScalar]" = Field(default=None)
+  # Signature order for the signatory.
+  signatureOrder: "AddSignatory_AddSignatoryOutput_Signatory_SignatureOrder"
+  # The current status of the signatory.
+  status: "SignatoryStatus"
+  # The reason for the signatory status (rejection reason when rejected).
+  statusReason: "Optional[StringScalar]" = Field(default=None)
+
+
+class AddSignatory_AddSignatoryOutput_Signatory_SignatoryDocumentConnection(BaseModel):
+  edges: "list[AddSignatory_AddSignatoryOutput_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge]"
+
+
+class AddSignatory_AddSignatoryOutput_Signatory_SignatureEvidenceProvider(BaseModel):
+  id: "IDScalar"
+
+
+class AddSignatory_AddSignatoryOutput_Signatory_SignatureOrder(BaseModel):
+  closedAt: "Optional[DateTimeScalar]" = Field(default=None)
+  expiresAt: "DateTimeScalar"
+  id: "IDScalar"
+  status: "SignatureOrderStatus"
+
+
+class AddSignatory_AddSignatoryOutput_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge(
+  BaseModel
+):
+  node: "AddSignatory_AddSignatoryOutput_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document"
+  status: "Optional[SignatoryDocumentStatus]" = Field(default=None)
+
+
+class AddSignatory_AddSignatoryOutput_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document(
+  BaseModel
+):
+  id: "IDScalar"
+
+
 addSignatoryDocument = f"""mutation addSignatory($input: AddSignatoryInput!) {{
   addSignatory(input: $input) {{
     signatory {{
@@ -153,6 +397,64 @@ addSignatoryDocument = f"""mutation addSignatory($input: AddSignatoryInput!) {{
   }}
 }}
 {BasicSignatoryFragment}"""
+
+
+class AddSignatories_AddSignatoriesOutput(BaseModel):
+  signatories: "list[AddSignatories_AddSignatoriesOutput_Signatory]"
+
+
+class AddSignatories_AddSignatoriesOutput_Signatory(BaseModel):
+  documents: "AddSignatories_AddSignatoriesOutput_Signatory_SignatoryDocumentConnection"
+  # A download link for signatories to download their signed documents. Signatories must verify their identity before downloading. Can be used when signature order is closed with document retention.
+  downloadHref: "Optional[StringScalar]" = Field(default=None)
+  evidenceProviders: (
+    "list[AddSignatories_AddSignatoriesOutput_Signatory_SignatureEvidenceProvider]"
+  )
+  # A link to the signatures frontend, you can send this link to your users to enable them to sign your documents.
+  href: "StringScalar"
+  id: "IDScalar"
+  reference: "Optional[StringScalar]" = Field(default=None)
+  role: "Optional[StringScalar]" = Field(default=None)
+  # Signature order for the signatory.
+  signatureOrder: "AddSignatories_AddSignatoriesOutput_Signatory_SignatureOrder"
+  # The current status of the signatory.
+  status: "SignatoryStatus"
+  # The reason for the signatory status (rejection reason when rejected).
+  statusReason: "Optional[StringScalar]" = Field(default=None)
+
+
+class AddSignatories_AddSignatoriesOutput_Signatory_SignatoryDocumentConnection(
+  BaseModel
+):
+  edges: "list[AddSignatories_AddSignatoriesOutput_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge]"
+
+
+class AddSignatories_AddSignatoriesOutput_Signatory_SignatureEvidenceProvider(
+  BaseModel
+):
+  id: "IDScalar"
+
+
+class AddSignatories_AddSignatoriesOutput_Signatory_SignatureOrder(BaseModel):
+  closedAt: "Optional[DateTimeScalar]" = Field(default=None)
+  expiresAt: "DateTimeScalar"
+  id: "IDScalar"
+  status: "SignatureOrderStatus"
+
+
+class AddSignatories_AddSignatoriesOutput_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge(
+  BaseModel
+):
+  node: "AddSignatories_AddSignatoriesOutput_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document"
+  status: "Optional[SignatoryDocumentStatus]" = Field(default=None)
+
+
+class AddSignatories_AddSignatoriesOutput_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document(
+  BaseModel
+):
+  id: "IDScalar"
+
+
 addSignatoriesDocument = f"""mutation addSignatories($input: AddSignatoriesInput!) {{
   addSignatories(input: $input) {{
     signatories {{
@@ -161,6 +463,66 @@ addSignatoriesDocument = f"""mutation addSignatories($input: AddSignatoriesInput
   }}
 }}
 {BasicSignatoryFragment}"""
+
+
+class ChangeSignatory_ChangeSignatoryOutput(BaseModel):
+  signatory: "ChangeSignatory_ChangeSignatoryOutput_Signatory"
+
+
+class ChangeSignatory_ChangeSignatoryOutput_Signatory(BaseModel):
+  documents: (
+    "ChangeSignatory_ChangeSignatoryOutput_Signatory_SignatoryDocumentConnection"
+  )
+  # A download link for signatories to download their signed documents. Signatories must verify their identity before downloading. Can be used when signature order is closed with document retention.
+  downloadHref: "Optional[StringScalar]" = Field(default=None)
+  evidenceProviders: (
+    "list[ChangeSignatory_ChangeSignatoryOutput_Signatory_SignatureEvidenceProvider]"
+  )
+  # A link to the signatures frontend, you can send this link to your users to enable them to sign your documents.
+  href: "StringScalar"
+  id: "IDScalar"
+  reference: "Optional[StringScalar]" = Field(default=None)
+  role: "Optional[StringScalar]" = Field(default=None)
+  # Signature order for the signatory.
+  signatureOrder: "ChangeSignatory_ChangeSignatoryOutput_Signatory_SignatureOrder"
+  # The current status of the signatory.
+  status: "SignatoryStatus"
+  # The reason for the signatory status (rejection reason when rejected).
+  statusReason: "Optional[StringScalar]" = Field(default=None)
+
+
+class ChangeSignatory_ChangeSignatoryOutput_Signatory_SignatoryDocumentConnection(
+  BaseModel
+):
+  edges: "list[ChangeSignatory_ChangeSignatoryOutput_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge]"
+
+
+class ChangeSignatory_ChangeSignatoryOutput_Signatory_SignatureEvidenceProvider(
+  BaseModel
+):
+  id: "IDScalar"
+
+
+class ChangeSignatory_ChangeSignatoryOutput_Signatory_SignatureOrder(BaseModel):
+  closedAt: "Optional[DateTimeScalar]" = Field(default=None)
+  expiresAt: "DateTimeScalar"
+  id: "IDScalar"
+  status: "SignatureOrderStatus"
+
+
+class ChangeSignatory_ChangeSignatoryOutput_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge(
+  BaseModel
+):
+  node: "ChangeSignatory_ChangeSignatoryOutput_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document"
+  status: "Optional[SignatoryDocumentStatus]" = Field(default=None)
+
+
+class ChangeSignatory_ChangeSignatoryOutput_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document(
+  BaseModel
+):
+  id: "IDScalar"
+
+
 changeSignatoryDocument = f"""mutation changeSignatory($input: ChangeSignatoryInput!) {{
   changeSignatory(input: $input) {{
     signatory {{
@@ -169,6 +531,113 @@ changeSignatoryDocument = f"""mutation changeSignatory($input: ChangeSignatoryIn
   }}
 }}
 {BasicSignatoryFragment}"""
+
+
+class CloseSignatureOrder_CloseSignatureOrderOutput(BaseModel):
+  signatureOrder: "CloseSignatureOrder_CloseSignatureOrderOutput_SignatureOrder"
+
+
+class CloseSignatureOrder_CloseSignatureOrderOutput_SignatureOrder(BaseModel):
+  closedAt: "Optional[DateTimeScalar]" = Field(default=None)
+  documents: (
+    "list[CloseSignatureOrder_CloseSignatureOrderOutput_SignatureOrder_Document]"
+  )
+  evidenceProviders: "list[CloseSignatureOrder_CloseSignatureOrderOutput_SignatureOrder_SignatureEvidenceProvider]"
+  expiresAt: "DateTimeScalar"
+  id: "IDScalar"
+  # Number of max signatories for the signature order
+  maxSignatories: "IntScalar"
+  # List of signatories for the signature order.
+  signatories: (
+    "list[CloseSignatureOrder_CloseSignatureOrderOutput_SignatureOrder_Signatory]"
+  )
+  status: "SignatureOrderStatus"
+  title: "Optional[StringScalar]" = Field(default=None)
+
+
+class CloseSignatureOrder_CloseSignatureOrderOutput_SignatureOrder_Document(BaseModel):
+  blob: "Optional[BlobScalar]" = Field(default=None)
+  id: "IDScalar"
+  reference: "Optional[StringScalar]" = Field(default=None)
+  signatures: "Optional[list[CloseSignatureOrder_CloseSignatureOrderOutput_SignatureOrder_Document_Signature]]" = Field(
+    default=None
+  )
+  title: "StringScalar"
+
+
+class CloseSignatureOrder_CloseSignatureOrderOutput_SignatureOrder_SignatureEvidenceProvider(
+  BaseModel
+):
+  id: "IDScalar"
+
+
+class CloseSignatureOrder_CloseSignatureOrderOutput_SignatureOrder_Signatory(BaseModel):
+  documents: "CloseSignatureOrder_CloseSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection"
+  # A download link for signatories to download their signed documents. Signatories must verify their identity before downloading. Can be used when signature order is closed with document retention.
+  downloadHref: "Optional[StringScalar]" = Field(default=None)
+  evidenceProviders: "list[CloseSignatureOrder_CloseSignatureOrderOutput_SignatureOrder_Signatory_SignatureEvidenceProvider]"
+  # A link to the signatures frontend, you can send this link to your users to enable them to sign your documents.
+  href: "StringScalar"
+  id: "IDScalar"
+  reference: "Optional[StringScalar]" = Field(default=None)
+  role: "Optional[StringScalar]" = Field(default=None)
+  # Signature order for the signatory.
+  signatureOrder: "CloseSignatureOrder_CloseSignatureOrderOutput_SignatureOrder_Signatory_SignatureOrder"
+  # The current status of the signatory.
+  status: "SignatoryStatus"
+  # The reason for the signatory status (rejection reason when rejected).
+  statusReason: "Optional[StringScalar]" = Field(default=None)
+
+
+# Represents a signature on a document.
+class CloseSignatureOrder_CloseSignatureOrderOutput_SignatureOrder_Document_Signature(
+  BaseModel
+):
+  signatory: "Optional[CloseSignatureOrder_CloseSignatureOrderOutput_SignatureOrder_Document_Signature_Signatory]" = Field(
+    default=None
+  )
+
+
+class CloseSignatureOrder_CloseSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection(
+  BaseModel
+):
+  edges: "list[CloseSignatureOrder_CloseSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge]"
+
+
+class CloseSignatureOrder_CloseSignatureOrderOutput_SignatureOrder_Signatory_SignatureEvidenceProvider(
+  BaseModel
+):
+  id: "IDScalar"
+
+
+class CloseSignatureOrder_CloseSignatureOrderOutput_SignatureOrder_Signatory_SignatureOrder(
+  BaseModel
+):
+  closedAt: "Optional[DateTimeScalar]" = Field(default=None)
+  expiresAt: "DateTimeScalar"
+  id: "IDScalar"
+  status: "SignatureOrderStatus"
+
+
+class CloseSignatureOrder_CloseSignatureOrderOutput_SignatureOrder_Document_Signature_Signatory(
+  BaseModel
+):
+  id: "IDScalar"
+
+
+class CloseSignatureOrder_CloseSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge(
+  BaseModel
+):
+  node: "CloseSignatureOrder_CloseSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document"
+  status: "Optional[SignatoryDocumentStatus]" = Field(default=None)
+
+
+class CloseSignatureOrder_CloseSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document(
+  BaseModel
+):
+  id: "IDScalar"
+
+
 closeSignatureOrderDocument = f"""mutation closeSignatureOrder($input: CloseSignatureOrderInput!) {{
   closeSignatureOrder(input: $input) {{
     signatureOrder {{
@@ -184,6 +653,98 @@ closeSignatureOrderDocument = f"""mutation closeSignatureOrder($input: CloseSign
 {BasicSignatoryFragment}
 {BasicDocumentFragment}
 {SignedDocumentFragment}"""
+
+
+class CancelSignatureOrder_CancelSignatureOrderOutput(BaseModel):
+  signatureOrder: "CancelSignatureOrder_CancelSignatureOrderOutput_SignatureOrder"
+
+
+class CancelSignatureOrder_CancelSignatureOrderOutput_SignatureOrder(BaseModel):
+  closedAt: "Optional[DateTimeScalar]" = Field(default=None)
+  documents: (
+    "list[CancelSignatureOrder_CancelSignatureOrderOutput_SignatureOrder_Document]"
+  )
+  evidenceProviders: "list[CancelSignatureOrder_CancelSignatureOrderOutput_SignatureOrder_SignatureEvidenceProvider]"
+  expiresAt: "DateTimeScalar"
+  id: "IDScalar"
+  # Number of max signatories for the signature order
+  maxSignatories: "IntScalar"
+  # List of signatories for the signature order.
+  signatories: (
+    "list[CancelSignatureOrder_CancelSignatureOrderOutput_SignatureOrder_Signatory]"
+  )
+  status: "SignatureOrderStatus"
+  title: "Optional[StringScalar]" = Field(default=None)
+
+
+class CancelSignatureOrder_CancelSignatureOrderOutput_SignatureOrder_Document(
+  BaseModel
+):
+  id: "IDScalar"
+  reference: "Optional[StringScalar]" = Field(default=None)
+  title: "StringScalar"
+
+
+class CancelSignatureOrder_CancelSignatureOrderOutput_SignatureOrder_SignatureEvidenceProvider(
+  BaseModel
+):
+  id: "IDScalar"
+
+
+class CancelSignatureOrder_CancelSignatureOrderOutput_SignatureOrder_Signatory(
+  BaseModel
+):
+  documents: "CancelSignatureOrder_CancelSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection"
+  # A download link for signatories to download their signed documents. Signatories must verify their identity before downloading. Can be used when signature order is closed with document retention.
+  downloadHref: "Optional[StringScalar]" = Field(default=None)
+  evidenceProviders: "list[CancelSignatureOrder_CancelSignatureOrderOutput_SignatureOrder_Signatory_SignatureEvidenceProvider]"
+  # A link to the signatures frontend, you can send this link to your users to enable them to sign your documents.
+  href: "StringScalar"
+  id: "IDScalar"
+  reference: "Optional[StringScalar]" = Field(default=None)
+  role: "Optional[StringScalar]" = Field(default=None)
+  # Signature order for the signatory.
+  signatureOrder: "CancelSignatureOrder_CancelSignatureOrderOutput_SignatureOrder_Signatory_SignatureOrder"
+  # The current status of the signatory.
+  status: "SignatoryStatus"
+  # The reason for the signatory status (rejection reason when rejected).
+  statusReason: "Optional[StringScalar]" = Field(default=None)
+
+
+class CancelSignatureOrder_CancelSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection(
+  BaseModel
+):
+  edges: "list[CancelSignatureOrder_CancelSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge]"
+
+
+class CancelSignatureOrder_CancelSignatureOrderOutput_SignatureOrder_Signatory_SignatureEvidenceProvider(
+  BaseModel
+):
+  id: "IDScalar"
+
+
+class CancelSignatureOrder_CancelSignatureOrderOutput_SignatureOrder_Signatory_SignatureOrder(
+  BaseModel
+):
+  closedAt: "Optional[DateTimeScalar]" = Field(default=None)
+  expiresAt: "DateTimeScalar"
+  id: "IDScalar"
+  status: "SignatureOrderStatus"
+
+
+class CancelSignatureOrder_CancelSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge(
+  BaseModel
+):
+  node: "CancelSignatureOrder_CancelSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document"
+  status: "Optional[SignatoryDocumentStatus]" = Field(default=None)
+
+
+class CancelSignatureOrder_CancelSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document(
+  BaseModel
+):
+  id: "IDScalar"
+
+
 cancelSignatureOrderDocument = f"""mutation cancelSignatureOrder($input: CancelSignatureOrderInput!) {{
   cancelSignatureOrder(input: $input) {{
     signatureOrder {{
@@ -197,6 +758,60 @@ cancelSignatureOrderDocument = f"""mutation cancelSignatureOrder($input: CancelS
 {BasicSignatureOrderFragment}
 {BasicSignatoryFragment}
 {BasicDocumentFragment}"""
+
+
+class SignActingAs_SignActingAsOutput(BaseModel):
+  signatory: "SignActingAs_SignActingAsOutput_Signatory"
+
+
+class SignActingAs_SignActingAsOutput_Signatory(BaseModel):
+  documents: "SignActingAs_SignActingAsOutput_Signatory_SignatoryDocumentConnection"
+  # A download link for signatories to download their signed documents. Signatories must verify their identity before downloading. Can be used when signature order is closed with document retention.
+  downloadHref: "Optional[StringScalar]" = Field(default=None)
+  evidenceProviders: (
+    "list[SignActingAs_SignActingAsOutput_Signatory_SignatureEvidenceProvider]"
+  )
+  # A link to the signatures frontend, you can send this link to your users to enable them to sign your documents.
+  href: "StringScalar"
+  id: "IDScalar"
+  reference: "Optional[StringScalar]" = Field(default=None)
+  role: "Optional[StringScalar]" = Field(default=None)
+  # Signature order for the signatory.
+  signatureOrder: "SignActingAs_SignActingAsOutput_Signatory_SignatureOrder"
+  # The current status of the signatory.
+  status: "SignatoryStatus"
+  # The reason for the signatory status (rejection reason when rejected).
+  statusReason: "Optional[StringScalar]" = Field(default=None)
+
+
+class SignActingAs_SignActingAsOutput_Signatory_SignatoryDocumentConnection(BaseModel):
+  edges: "list[SignActingAs_SignActingAsOutput_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge]"
+
+
+class SignActingAs_SignActingAsOutput_Signatory_SignatureEvidenceProvider(BaseModel):
+  id: "IDScalar"
+
+
+class SignActingAs_SignActingAsOutput_Signatory_SignatureOrder(BaseModel):
+  closedAt: "Optional[DateTimeScalar]" = Field(default=None)
+  expiresAt: "DateTimeScalar"
+  id: "IDScalar"
+  status: "SignatureOrderStatus"
+
+
+class SignActingAs_SignActingAsOutput_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge(
+  BaseModel
+):
+  node: "SignActingAs_SignActingAsOutput_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document"
+  status: "Optional[SignatoryDocumentStatus]" = Field(default=None)
+
+
+class SignActingAs_SignActingAsOutput_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document(
+  BaseModel
+):
+  id: "IDScalar"
+
+
 signActingAsDocument = f"""mutation signActingAs($input: SignActingAsInput!) {{
   signActingAs(input: $input) {{
     signatory {{
@@ -205,6 +820,15 @@ signActingAsDocument = f"""mutation signActingAs($input: SignActingAsInput!) {{
   }}
 }}
 {BasicSignatoryFragment}"""
+
+
+class ValidateDocument_ValidateDocumentOutput(BaseModel):
+  errors: "Optional[list[StringScalar]]" = Field(default=None)
+  # Whether or not the errors are fixable using 'fixDocumentFormattingErrors'
+  fixable: "Optional[BooleanScalar]" = Field(default=None)
+  valid: "BooleanScalar"
+
+
 validateDocumentDocument = """mutation validateDocument($input: ValidateDocumentInput!) {
   validateDocument(input: $input) {
     valid
@@ -212,6 +836,98 @@ validateDocumentDocument = """mutation validateDocument($input: ValidateDocument
     fixable
   }
 }"""
+
+
+class ExtendSignatureOrder_ExtendSignatureOrderOutput(BaseModel):
+  signatureOrder: "ExtendSignatureOrder_ExtendSignatureOrderOutput_SignatureOrder"
+
+
+class ExtendSignatureOrder_ExtendSignatureOrderOutput_SignatureOrder(BaseModel):
+  closedAt: "Optional[DateTimeScalar]" = Field(default=None)
+  documents: (
+    "list[ExtendSignatureOrder_ExtendSignatureOrderOutput_SignatureOrder_Document]"
+  )
+  evidenceProviders: "list[ExtendSignatureOrder_ExtendSignatureOrderOutput_SignatureOrder_SignatureEvidenceProvider]"
+  expiresAt: "DateTimeScalar"
+  id: "IDScalar"
+  # Number of max signatories for the signature order
+  maxSignatories: "IntScalar"
+  # List of signatories for the signature order.
+  signatories: (
+    "list[ExtendSignatureOrder_ExtendSignatureOrderOutput_SignatureOrder_Signatory]"
+  )
+  status: "SignatureOrderStatus"
+  title: "Optional[StringScalar]" = Field(default=None)
+
+
+class ExtendSignatureOrder_ExtendSignatureOrderOutput_SignatureOrder_Document(
+  BaseModel
+):
+  id: "IDScalar"
+  reference: "Optional[StringScalar]" = Field(default=None)
+  title: "StringScalar"
+
+
+class ExtendSignatureOrder_ExtendSignatureOrderOutput_SignatureOrder_SignatureEvidenceProvider(
+  BaseModel
+):
+  id: "IDScalar"
+
+
+class ExtendSignatureOrder_ExtendSignatureOrderOutput_SignatureOrder_Signatory(
+  BaseModel
+):
+  documents: "ExtendSignatureOrder_ExtendSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection"
+  # A download link for signatories to download their signed documents. Signatories must verify their identity before downloading. Can be used when signature order is closed with document retention.
+  downloadHref: "Optional[StringScalar]" = Field(default=None)
+  evidenceProviders: "list[ExtendSignatureOrder_ExtendSignatureOrderOutput_SignatureOrder_Signatory_SignatureEvidenceProvider]"
+  # A link to the signatures frontend, you can send this link to your users to enable them to sign your documents.
+  href: "StringScalar"
+  id: "IDScalar"
+  reference: "Optional[StringScalar]" = Field(default=None)
+  role: "Optional[StringScalar]" = Field(default=None)
+  # Signature order for the signatory.
+  signatureOrder: "ExtendSignatureOrder_ExtendSignatureOrderOutput_SignatureOrder_Signatory_SignatureOrder"
+  # The current status of the signatory.
+  status: "SignatoryStatus"
+  # The reason for the signatory status (rejection reason when rejected).
+  statusReason: "Optional[StringScalar]" = Field(default=None)
+
+
+class ExtendSignatureOrder_ExtendSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection(
+  BaseModel
+):
+  edges: "list[ExtendSignatureOrder_ExtendSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge]"
+
+
+class ExtendSignatureOrder_ExtendSignatureOrderOutput_SignatureOrder_Signatory_SignatureEvidenceProvider(
+  BaseModel
+):
+  id: "IDScalar"
+
+
+class ExtendSignatureOrder_ExtendSignatureOrderOutput_SignatureOrder_Signatory_SignatureOrder(
+  BaseModel
+):
+  closedAt: "Optional[DateTimeScalar]" = Field(default=None)
+  expiresAt: "DateTimeScalar"
+  id: "IDScalar"
+  status: "SignatureOrderStatus"
+
+
+class ExtendSignatureOrder_ExtendSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge(
+  BaseModel
+):
+  node: "ExtendSignatureOrder_ExtendSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document"
+  status: "Optional[SignatoryDocumentStatus]" = Field(default=None)
+
+
+class ExtendSignatureOrder_ExtendSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document(
+  BaseModel
+):
+  id: "IDScalar"
+
+
 extendSignatureOrderDocument = f"""mutation extendSignatureOrder($input: ExtendSignatureOrderInput!) {{
   extendSignatureOrder(input: $input) {{
     signatureOrder {{
@@ -225,6 +941,85 @@ extendSignatureOrderDocument = f"""mutation extendSignatureOrder($input: ExtendS
 {BasicSignatureOrderFragment}
 {BasicSignatoryFragment}
 {BasicDocumentFragment}"""
+
+
+class DeleteSignatory_DeleteSignatoryOutput(BaseModel):
+  signatureOrder: "DeleteSignatory_DeleteSignatoryOutput_SignatureOrder"
+
+
+class DeleteSignatory_DeleteSignatoryOutput_SignatureOrder(BaseModel):
+  closedAt: "Optional[DateTimeScalar]" = Field(default=None)
+  evidenceProviders: "list[DeleteSignatory_DeleteSignatoryOutput_SignatureOrder_SignatureEvidenceProvider]"
+  expiresAt: "DateTimeScalar"
+  id: "IDScalar"
+  # Number of max signatories for the signature order
+  maxSignatories: "IntScalar"
+  # List of signatories for the signature order.
+  signatories: "list[DeleteSignatory_DeleteSignatoryOutput_SignatureOrder_Signatory]"
+  status: "SignatureOrderStatus"
+  title: "Optional[StringScalar]" = Field(default=None)
+
+
+class DeleteSignatory_DeleteSignatoryOutput_SignatureOrder_SignatureEvidenceProvider(
+  BaseModel
+):
+  id: "IDScalar"
+
+
+class DeleteSignatory_DeleteSignatoryOutput_SignatureOrder_Signatory(BaseModel):
+  documents: "DeleteSignatory_DeleteSignatoryOutput_SignatureOrder_Signatory_SignatoryDocumentConnection"
+  # A download link for signatories to download their signed documents. Signatories must verify their identity before downloading. Can be used when signature order is closed with document retention.
+  downloadHref: "Optional[StringScalar]" = Field(default=None)
+  evidenceProviders: "list[DeleteSignatory_DeleteSignatoryOutput_SignatureOrder_Signatory_SignatureEvidenceProvider]"
+  # A link to the signatures frontend, you can send this link to your users to enable them to sign your documents.
+  href: "StringScalar"
+  id: "IDScalar"
+  reference: "Optional[StringScalar]" = Field(default=None)
+  role: "Optional[StringScalar]" = Field(default=None)
+  # Signature order for the signatory.
+  signatureOrder: (
+    "DeleteSignatory_DeleteSignatoryOutput_SignatureOrder_Signatory_SignatureOrder"
+  )
+  # The current status of the signatory.
+  status: "SignatoryStatus"
+  # The reason for the signatory status (rejection reason when rejected).
+  statusReason: "Optional[StringScalar]" = Field(default=None)
+
+
+class DeleteSignatory_DeleteSignatoryOutput_SignatureOrder_Signatory_SignatoryDocumentConnection(
+  BaseModel
+):
+  edges: "list[DeleteSignatory_DeleteSignatoryOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge]"
+
+
+class DeleteSignatory_DeleteSignatoryOutput_SignatureOrder_Signatory_SignatureEvidenceProvider(
+  BaseModel
+):
+  id: "IDScalar"
+
+
+class DeleteSignatory_DeleteSignatoryOutput_SignatureOrder_Signatory_SignatureOrder(
+  BaseModel
+):
+  closedAt: "Optional[DateTimeScalar]" = Field(default=None)
+  expiresAt: "DateTimeScalar"
+  id: "IDScalar"
+  status: "SignatureOrderStatus"
+
+
+class DeleteSignatory_DeleteSignatoryOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge(
+  BaseModel
+):
+  node: "DeleteSignatory_DeleteSignatoryOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document"
+  status: "Optional[SignatoryDocumentStatus]" = Field(default=None)
+
+
+class DeleteSignatory_DeleteSignatoryOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document(
+  BaseModel
+):
+  id: "IDScalar"
+
+
 deleteSignatoryDocument = f"""mutation deleteSignatory($input: DeleteSignatoryInput!) {{
   deleteSignatory(input: $input) {{
     signatureOrder {{
@@ -234,6 +1029,156 @@ deleteSignatoryDocument = f"""mutation deleteSignatory($input: DeleteSignatoryIn
 }}
 {BasicSignatureOrderFragment}
 {BasicSignatoryFragment}"""
+
+
+class CreateBatchSignatory_CreateBatchSignatoryOutput(BaseModel):
+  batchSignatory: "CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory"
+
+
+class CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory(BaseModel):
+  href: "StringScalar"
+  id: "IDScalar"
+  items: "list[CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem]"
+  # The authentication token required for performing batch operations.
+  token: "StringScalar"
+
+
+class CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem(
+  BaseModel
+):
+  signatory: "CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_Signatory"
+  signatureOrder: "CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_SignatureOrder"
+
+
+class CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_Signatory(
+  BaseModel
+):
+  documents: "CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_Signatory_SignatoryDocumentConnection"
+  # A download link for signatories to download their signed documents. Signatories must verify their identity before downloading. Can be used when signature order is closed with document retention.
+  downloadHref: "Optional[StringScalar]" = Field(default=None)
+  evidenceProviders: "list[CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_Signatory_SignatureEvidenceProvider]"
+  # A link to the signatures frontend, you can send this link to your users to enable them to sign your documents.
+  href: "StringScalar"
+  id: "IDScalar"
+  reference: "Optional[StringScalar]" = Field(default=None)
+  role: "Optional[StringScalar]" = Field(default=None)
+  # Signature order for the signatory.
+  signatureOrder: "CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_Signatory_SignatureOrder"
+  # The current status of the signatory.
+  status: "SignatoryStatus"
+  # The reason for the signatory status (rejection reason when rejected).
+  statusReason: "Optional[StringScalar]" = Field(default=None)
+
+
+class CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_SignatureOrder(
+  BaseModel
+):
+  closedAt: "Optional[DateTimeScalar]" = Field(default=None)
+  evidenceProviders: "list[CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_SignatureOrder_SignatureEvidenceProvider]"
+  expiresAt: "DateTimeScalar"
+  id: "IDScalar"
+  # Number of max signatories for the signature order
+  maxSignatories: "IntScalar"
+  # List of signatories for the signature order.
+  signatories: "list[CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory]"
+  status: "SignatureOrderStatus"
+  title: "Optional[StringScalar]" = Field(default=None)
+
+
+class CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_Signatory_SignatoryDocumentConnection(
+  BaseModel
+):
+  edges: "list[CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge]"
+
+
+class CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_Signatory_SignatureEvidenceProvider(
+  BaseModel
+):
+  id: "IDScalar"
+
+
+class CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_Signatory_SignatureOrder(
+  BaseModel
+):
+  closedAt: "Optional[DateTimeScalar]" = Field(default=None)
+  expiresAt: "DateTimeScalar"
+  id: "IDScalar"
+  status: "SignatureOrderStatus"
+
+
+class CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_SignatureOrder_SignatureEvidenceProvider(
+  BaseModel
+):
+  id: "IDScalar"
+
+
+class CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory(
+  BaseModel
+):
+  documents: "CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory_SignatoryDocumentConnection"
+  # A download link for signatories to download their signed documents. Signatories must verify their identity before downloading. Can be used when signature order is closed with document retention.
+  downloadHref: "Optional[StringScalar]" = Field(default=None)
+  evidenceProviders: "list[CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory_SignatureEvidenceProvider]"
+  # A link to the signatures frontend, you can send this link to your users to enable them to sign your documents.
+  href: "StringScalar"
+  id: "IDScalar"
+  reference: "Optional[StringScalar]" = Field(default=None)
+  role: "Optional[StringScalar]" = Field(default=None)
+  # Signature order for the signatory.
+  signatureOrder: "CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory_SignatureOrder"
+  # The current status of the signatory.
+  status: "SignatoryStatus"
+  # The reason for the signatory status (rejection reason when rejected).
+  statusReason: "Optional[StringScalar]" = Field(default=None)
+
+
+class CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge(
+  BaseModel
+):
+  node: "CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document"
+  status: "Optional[SignatoryDocumentStatus]" = Field(default=None)
+
+
+class CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory_SignatoryDocumentConnection(
+  BaseModel
+):
+  edges: "list[CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge]"
+
+
+class CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory_SignatureEvidenceProvider(
+  BaseModel
+):
+  id: "IDScalar"
+
+
+class CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory_SignatureOrder(
+  BaseModel
+):
+  closedAt: "Optional[DateTimeScalar]" = Field(default=None)
+  expiresAt: "DateTimeScalar"
+  id: "IDScalar"
+  status: "SignatureOrderStatus"
+
+
+class CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document(
+  BaseModel
+):
+  id: "IDScalar"
+
+
+class CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge(
+  BaseModel
+):
+  node: "CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document"
+  status: "Optional[SignatoryDocumentStatus]" = Field(default=None)
+
+
+class CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document(
+  BaseModel
+):
+  id: "IDScalar"
+
+
 createBatchSignatoryDocument = f"""mutation createBatchSignatory($input: CreateBatchSignatoryInput!) {{
   createBatchSignatory(input: $input) {{
     batchSignatory {{
@@ -252,6 +1197,87 @@ createBatchSignatoryDocument = f"""mutation createBatchSignatory($input: CreateB
 {BasicBatchSignatoryFragment}
 {BasicSignatureOrderFragment}
 {BasicSignatoryFragment}"""
+
+
+class ChangeSignatureOrder_ChangeSignatureOrderOutput(BaseModel):
+  signatureOrder: "ChangeSignatureOrder_ChangeSignatureOrderOutput_SignatureOrder"
+
+
+class ChangeSignatureOrder_ChangeSignatureOrderOutput_SignatureOrder(BaseModel):
+  closedAt: "Optional[DateTimeScalar]" = Field(default=None)
+  evidenceProviders: "list[ChangeSignatureOrder_ChangeSignatureOrderOutput_SignatureOrder_SignatureEvidenceProvider]"
+  expiresAt: "DateTimeScalar"
+  id: "IDScalar"
+  # Number of max signatories for the signature order
+  maxSignatories: "IntScalar"
+  # List of signatories for the signature order.
+  signatories: (
+    "list[ChangeSignatureOrder_ChangeSignatureOrderOutput_SignatureOrder_Signatory]"
+  )
+  status: "SignatureOrderStatus"
+  title: "Optional[StringScalar]" = Field(default=None)
+
+
+class ChangeSignatureOrder_ChangeSignatureOrderOutput_SignatureOrder_SignatureEvidenceProvider(
+  BaseModel
+):
+  id: "IDScalar"
+
+
+class ChangeSignatureOrder_ChangeSignatureOrderOutput_SignatureOrder_Signatory(
+  BaseModel
+):
+  documents: "ChangeSignatureOrder_ChangeSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection"
+  # A download link for signatories to download their signed documents. Signatories must verify their identity before downloading. Can be used when signature order is closed with document retention.
+  downloadHref: "Optional[StringScalar]" = Field(default=None)
+  evidenceProviders: "list[ChangeSignatureOrder_ChangeSignatureOrderOutput_SignatureOrder_Signatory_SignatureEvidenceProvider]"
+  # A link to the signatures frontend, you can send this link to your users to enable them to sign your documents.
+  href: "StringScalar"
+  id: "IDScalar"
+  reference: "Optional[StringScalar]" = Field(default=None)
+  role: "Optional[StringScalar]" = Field(default=None)
+  # Signature order for the signatory.
+  signatureOrder: "ChangeSignatureOrder_ChangeSignatureOrderOutput_SignatureOrder_Signatory_SignatureOrder"
+  # The current status of the signatory.
+  status: "SignatoryStatus"
+  # The reason for the signatory status (rejection reason when rejected).
+  statusReason: "Optional[StringScalar]" = Field(default=None)
+
+
+class ChangeSignatureOrder_ChangeSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection(
+  BaseModel
+):
+  edges: "list[ChangeSignatureOrder_ChangeSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge]"
+
+
+class ChangeSignatureOrder_ChangeSignatureOrderOutput_SignatureOrder_Signatory_SignatureEvidenceProvider(
+  BaseModel
+):
+  id: "IDScalar"
+
+
+class ChangeSignatureOrder_ChangeSignatureOrderOutput_SignatureOrder_Signatory_SignatureOrder(
+  BaseModel
+):
+  closedAt: "Optional[DateTimeScalar]" = Field(default=None)
+  expiresAt: "DateTimeScalar"
+  id: "IDScalar"
+  status: "SignatureOrderStatus"
+
+
+class ChangeSignatureOrder_ChangeSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge(
+  BaseModel
+):
+  node: "ChangeSignatureOrder_ChangeSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document"
+  status: "Optional[SignatoryDocumentStatus]" = Field(default=None)
+
+
+class ChangeSignatureOrder_ChangeSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document(
+  BaseModel
+):
+  id: "IDScalar"
+
+
 changeSignatureOrderDocument = f"""mutation changeSignatureOrder($input: ChangeSignatureOrderInput!) {{
   changeSignatureOrder(input: $input) {{
     signatureOrder {{
@@ -261,6 +1287,77 @@ changeSignatureOrderDocument = f"""mutation changeSignatureOrder($input: ChangeS
 }}
 {BasicSignatureOrderFragment}
 {BasicSignatoryFragment}"""
+
+
+class QuerySignatureOrder_SignatureOrder(BaseModel):
+  closedAt: "Optional[DateTimeScalar]" = Field(default=None)
+  evidenceProviders: (
+    "list[QuerySignatureOrder_SignatureOrder_SignatureEvidenceProvider]"
+  )
+  expiresAt: "DateTimeScalar"
+  id: "IDScalar"
+  # Number of max signatories for the signature order
+  maxSignatories: "IntScalar"
+  # List of signatories for the signature order.
+  signatories: "list[QuerySignatureOrder_SignatureOrder_Signatory]"
+  status: "SignatureOrderStatus"
+  title: "Optional[StringScalar]" = Field(default=None)
+
+
+class QuerySignatureOrder_SignatureOrder_SignatureEvidenceProvider(BaseModel):
+  id: "IDScalar"
+
+
+class QuerySignatureOrder_SignatureOrder_Signatory(BaseModel):
+  documents: "QuerySignatureOrder_SignatureOrder_Signatory_SignatoryDocumentConnection"
+  # A download link for signatories to download their signed documents. Signatories must verify their identity before downloading. Can be used when signature order is closed with document retention.
+  downloadHref: "Optional[StringScalar]" = Field(default=None)
+  evidenceProviders: (
+    "list[QuerySignatureOrder_SignatureOrder_Signatory_SignatureEvidenceProvider]"
+  )
+  # A link to the signatures frontend, you can send this link to your users to enable them to sign your documents.
+  href: "StringScalar"
+  id: "IDScalar"
+  reference: "Optional[StringScalar]" = Field(default=None)
+  role: "Optional[StringScalar]" = Field(default=None)
+  # Signature order for the signatory.
+  signatureOrder: "QuerySignatureOrder_SignatureOrder_Signatory_SignatureOrder"
+  # The current status of the signatory.
+  status: "SignatoryStatus"
+  # The reason for the signatory status (rejection reason when rejected).
+  statusReason: "Optional[StringScalar]" = Field(default=None)
+
+
+class QuerySignatureOrder_SignatureOrder_Signatory_SignatoryDocumentConnection(
+  BaseModel
+):
+  edges: "list[QuerySignatureOrder_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge]"
+
+
+class QuerySignatureOrder_SignatureOrder_Signatory_SignatureEvidenceProvider(BaseModel):
+  id: "IDScalar"
+
+
+class QuerySignatureOrder_SignatureOrder_Signatory_SignatureOrder(BaseModel):
+  closedAt: "Optional[DateTimeScalar]" = Field(default=None)
+  expiresAt: "DateTimeScalar"
+  id: "IDScalar"
+  status: "SignatureOrderStatus"
+
+
+class QuerySignatureOrder_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge(
+  BaseModel
+):
+  node: "QuerySignatureOrder_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document"
+  status: "Optional[SignatoryDocumentStatus]" = Field(default=None)
+
+
+class QuerySignatureOrder_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document(
+  BaseModel
+):
+  id: "IDScalar"
+
+
 querySignatureOrderDocument = f"""query signatureOrder($id: ID!) {{
   signatureOrder(id: $id) {{
     ...BasicSignatureOrder
@@ -268,6 +1365,107 @@ querySignatureOrderDocument = f"""query signatureOrder($id: ID!) {{
 }}
 {BasicSignatureOrderFragment}
 {BasicSignatoryFragment}"""
+
+
+class QuerySignatureOrderWithDocuments_SignatureOrder(BaseModel):
+  closedAt: "Optional[DateTimeScalar]" = Field(default=None)
+  documents: "list[QuerySignatureOrderWithDocuments_SignatureOrder_Document]"
+  evidenceProviders: (
+    "list[QuerySignatureOrderWithDocuments_SignatureOrder_SignatureEvidenceProvider]"
+  )
+  expiresAt: "DateTimeScalar"
+  id: "IDScalar"
+  # Number of max signatories for the signature order
+  maxSignatories: "IntScalar"
+  # List of signatories for the signature order.
+  signatories: "list[QuerySignatureOrderWithDocuments_SignatureOrder_Signatory]"
+  status: "SignatureOrderStatus"
+  title: "Optional[StringScalar]" = Field(default=None)
+
+
+class QuerySignatureOrderWithDocuments_SignatureOrder_Document(BaseModel):
+  blob: "Optional[BlobScalar]" = Field(default=None)
+  id: "IDScalar"
+  reference: "Optional[StringScalar]" = Field(default=None)
+  signatures: "Optional[list[QuerySignatureOrderWithDocuments_SignatureOrder_Document_Signature]]" = Field(
+    default=None
+  )
+  title: "StringScalar"
+
+
+class QuerySignatureOrderWithDocuments_SignatureOrder_SignatureEvidenceProvider(
+  BaseModel
+):
+  id: "IDScalar"
+
+
+class QuerySignatureOrderWithDocuments_SignatureOrder_Signatory(BaseModel):
+  documents: "QuerySignatureOrderWithDocuments_SignatureOrder_Signatory_SignatoryDocumentConnection"
+  # A download link for signatories to download their signed documents. Signatories must verify their identity before downloading. Can be used when signature order is closed with document retention.
+  downloadHref: "Optional[StringScalar]" = Field(default=None)
+  evidenceProviders: "list[QuerySignatureOrderWithDocuments_SignatureOrder_Signatory_SignatureEvidenceProvider]"
+  # A link to the signatures frontend, you can send this link to your users to enable them to sign your documents.
+  href: "StringScalar"
+  id: "IDScalar"
+  reference: "Optional[StringScalar]" = Field(default=None)
+  role: "Optional[StringScalar]" = Field(default=None)
+  # Signature order for the signatory.
+  signatureOrder: (
+    "QuerySignatureOrderWithDocuments_SignatureOrder_Signatory_SignatureOrder"
+  )
+  # The current status of the signatory.
+  status: "SignatoryStatus"
+  # The reason for the signatory status (rejection reason when rejected).
+  statusReason: "Optional[StringScalar]" = Field(default=None)
+
+
+# Represents a signature on a document.
+class QuerySignatureOrderWithDocuments_SignatureOrder_Document_Signature(BaseModel):
+  signatory: "Optional[QuerySignatureOrderWithDocuments_SignatureOrder_Document_Signature_Signatory]" = Field(
+    default=None
+  )
+
+
+class QuerySignatureOrderWithDocuments_SignatureOrder_Signatory_SignatoryDocumentConnection(
+  BaseModel
+):
+  edges: "list[QuerySignatureOrderWithDocuments_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge]"
+
+
+class QuerySignatureOrderWithDocuments_SignatureOrder_Signatory_SignatureEvidenceProvider(
+  BaseModel
+):
+  id: "IDScalar"
+
+
+class QuerySignatureOrderWithDocuments_SignatureOrder_Signatory_SignatureOrder(
+  BaseModel
+):
+  closedAt: "Optional[DateTimeScalar]" = Field(default=None)
+  expiresAt: "DateTimeScalar"
+  id: "IDScalar"
+  status: "SignatureOrderStatus"
+
+
+class QuerySignatureOrderWithDocuments_SignatureOrder_Document_Signature_Signatory(
+  BaseModel
+):
+  id: "IDScalar"
+
+
+class QuerySignatureOrderWithDocuments_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge(
+  BaseModel
+):
+  node: "QuerySignatureOrderWithDocuments_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document"
+  status: "Optional[SignatoryDocumentStatus]" = Field(default=None)
+
+
+class QuerySignatureOrderWithDocuments_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document(
+  BaseModel
+):
+  id: "IDScalar"
+
+
 querySignatureOrderWithDocumentsDocument = f"""query signatureOrderWithDocuments($id: ID!) {{
   signatureOrder(id: $id) {{
     ...BasicSignatureOrder
@@ -281,6 +1479,122 @@ querySignatureOrderWithDocumentsDocument = f"""query signatureOrderWithDocuments
 {BasicSignatoryFragment}
 {BasicDocumentFragment}
 {SignedDocumentFragment}"""
+
+
+class QuerySignatory_Signatory(BaseModel):
+  documents: "QuerySignatory_Signatory_SignatoryDocumentConnection"
+  # A download link for signatories to download their signed documents. Signatories must verify their identity before downloading. Can be used when signature order is closed with document retention.
+  downloadHref: "Optional[StringScalar]" = Field(default=None)
+  evidenceProviders: "list[QuerySignatory_Signatory_SignatureEvidenceProvider]"
+  # A link to the signatures frontend, you can send this link to your users to enable them to sign your documents.
+  href: "StringScalar"
+  id: "IDScalar"
+  reference: "Optional[StringScalar]" = Field(default=None)
+  role: "Optional[StringScalar]" = Field(default=None)
+  # Signature order for the signatory.
+  signatureOrder: "QuerySignatory_Signatory_SignatureOrder"
+  # The current status of the signatory.
+  status: "SignatoryStatus"
+  # The reason for the signatory status (rejection reason when rejected).
+  statusReason: "Optional[StringScalar]" = Field(default=None)
+
+
+class QuerySignatory_Signatory_SignatoryDocumentConnection(BaseModel):
+  edges: (
+    "list[QuerySignatory_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge]"
+  )
+
+
+class QuerySignatory_Signatory_SignatureEvidenceProvider(BaseModel):
+  id: "IDScalar"
+
+
+class QuerySignatory_Signatory_SignatureOrder(BaseModel):
+  closedAt: "Optional[DateTimeScalar]" = Field(default=None)
+  evidenceProviders: (
+    "list[QuerySignatory_Signatory_SignatureOrder_SignatureEvidenceProvider]"
+  )
+  expiresAt: "DateTimeScalar"
+  id: "IDScalar"
+  # Number of max signatories for the signature order
+  maxSignatories: "IntScalar"
+  # List of signatories for the signature order.
+  signatories: "list[QuerySignatory_Signatory_SignatureOrder_Signatory]"
+  status: "SignatureOrderStatus"
+  title: "Optional[StringScalar]" = Field(default=None)
+
+
+class QuerySignatory_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge(
+  BaseModel
+):
+  node: "QuerySignatory_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document"
+  status: "Optional[SignatoryDocumentStatus]" = Field(default=None)
+
+
+class QuerySignatory_Signatory_SignatureOrder_SignatureEvidenceProvider(BaseModel):
+  id: "IDScalar"
+
+
+class QuerySignatory_Signatory_SignatureOrder_Signatory(BaseModel):
+  documents: (
+    "QuerySignatory_Signatory_SignatureOrder_Signatory_SignatoryDocumentConnection"
+  )
+  # A download link for signatories to download their signed documents. Signatories must verify their identity before downloading. Can be used when signature order is closed with document retention.
+  downloadHref: "Optional[StringScalar]" = Field(default=None)
+  evidenceProviders: (
+    "list[QuerySignatory_Signatory_SignatureOrder_Signatory_SignatureEvidenceProvider]"
+  )
+  # A link to the signatures frontend, you can send this link to your users to enable them to sign your documents.
+  href: "StringScalar"
+  id: "IDScalar"
+  reference: "Optional[StringScalar]" = Field(default=None)
+  role: "Optional[StringScalar]" = Field(default=None)
+  # Signature order for the signatory.
+  signatureOrder: "QuerySignatory_Signatory_SignatureOrder_Signatory_SignatureOrder"
+  # The current status of the signatory.
+  status: "SignatoryStatus"
+  # The reason for the signatory status (rejection reason when rejected).
+  statusReason: "Optional[StringScalar]" = Field(default=None)
+
+
+class QuerySignatory_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document(
+  BaseModel
+):
+  id: "IDScalar"
+
+
+class QuerySignatory_Signatory_SignatureOrder_Signatory_SignatoryDocumentConnection(
+  BaseModel
+):
+  edges: "list[QuerySignatory_Signatory_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge]"
+
+
+class QuerySignatory_Signatory_SignatureOrder_Signatory_SignatureEvidenceProvider(
+  BaseModel
+):
+  id: "IDScalar"
+
+
+class QuerySignatory_Signatory_SignatureOrder_Signatory_SignatureOrder(BaseModel):
+  closedAt: "Optional[DateTimeScalar]" = Field(default=None)
+  expiresAt: "DateTimeScalar"
+  id: "IDScalar"
+  status: "SignatureOrderStatus"
+
+
+class QuerySignatory_Signatory_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge(
+  BaseModel
+):
+  node: "QuerySignatory_Signatory_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document"
+  status: "Optional[SignatoryDocumentStatus]" = Field(default=None)
+
+
+class QuerySignatory_Signatory_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document(
+  BaseModel
+):
+  id: "IDScalar"
+
+
 querySignatoryDocument = f"""query signatory($id: ID!) {{
   signatory(id: $id) {{
     signatureOrder {{
@@ -291,6 +1605,12 @@ querySignatoryDocument = f"""query signatory($id: ID!) {{
 }}
 {BasicSignatureOrderFragment}
 {BasicSignatoryFragment}"""
+
+
+class QuerySignatureOrders_Viewer(BaseModel):
+  pass
+
+
 querySignatureOrdersDocument = f"""query signatureOrders($status: SignatureOrderStatus, $first: Int!, $after: String) {{
   viewer {{
     __typename
@@ -307,6 +1627,148 @@ querySignatureOrdersDocument = f"""query signatureOrders($status: SignatureOrder
 }}
 {BasicSignatureOrderFragment}
 {BasicSignatoryFragment}"""
+
+
+class QueryBatchSignatory_BatchSignatory(BaseModel):
+  href: "StringScalar"
+  id: "IDScalar"
+  items: "list[QueryBatchSignatory_BatchSignatory_BatchSignatoryItem]"
+  # The authentication token required for performing batch operations.
+  token: "StringScalar"
+
+
+class QueryBatchSignatory_BatchSignatory_BatchSignatoryItem(BaseModel):
+  signatory: "QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_Signatory"
+  signatureOrder: "QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_SignatureOrder"
+
+
+class QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_Signatory(BaseModel):
+  documents: "QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_Signatory_SignatoryDocumentConnection"
+  # A download link for signatories to download their signed documents. Signatories must verify their identity before downloading. Can be used when signature order is closed with document retention.
+  downloadHref: "Optional[StringScalar]" = Field(default=None)
+  evidenceProviders: "list[QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_Signatory_SignatureEvidenceProvider]"
+  # A link to the signatures frontend, you can send this link to your users to enable them to sign your documents.
+  href: "StringScalar"
+  id: "IDScalar"
+  reference: "Optional[StringScalar]" = Field(default=None)
+  role: "Optional[StringScalar]" = Field(default=None)
+  # Signature order for the signatory.
+  signatureOrder: (
+    "QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_Signatory_SignatureOrder"
+  )
+  # The current status of the signatory.
+  status: "SignatoryStatus"
+  # The reason for the signatory status (rejection reason when rejected).
+  statusReason: "Optional[StringScalar]" = Field(default=None)
+
+
+class QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_SignatureOrder(BaseModel):
+  closedAt: "Optional[DateTimeScalar]" = Field(default=None)
+  evidenceProviders: "list[QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_SignatureOrder_SignatureEvidenceProvider]"
+  expiresAt: "DateTimeScalar"
+  id: "IDScalar"
+  # Number of max signatories for the signature order
+  maxSignatories: "IntScalar"
+  # List of signatories for the signature order.
+  signatories: "list[QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory]"
+  status: "SignatureOrderStatus"
+  title: "Optional[StringScalar]" = Field(default=None)
+
+
+class QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_Signatory_SignatoryDocumentConnection(
+  BaseModel
+):
+  edges: "list[QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge]"
+
+
+class QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_Signatory_SignatureEvidenceProvider(
+  BaseModel
+):
+  id: "IDScalar"
+
+
+class QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_Signatory_SignatureOrder(
+  BaseModel
+):
+  closedAt: "Optional[DateTimeScalar]" = Field(default=None)
+  expiresAt: "DateTimeScalar"
+  id: "IDScalar"
+  status: "SignatureOrderStatus"
+
+
+class QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_SignatureOrder_SignatureEvidenceProvider(
+  BaseModel
+):
+  id: "IDScalar"
+
+
+class QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory(
+  BaseModel
+):
+  documents: "QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory_SignatoryDocumentConnection"
+  # A download link for signatories to download their signed documents. Signatories must verify their identity before downloading. Can be used when signature order is closed with document retention.
+  downloadHref: "Optional[StringScalar]" = Field(default=None)
+  evidenceProviders: "list[QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory_SignatureEvidenceProvider]"
+  # A link to the signatures frontend, you can send this link to your users to enable them to sign your documents.
+  href: "StringScalar"
+  id: "IDScalar"
+  reference: "Optional[StringScalar]" = Field(default=None)
+  role: "Optional[StringScalar]" = Field(default=None)
+  # Signature order for the signatory.
+  signatureOrder: "QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory_SignatureOrder"
+  # The current status of the signatory.
+  status: "SignatoryStatus"
+  # The reason for the signatory status (rejection reason when rejected).
+  statusReason: "Optional[StringScalar]" = Field(default=None)
+
+
+class QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge(
+  BaseModel
+):
+  node: "QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document"
+  status: "Optional[SignatoryDocumentStatus]" = Field(default=None)
+
+
+class QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory_SignatoryDocumentConnection(
+  BaseModel
+):
+  edges: "list[QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge]"
+
+
+class QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory_SignatureEvidenceProvider(
+  BaseModel
+):
+  id: "IDScalar"
+
+
+class QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory_SignatureOrder(
+  BaseModel
+):
+  closedAt: "Optional[DateTimeScalar]" = Field(default=None)
+  expiresAt: "DateTimeScalar"
+  id: "IDScalar"
+  status: "SignatureOrderStatus"
+
+
+class QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document(
+  BaseModel
+):
+  id: "IDScalar"
+
+
+class QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge(
+  BaseModel
+):
+  node: "QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document"
+  status: "Optional[SignatoryDocumentStatus]" = Field(default=None)
+
+
+class QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document(
+  BaseModel
+):
+  id: "IDScalar"
+
+
 queryBatchSignatoryDocument = f"""query batchSignatory($id: ID!) {{
   batchSignatory(id: $id) {{
     ...BasicBatchSignatory
@@ -335,154 +1797,183 @@ class CriiptoSignaturesSDK:
 
   def createSignatureOrder(
     self, input: CreateSignatureOrderInput
-  ) -> CreateSignatureOrderOutput:
+  ) -> CreateSignatureOrder_CreateSignatureOrderOutput:
     query = gql(createSignatureOrderDocument)
     variables = {"input": input.model_dump()}
     result = self.client.execute(query, variable_values=variables)
-    parsed = CreateSignatureOrderOutput.model_validate(
+    parsed = CreateSignatureOrder_CreateSignatureOrderOutput.model_validate(
       result.get("createSignatureOrder")
     )
     return parsed
 
   def cleanupSignatureOrder(
     self, input: CleanupSignatureOrderInput
-  ) -> CleanupSignatureOrderOutput:
+  ) -> CleanupSignatureOrder_CleanupSignatureOrderOutput:
     query = gql(cleanupSignatureOrderDocument)
     variables = {"input": input.model_dump()}
     result = self.client.execute(query, variable_values=variables)
-    parsed = CleanupSignatureOrderOutput.model_validate(
+    parsed = CleanupSignatureOrder_CleanupSignatureOrderOutput.model_validate(
       result.get("cleanupSignatureOrder")
     )
     return parsed
 
-  def addSignatory(self, input: AddSignatoryInput) -> AddSignatoryOutput:
+  def addSignatory(self, input: AddSignatoryInput) -> AddSignatory_AddSignatoryOutput:
     query = gql(addSignatoryDocument)
     variables = {"input": input.model_dump()}
     result = self.client.execute(query, variable_values=variables)
-    parsed = AddSignatoryOutput.model_validate(result.get("addSignatory"))
+    parsed = AddSignatory_AddSignatoryOutput.model_validate(result.get("addSignatory"))
     return parsed
 
-  def addSignatories(self, input: AddSignatoriesInput) -> AddSignatoriesOutput:
+  def addSignatories(
+    self, input: AddSignatoriesInput
+  ) -> AddSignatories_AddSignatoriesOutput:
     query = gql(addSignatoriesDocument)
     variables = {"input": input.model_dump()}
     result = self.client.execute(query, variable_values=variables)
-    parsed = AddSignatoriesOutput.model_validate(result.get("addSignatories"))
+    parsed = AddSignatories_AddSignatoriesOutput.model_validate(
+      result.get("addSignatories")
+    )
     return parsed
 
-  def changeSignatory(self, input: ChangeSignatoryInput) -> ChangeSignatoryOutput:
+  def changeSignatory(
+    self, input: ChangeSignatoryInput
+  ) -> ChangeSignatory_ChangeSignatoryOutput:
     query = gql(changeSignatoryDocument)
     variables = {"input": input.model_dump()}
     result = self.client.execute(query, variable_values=variables)
-    parsed = ChangeSignatoryOutput.model_validate(result.get("changeSignatory"))
+    parsed = ChangeSignatory_ChangeSignatoryOutput.model_validate(
+      result.get("changeSignatory")
+    )
     return parsed
 
   def closeSignatureOrder(
     self, input: CloseSignatureOrderInput
-  ) -> CloseSignatureOrderOutput:
+  ) -> CloseSignatureOrder_CloseSignatureOrderOutput:
     query = gql(closeSignatureOrderDocument)
     variables = {"input": input.model_dump()}
     result = self.client.execute(query, variable_values=variables)
-    parsed = CloseSignatureOrderOutput.model_validate(result.get("closeSignatureOrder"))
+    parsed = CloseSignatureOrder_CloseSignatureOrderOutput.model_validate(
+      result.get("closeSignatureOrder")
+    )
     return parsed
 
   def cancelSignatureOrder(
     self, input: CancelSignatureOrderInput
-  ) -> CancelSignatureOrderOutput:
+  ) -> CancelSignatureOrder_CancelSignatureOrderOutput:
     query = gql(cancelSignatureOrderDocument)
     variables = {"input": input.model_dump()}
     result = self.client.execute(query, variable_values=variables)
-    parsed = CancelSignatureOrderOutput.model_validate(
+    parsed = CancelSignatureOrder_CancelSignatureOrderOutput.model_validate(
       result.get("cancelSignatureOrder")
     )
     return parsed
 
-  def signActingAs(self, input: SignActingAsInput) -> SignActingAsOutput:
+  def signActingAs(self, input: SignActingAsInput) -> SignActingAs_SignActingAsOutput:
     query = gql(signActingAsDocument)
     variables = {"input": input.model_dump()}
     result = self.client.execute(query, variable_values=variables)
-    parsed = SignActingAsOutput.model_validate(result.get("signActingAs"))
+    parsed = SignActingAs_SignActingAsOutput.model_validate(result.get("signActingAs"))
     return parsed
 
-  def validateDocument(self, input: ValidateDocumentInput) -> ValidateDocumentOutput:
+  def validateDocument(
+    self, input: ValidateDocumentInput
+  ) -> ValidateDocument_ValidateDocumentOutput:
     query = gql(validateDocumentDocument)
     variables = {"input": input.model_dump()}
     result = self.client.execute(query, variable_values=variables)
-    parsed = ValidateDocumentOutput.model_validate(result.get("validateDocument"))
+    parsed = ValidateDocument_ValidateDocumentOutput.model_validate(
+      result.get("validateDocument")
+    )
     return parsed
 
   def extendSignatureOrder(
     self, input: ExtendSignatureOrderInput
-  ) -> ExtendSignatureOrderOutput:
+  ) -> ExtendSignatureOrder_ExtendSignatureOrderOutput:
     query = gql(extendSignatureOrderDocument)
     variables = {"input": input.model_dump()}
     result = self.client.execute(query, variable_values=variables)
-    parsed = ExtendSignatureOrderOutput.model_validate(
+    parsed = ExtendSignatureOrder_ExtendSignatureOrderOutput.model_validate(
       result.get("extendSignatureOrder")
     )
     return parsed
 
-  def deleteSignatory(self, input: DeleteSignatoryInput) -> DeleteSignatoryOutput:
+  def deleteSignatory(
+    self, input: DeleteSignatoryInput
+  ) -> DeleteSignatory_DeleteSignatoryOutput:
     query = gql(deleteSignatoryDocument)
     variables = {"input": input.model_dump()}
     result = self.client.execute(query, variable_values=variables)
-    parsed = DeleteSignatoryOutput.model_validate(result.get("deleteSignatory"))
+    parsed = DeleteSignatory_DeleteSignatoryOutput.model_validate(
+      result.get("deleteSignatory")
+    )
     return parsed
 
   def createBatchSignatory(
     self, input: CreateBatchSignatoryInput
-  ) -> CreateBatchSignatoryOutput:
+  ) -> CreateBatchSignatory_CreateBatchSignatoryOutput:
     query = gql(createBatchSignatoryDocument)
     variables = {"input": input.model_dump()}
     result = self.client.execute(query, variable_values=variables)
-    parsed = CreateBatchSignatoryOutput.model_validate(
+    parsed = CreateBatchSignatory_CreateBatchSignatoryOutput.model_validate(
       result.get("createBatchSignatory")
     )
     return parsed
 
   def changeSignatureOrder(
     self, input: ChangeSignatureOrderInput
-  ) -> ChangeSignatureOrderOutput:
+  ) -> ChangeSignatureOrder_ChangeSignatureOrderOutput:
     query = gql(changeSignatureOrderDocument)
     variables = {"input": input.model_dump()}
     result = self.client.execute(query, variable_values=variables)
-    parsed = ChangeSignatureOrderOutput.model_validate(
+    parsed = ChangeSignatureOrder_ChangeSignatureOrderOutput.model_validate(
       result.get("changeSignatureOrder")
     )
     return parsed
 
-  def querySignatureOrder(self, id: IDScalar) -> SignatureOrder:
+  def querySignatureOrder(self, id: IDScalar) -> QuerySignatureOrder_SignatureOrder:
     query = gql(querySignatureOrderDocument)
     variables = {"id": id}
     result = self.client.execute(query, variable_values=variables)
-    parsed = SignatureOrder.model_validate(result.get("signatureOrder"))
+    parsed = QuerySignatureOrder_SignatureOrder.model_validate(
+      result.get("signatureOrder")
+    )
     return parsed
 
-  def querySignatureOrderWithDocuments(self, id: IDScalar) -> SignatureOrder:
+  def querySignatureOrderWithDocuments(
+    self, id: IDScalar
+  ) -> QuerySignatureOrderWithDocuments_SignatureOrder:
     query = gql(querySignatureOrderWithDocumentsDocument)
     variables = {"id": id}
     result = self.client.execute(query, variable_values=variables)
-    parsed = SignatureOrder.model_validate(result.get("signatureOrder"))
+    parsed = QuerySignatureOrderWithDocuments_SignatureOrder.model_validate(
+      result.get("signatureOrder")
+    )
     return parsed
 
-  def querySignatory(self, id: IDScalar) -> Signatory:
+  def querySignatory(self, id: IDScalar) -> QuerySignatory_Signatory:
     query = gql(querySignatoryDocument)
     variables = {"id": id}
     result = self.client.execute(query, variable_values=variables)
-    parsed = Signatory.model_validate(result.get("signatory"))
+    parsed = QuerySignatory_Signatory.model_validate(result.get("signatory"))
     return parsed
 
   def querySignatureOrders(
-    self, status: SignatureOrderStatus, first: IntScalar, after: StringScalar
-  ) -> Viewer:
+    self,
+    status: Optional[SignatureOrderStatus],
+    first: IntScalar,
+    after: Optional[StringScalar],
+  ) -> QuerySignatureOrders_Viewer:
     query = gql(querySignatureOrdersDocument)
     variables = {"status": status, "first": first, "after": after}
     result = self.client.execute(query, variable_values=variables)
-    parsed = Viewer.model_validate(result.get("viewer"))
+    parsed = QuerySignatureOrders_Viewer.model_validate(result.get("viewer"))
     return parsed
 
-  def queryBatchSignatory(self, id: IDScalar) -> BatchSignatory:
+  def queryBatchSignatory(self, id: IDScalar) -> QueryBatchSignatory_BatchSignatory:
     query = gql(queryBatchSignatoryDocument)
     variables = {"id": id}
     result = self.client.execute(query, variable_values=variables)
-    parsed = BatchSignatory.model_validate(result.get("batchSignatory"))
+    parsed = QueryBatchSignatory_BatchSignatory.model_validate(
+      result.get("batchSignatory")
+    )
     return parsed

--- a/packages/python/uv.lock
+++ b/packages/python/uv.lock
@@ -119,6 +119,7 @@ dependencies = [
 dev = [
     { name = "pytest" },
     { name = "ruff" },
+    { name = "ty" },
 ]
 
 [package.metadata]
@@ -131,6 +132,7 @@ requires-dist = [
 dev = [
     { name = "pytest", specifier = ">=8.4.1" },
     { name = "ruff", specifier = ">=0.12.7" },
+    { name = "ty", specifier = ">=0.0.1a17" },
 ]
 test = []
 
@@ -428,6 +430,31 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "ty"
+version = "0.0.1a17"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/59/f29cf1adc5c5dd6e739e08138dfa2435d3210841c6b6aa4d5bee7203cabf/ty-0.0.1a17.tar.gz", hash = "sha256:8bd0c5722c630b46a136ffc8f273f47d46cf00d9df2b0c72f1bfd28d1908a7c2", size = 4037064, upload-time = "2025-08-06T12:13:55.862Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/76/1275e4b02a74dbff40408c608dcccb758245173bd794618dadcb092e384f/ty-0.0.1a17-py3-none-linux_armv6l.whl", hash = "sha256:c16b109f05ab34f084b98b9da84c795a23780c9a2f44c237464e52efc5f97139", size = 7970950, upload-time = "2025-08-06T12:13:24.031Z" },
+    { url = "https://files.pythonhosted.org/packages/df/15/10947e3a0993b02acb563fa958fb9334937615195dbe6efd17c889d1925d/ty-0.0.1a17-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:59e2db756b2b727723ebee58c2e00f172e00a60083a49c8522a19e81887dbc71", size = 8117684, upload-time = "2025-08-06T12:13:26.035Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/73/1f982b361b0f161dad3181739f6dc010252e17d5eb8eea625d88f03deb23/ty-0.0.1a17-py3-none-macosx_11_0_arm64.whl", hash = "sha256:79b6d76d64f86414d482f08e09433bedd3e489a1973fa1226b457d4935b592a3", size = 7721774, upload-time = "2025-08-06T12:13:27.528Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/fc/a8837d4c1e395730157b16f379f4204035bb75e3fc815a1238c02bab2655/ty-0.0.1a17-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bdbc144e7d7a5c8dc102715870bf211b51efe581e952a933a0fcba2df9d6ac8d", size = 7841709, upload-time = "2025-08-06T12:13:29.726Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ae/1f69a9aa9f3092c7c1e3bf8e8d2d3db4a7a03108432fc02af24e313c8deb/ty-0.0.1a17-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:677388fbe5b9e75764dd8b520eff9c3273f9749ece5425eb34e6fa1359430e3b", size = 7811651, upload-time = "2025-08-06T12:13:31.448Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/d8/561283da06dd8f7da44543af9e4a7fde1716f1fe174dde073f78ea291b35/ty-0.0.1a17-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cdaa4baee9f559ee5bb36b66ad0635e2e4308c6937e8e655a4d4ae1bcf736ad0", size = 8702850, upload-time = "2025-08-06T12:13:34.484Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/10/da263a67fea576027b65d78a7d2a55d9829aa22b17e0e10d4201b8d6bd8c/ty-0.0.1a17-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:a0637f80301e7a961b87df2e01db22e8f764cd46d371a73b9a968e1894c334ab", size = 9188621, upload-time = "2025-08-06T12:13:36.206Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/e3/e0d2c55df43ecf1bd5f11859fd9f8dd8536643ce1433aec6b8c8bf3b2865/ty-0.0.1a17-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:749622726587e758fbbb530d1ab293b7489476cd5502c3ac5da5d6b042bb6a1b", size = 8795061, upload-time = "2025-08-06T12:13:37.99Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/3c/ad62544ad7982cb4029f7901953ede9a27c7f6a3afef207fef6a4c6ebfce/ty-0.0.1a17-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5f1cb91c4b79127193829ab2d1bda79a86ab782fcbdf2988b5a3af37a44a7ae2", size = 8643000, upload-time = "2025-08-06T12:13:40.075Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/cb/029bf9f24bb5c5c7c4b139d1f131b19530303fcdd8141607a8d065a87f74/ty-0.0.1a17-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7310e783c54f4f9b2380e050b2e992ccbebcf7e73748689f1d8408199cc5a14e", size = 8432265, upload-time = "2025-08-06T12:13:41.631Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/6c/b4c7ba46218953a822f17813ed2d86238a04ca7937de286841a2c18ff857/ty-0.0.1a17-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:96681e474600811066bf42e3e2cfac7603b7ca1da065fb4f852f94f3df9c944a", size = 7730711, upload-time = "2025-08-06T12:13:43.32Z" },
+    { url = "https://files.pythonhosted.org/packages/74/fd/f3aa541e1b7e1d0becf9f28e44e986ae5eb556f827a5312011026938d197/ty-0.0.1a17-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:0ddc72485af203a70267c522ff6ab6cf648ea0a065a7fa542e9e9552c83cdaee", size = 7836927, upload-time = "2025-08-06T12:13:44.614Z" },
+    { url = "https://files.pythonhosted.org/packages/94/06/7d8b4b52af385a20705cc063a7f9c144aae3b6aaef165ad2fcc029c9f755/ty-0.0.1a17-py3-none-musllinux_1_2_i686.whl", hash = "sha256:7b05f97cc5149b01cb979b9b6b2d773055fb482e490d7169d7c3a213de07ade5", size = 8304523, upload-time = "2025-08-06T12:13:45.983Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/a6/e14d4600339a6654e9ccc90ad9662a116f9544e0afb8d0abf1c99d6a2c2d/ty-0.0.1a17-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:8f80d9b5bc8681fe072ede10d4052035ec1f54c194532932e6c4230a2a5526e5", size = 8492400, upload-time = "2025-08-06T12:13:47.406Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/90/19dac956ab9f1ad04b4d1a38df856b44f237b3eda5af5b76a29439e64165/ty-0.0.1a17-py3-none-win32.whl", hash = "sha256:c3ba585145c4a019cb31001a1d0bd606e01fe01b285a20188a42eba165dddd50", size = 7617341, upload-time = "2025-08-06T12:13:49.093Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/94/08e2b3f6bc0af97abcd3fcc8ea28797a627296613256ae37e98043c871ca/ty-0.0.1a17-py3-none-win_amd64.whl", hash = "sha256:7d00b569ebd4635c58840d2ed9e1d2d8b36f496619c0bc0c8d1777767786b508", size = 8230727, upload-time = "2025-08-06T12:13:50.705Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c6/207bbc2f3bb71df4b1aeabe8e9c31a1cd22c72aff0ab9c1a832b9ae54f6e/ty-0.0.1a17-py3-none-win_arm64.whl", hash = "sha256:636eacc1dceaf09325415a70a03cd57eae53e5c7f281813aaa943a698a45cddb", size = 7782847, upload-time = "2025-08-06T12:13:54.243Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR significantly improves the return types of our python SDK, by generating specific types for each operation.

Previously, we would use the return types from the schema, meaning `createSignatureOrder` would return a type with the following fields:
```python
class CreateSignatureOrderOutput(BaseModel):
  application: "Application"
  signatureOrder: "SignatureOrder"

class SignatureOrder(BaseModel):
  application: "Optional[Application]" = Field(default=None)
  closedAt: "Optional[DateTimeScalar]" = Field(default=None)
  createdAt: "DateTimeScalar"
  documents: "list[Document]"
  evidenceProviders: "list[SignatureEvidenceProvider]"
  expiresAt: "DateTimeScalar"
  id: "IDScalar"
  # Number of max signatories for the signature order
  maxSignatories: "IntScalar"
  # List of signatories for the signature order.
  signatories: "list[Signatory]"
  status: "SignatureOrderStatus"
  # Tenants are only accessable from user viewers
  tenant: "Optional[Tenant]" = Field(default=None)
  timezone: "StringScalar"
  title: "Optional[StringScalar]" = Field(default=None)
  traceId: "StringScalar"
  ui: "SignatureOrderUI"
  webhook: "Optional[SignatureOrderWebhook]" = Field(default=None)
``` 

However, in the actual definition of the mutation, we don't select `application` at all:
```graphql
mutation createSignatureOrder($input: CreateSignatureOrderInput!) {
  createSignatureOrder(input: $input) {
    signatureOrder {
      ...BasicSignatureOrder
      documents {
        ...BasicDocument
      }
    }
  }
}
```
Same goes for the `tenant` field on `signatureOrder`, and other fields. That meant we had to make all fields on the output types optional, because we didn't know if they were actually selected (see https://github.com/criipto/criipto-signatures-sdk/commit/ba963e6e99973f78682272b8f1e383e34d9488ad)

However, we can do better!

Now we have types that look like this:

```python
class CreateSignatureOrder_CreateSignatureOrderOutput(BaseModel):
  signatureOrder: "CreateSignatureOrder_CreateSignatureOrderOutput_SignatureOrder"

class CreateSignatureOrder_CreateSignatureOrderOutput_SignatureOrder(BaseModel):
  closedAt: "Optional[DateTimeScalar]" = Field(default=None)
  documents: (
    "list[CreateSignatureOrder_CreateSignatureOrderOutput_SignatureOrder_Document]"
  )
  evidenceProviders: "list[CreateSignatureOrder_CreateSignatureOrderOutput_SignatureOrder_SignatureEvidenceProvider]"
  expiresAt: "DateTimeScalar"
  id: "IDScalar"
  # Number of max signatories for the signature order
  maxSignatories: "IntScalar"
  # List of signatories for the signature order.
  signatories: (
    "list[CreateSignatureOrder_CreateSignatureOrderOutput_SignatureOrder_Signatory]"
  )
  status: "SignatureOrderStatus"
  title: "Optional[StringScalar]" = Field(default=None)
```

This happens in three steps:
1. We take the selection set, and convert it to a tree of field names. The selection set is already a tree, but it can contain references to fragments, and we want to expand those references before doing any further processing. https://github.com/criipto/criipto-signatures-sdk/pull/22/commits/d3cdb1aefa5136599ac8edc0f0a96b448e03d797 If you want to look at the format of a selection set, there's a simple AST [here](https://astexplorer.net/#/gist/29c124c189fd1ea8c1c39a94058285e4/97ca3b8decde0d8d3bb2c237fa114fd814aa274e)
2. We take the output from the previous step, and use that to convert the tree of selected fields into a tree of AST nodes https://github.com/criipto/criipto-signatures-sdk/pull/22/commits/3829a4d53789cc630118e65d5d986efbb9c74ff4
3. Finally, we walk through the tree of AST nodes, and generate python types for each of them https://github.com/criipto/criipto-signatures-sdk/pull/22/commits/2965254b77a3909ec6ce517fe0ab908734a6ea5a

Steps 1 and 2 are entirely generic and only work on the GraphQL schema and AST nodes. The only python specific thing in step 3 is that we instantiate a `PythonTypesVisitor` to convert the GraphQL AST nodes to concrete python types. The rest of the code is a generic walk over the AST tree.