### PR TITLE
change(codegen/python): Allow passing a `bytes` object to fields that expect a `Blob`

### DIFF
--- a/codegen/graphql-codegen-plugin-python/src/PythonOperationsVisitor.ts
+++ b/codegen/graphql-codegen-plugin-python/src/PythonOperationsVisitor.ts
@@ -212,7 +212,7 @@ class CriiptoSignaturesSDK:
               let variableTypeName = variableTypeNode.name.value;
               const variableSchemaType = this._schema.getType(variableTypeName);
               if (isScalarType(variableSchemaType)) {
-                variableTypeName = `${variableTypeName}Scalar`;
+                variableTypeName = `${variableTypeName}ScalarInput`;
               } else if (isInputObjectType(variableSchemaType)) {
                 this.modelImports.add(variableTypeName);
               }
@@ -271,7 +271,7 @@ return parsed`,
     return [
       ...PythonTypesVisitor.getImports(),
       `from .models import ${Array.from(this.modelImports).join(',')}`,
-      `from .models import ${scalars.map(scalar => `${scalar.name}Scalar`).join(',')}`,
+      `from .models import ${scalars.flatMap(scalar => [`${scalar.name}ScalarInput`, `${scalar.name}ScalarOutput`]).join(',')}`,
       `from .models import ${enums.map(e => e.name).join(',')}`,
       'from gql import Client, gql',
       'from gql.transport.aiohttp import AIOHTTPTransport, BasicAuth',

--- a/codegen/graphql-codegen-plugin-python/src/PythonTypesVisitor.ts
+++ b/codegen/graphql-codegen-plugin-python/src/PythonTypesVisitor.ts
@@ -33,6 +33,7 @@ const DEFAULT_SCALARS = {
   Int: { input: 'int', output: 'int' },
   Float: { input: 'float', output: 'float' },
   Boolean: { input: 'bool', output: 'bool' },
+  Blob: { input: 'CustomBlobInput', output: 'str' },
 } as const;
 
 export class PythonTypesVisitor extends BaseVisitor {
@@ -56,6 +57,7 @@ export class PythonTypesVisitor extends BaseVisitor {
   static getImports() {
     return [
       'from __future__ import annotations',
+      'from .utils import CustomBlobInput',
       'from enum import StrEnum',
       'from typing import Optional',
       'from pydantic import BaseModel, Field',

--- a/codegen/graphql-codegen-plugin-python/src/PythonTypesVisitor.ts
+++ b/codegen/graphql-codegen-plugin-python/src/PythonTypesVisitor.ts
@@ -55,6 +55,7 @@ export class PythonTypesVisitor extends BaseVisitor {
 
   static getImports() {
     return [
+      'from __future__ import annotations',
       'from enum import StrEnum',
       'from typing import Optional',
       'from pydantic import BaseModel, Field',
@@ -138,7 +139,7 @@ export class PythonTypesVisitor extends BaseVisitor {
       output += `# ${node.description.value}\n`;
     }
 
-    output += `${node.name.value}: "${typeString}"`;
+    output += `${node.name.value}: ${typeString}`;
 
     if (nullable || (listType && nullableList)) {
       output += ` = Field(default=None)`;

--- a/codegen/graphql-codegen-plugin-python/src/PythonTypesVisitor.ts
+++ b/codegen/graphql-codegen-plugin-python/src/PythonTypesVisitor.ts
@@ -64,7 +64,10 @@ export class PythonTypesVisitor extends BaseVisitor {
 
   getScalarsTypes() {
     return Object.entries(this.scalars)
-      .map(([name, type]) => `type ${name}Scalar = ${type.input}`)
+      .flatMap(([name, type]) => [
+        `type ${name}ScalarInput = ${type.input}`,
+        `type ${name}ScalarOutput = ${type.output}`,
+      ])
       .join('\n');
   }
 
@@ -119,7 +122,7 @@ export class PythonTypesVisitor extends BaseVisitor {
     let typeString = typeNode.name.value;
 
     if (isScalarType(schemaType)) {
-      typeString = `${typeString}Scalar`;
+      typeString = `${typeString}Scalar${node.kind === Kind.INPUT_VALUE_DEFINITION ? 'Input' : 'Output'}`;
     } else if (isObjectType(schemaType) || isInterfaceType(schemaType)) {
       typeString = this.config.typesPrefix + typeString;
     }

--- a/codegen/graphql-codegen-shared/src/index.ts
+++ b/codegen/graphql-codegen-shared/src/index.ts
@@ -1,2 +1,3 @@
 export { operationSelectionsToAstTree, type AstTreeNode } from './selection-set-to-ast.ts';
 export { assertIsNotUndefined } from './assertIsNotUndefined.ts';
+export { unwrapTypeNode } from './unwrapTypeNode.ts';

--- a/codegen/graphql-codegen-shared/src/unwrapTypeNode.ts
+++ b/codegen/graphql-codegen-shared/src/unwrapTypeNode.ts
@@ -1,0 +1,36 @@
+import { Kind, type NamedTypeNode, type TypeNode } from 'graphql';
+
+/**
+ * Named types can be wrapped in both non-nullable and list nodes (such as foo: [Bar!]!),
+ * which translates to NonNullType(ListType(NonNullType(Bar)))).
+ *
+ * This function unwraps the node, and returns booleans indicating whether:
+ * * The innermost type was nullable (`nullable`)
+ * * The type was wrapped in a list (`listType`)
+ * * The list type was nullable (`nullableList`)
+ */
+export function unwrapTypeNode(node: TypeNode): {
+  nullable: boolean;
+  listType: boolean;
+  nullableList: boolean;
+  node: NamedTypeNode;
+} {
+  let nullable = true;
+  let listType = false;
+  let nullableList = true;
+
+  while (node.kind === Kind.LIST_TYPE || node.kind == Kind.NON_NULL_TYPE) {
+    if (node.kind === Kind.NON_NULL_TYPE) {
+      nullable = false;
+    }
+    if (node.kind === Kind.LIST_TYPE) {
+      listType = true;
+      if (!nullable) {
+        nullableList = false;
+        nullable = true;
+      }
+    }
+    node = node.type;
+  }
+  return { nullable, listType, nullableList, node };
+}

--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
       "dotnet csharpier"
     ],
     "*.py": [
-      "uvx ruff format"
+      "uvx ruff format",
+      "uvx ty check --project packages/python"
     ]
   }
 }

--- a/packages/python/src/criipto_signatures/models.py
+++ b/packages/python/src/criipto_signatures/models.py
@@ -3,20 +3,29 @@ from enum import StrEnum
 from typing import Optional
 from pydantic import BaseModel, Field
 
-type IDScalar = str
-type StringScalar = str
-type IntScalar = int
-type FloatScalar = float
-type BooleanScalar = bool
-type BlobScalar = str
-type DateScalar = str
-type DateTimeScalar = str
-type URIScalar = str
+type IDScalarInput = str
+type IDScalarOutput = str
+type StringScalarInput = str
+type StringScalarOutput = str
+type IntScalarInput = int
+type IntScalarOutput = int
+type FloatScalarInput = float
+type FloatScalarOutput = float
+type BooleanScalarInput = bool
+type BooleanScalarOutput = bool
+type BlobScalarInput = str
+type BlobScalarOutput = str
+type DateScalarInput = str
+type DateScalarOutput = str
+type DateTimeScalarInput = str
+type DateTimeScalarOutput = str
+type URIScalarInput = str
+type URIScalarOutput = str
 
 
 class AddSignatoriesInput(BaseModel):
   signatories: list[CreateSignatureOrderSignatoryInput]
-  signatureOrderId: IDScalar
+  signatureOrderId: IDScalarInput
 
 
 class AddSignatoriesOutput(BaseModel):
@@ -35,11 +44,11 @@ class AddSignatoryInput(BaseModel):
     default=None
   )
   # Will not be displayed to signatories, can be used as a reference to your own system.
-  reference: Optional[StringScalar] = Field(default=None)
+  reference: Optional[StringScalarInput] = Field(default=None)
   # Define a role for the signatory, i.e. 'Chairman'. Will be visible in the document output.
-  role: Optional[StringScalar] = Field(default=None)
+  role: Optional[StringScalarInput] = Field(default=None)
   signatureAppearance: Optional[SignatureAppearanceInput] = Field(default=None)
-  signatureOrderId: IDScalar
+  signatureOrderId: IDScalarInput
   # Override UI settings for signatory, defaults to UI settings for signature order
   ui: Optional[SignatoryUIInput] = Field(default=None)
 
@@ -54,19 +63,19 @@ class AllOfEvidenceProviderInput(BaseModel):
 
 
 class AllOfSignatureEvidenceProvider(BaseModel):
-  id: IDScalar
+  id: IDScalarOutput
   providers: list[SingleSignatureEvidenceProvider]
 
 
 class AnonymousViewer(BaseModel):
-  authenticated: BooleanScalar
-  id: IDScalar
+  authenticated: BooleanScalarOutput
+  id: IDScalarOutput
 
 
 class Application(BaseModel):
   apiKeys: list[ApplicationApiKey]
-  id: IDScalar
-  name: StringScalar
+  id: IDScalarOutput
+  name: StringScalarOutput
   signatureOrders: SignatureOrderConnection
   # Tenants are only accessable from user viewers
   tenant: Optional[Tenant] = Field(default=None)
@@ -75,11 +84,11 @@ class Application(BaseModel):
 
 
 class ApplicationApiKey(BaseModel):
-  clientId: StringScalar
-  clientSecret: Optional[StringScalar] = Field(default=None)
-  id: IDScalar
+  clientId: StringScalarOutput
+  clientSecret: Optional[StringScalarOutput] = Field(default=None)
+  id: IDScalarOutput
   mode: ApplicationApiKeyMode
-  note: Optional[StringScalar] = Field(default=None)
+  note: Optional[StringScalarOutput] = Field(default=None)
 
 
 class ApplicationApiKeyMode(StrEnum):
@@ -88,12 +97,12 @@ class ApplicationApiKeyMode(StrEnum):
 
 
 class BatchSignatory(BaseModel):
-  href: StringScalar
-  id: IDScalar
+  href: StringScalarOutput
+  id: IDScalarOutput
   items: list[BatchSignatoryItem]
   # The authentication token required for performing batch operations.
-  token: StringScalar
-  traceId: StringScalar
+  token: StringScalarOutput
+  traceId: StringScalarOutput
   ui: SignatureOrderUI
 
 
@@ -103,23 +112,23 @@ class BatchSignatoryItem(BaseModel):
 
 
 class BatchSignatoryItemInput(BaseModel):
-  signatoryId: StringScalar
-  signatureOrderId: StringScalar
+  signatoryId: StringScalarInput
+  signatureOrderId: StringScalarInput
 
 
 class BatchSignatoryViewer(BaseModel):
-  authenticated: BooleanScalar
-  batchSignatoryId: IDScalar
+  authenticated: BooleanScalarOutput
+  batchSignatoryId: IDScalarOutput
   documents: SignatoryDocumentConnection
   evidenceProviders: list[SignatureEvidenceProvider]
-  id: IDScalar
-  signer: BooleanScalar
+  id: IDScalarOutput
+  signer: BooleanScalarOutput
   status: SignatoryStatus
   ui: SignatureOrderUI
 
 
 class CancelSignatureOrderInput(BaseModel):
-  signatureOrderId: IDScalar
+  signatureOrderId: IDScalarInput
 
 
 class CancelSignatureOrderOutput(BaseModel):
@@ -137,10 +146,10 @@ class ChangeSignatoryInput(BaseModel):
     default=None
   )
   # Will not be displayed to signatories, can be used as a reference to your own system.
-  reference: Optional[StringScalar] = Field(default=None)
+  reference: Optional[StringScalarInput] = Field(default=None)
   # Define a role for the signatory, i.e. 'Chairman'. Will be visible in the document output.
-  role: Optional[StringScalar] = Field(default=None)
-  signatoryId: IDScalar
+  role: Optional[StringScalarInput] = Field(default=None)
+  signatoryId: IDScalarInput
   signatureAppearance: Optional[SignatureAppearanceInput] = Field(default=None)
   # Override UI settings for signatory, defaults to UI settings for signature order
   ui: Optional[SignatoryUIInput] = Field(default=None)
@@ -153,8 +162,8 @@ class ChangeSignatoryOutput(BaseModel):
 
 class ChangeSignatureOrderInput(BaseModel):
   # Max allowed signatories (as it influences pages needed for seals). Cannot be changed after first signer.
-  maxSignatories: Optional[IntScalar] = Field(default=None)
-  signatureOrderId: IDScalar
+  maxSignatories: Optional[IntScalarInput] = Field(default=None)
+  signatureOrderId: IDScalarInput
   # Signature order webhook settings
   webhook: Optional[CreateSignatureOrderWebhookInput] = Field(default=None)
 
@@ -164,7 +173,7 @@ class ChangeSignatureOrderOutput(BaseModel):
 
 
 class CleanupSignatureOrderInput(BaseModel):
-  signatureOrderId: IDScalar
+  signatureOrderId: IDScalarInput
 
 
 class CleanupSignatureOrderOutput(BaseModel):
@@ -173,8 +182,8 @@ class CleanupSignatureOrderOutput(BaseModel):
 
 class CloseSignatureOrderInput(BaseModel):
   # Retains documents on Criipto servers after closing a signature order. You MUST manually call the cleanupSignatureOrder mutation when you are sure you have downloaded the blobs. Maximum value is 7 days.
-  retainDocumentsForDays: Optional[IntScalar] = Field(default=None)
-  signatureOrderId: IDScalar
+  retainDocumentsForDays: Optional[IntScalarInput] = Field(default=None)
+  signatureOrderId: IDScalarInput
 
 
 class CloseSignatureOrderOutput(BaseModel):
@@ -182,12 +191,12 @@ class CloseSignatureOrderOutput(BaseModel):
 
 
 class CompleteCriiptoVerifyEvidenceProviderInput(BaseModel):
-  code: StringScalar
-  state: StringScalar
+  code: StringScalarInput
+  state: StringScalarInput
 
 
 class CompleteCriiptoVerifyEvidenceProviderOutput(BaseModel):
-  jwt: StringScalar
+  jwt: StringScalarOutput
 
 
 class CompositeSignature(BaseModel):
@@ -196,9 +205,9 @@ class CompositeSignature(BaseModel):
 
 
 class CreateApplicationApiKeyInput(BaseModel):
-  applicationId: IDScalar
+  applicationId: IDScalarInput
   mode: Optional[ApplicationApiKeyMode] = Field(default=None)
-  note: Optional[StringScalar] = Field(default=None)
+  note: Optional[StringScalarInput] = Field(default=None)
 
 
 class CreateApplicationApiKeyOutput(BaseModel):
@@ -207,11 +216,11 @@ class CreateApplicationApiKeyOutput(BaseModel):
 
 
 class CreateApplicationInput(BaseModel):
-  name: StringScalar
-  tenantId: IDScalar
-  verifyApplicationDomain: StringScalar
+  name: StringScalarInput
+  tenantId: IDScalarInput
+  verifyApplicationDomain: StringScalarInput
   verifyApplicationEnvironment: VerifyApplicationEnvironment
-  verifyApplicationRealm: StringScalar
+  verifyApplicationRealm: StringScalarInput
 
 
 class CreateApplicationOutput(BaseModel):
@@ -232,7 +241,7 @@ class CreateBatchSignatoryOutput(BaseModel):
 
 class CreateSignatureOrderInput(BaseModel):
   # By default signatories will be prompted to sign with a Criipto Verify based e-ID, this setting disables it.
-  disableVerifyEvidenceProvider: Optional[BooleanScalar] = Field(default=None)
+  disableVerifyEvidenceProvider: Optional[BooleanScalarInput] = Field(default=None)
   documents: list[DocumentInput]
   # Define evidence providers for signature order if not using built-in Criipto Verify for e-IDs
   evidenceProviders: Optional[list[EvidenceProviderInput]] = Field(default=None)
@@ -241,19 +250,19 @@ class CreateSignatureOrderInput(BaseModel):
     default=None
   )
   # When this signature order will auto-close/expire at exactly in one of the following ISO-8601 formats: yyyy-MM-ddTHH:mm:ssZ, yyyy-MM-ddTHH:mm:ss.ffZ, yyyy-MM-ddTHH:mm:ss.fffZ, yyyy-MM-ddTHH:mm:ssK, yyyy-MM-ddTHH:mm:ss.ffK, yyyy-MM-ddTHH:mm:ss.fffK. Cannot be provided with `expiresInDays`.
-  expiresAt: Optional[StringScalar] = Field(default=None)
+  expiresAt: Optional[StringScalarInput] = Field(default=None)
   # When this signature order will auto-close/expire. Default 90 days. Cannot be provided with `expiresAt`
-  expiresInDays: Optional[IntScalar] = Field(default=None)
+  expiresInDays: Optional[IntScalarInput] = Field(default=None)
   # Attempt to automatically fix document formatting errors if possible. Default 'true'.
-  fixDocumentFormattingErrors: Optional[BooleanScalar] = Field(default=None)
+  fixDocumentFormattingErrors: Optional[BooleanScalarInput] = Field(default=None)
   # Max allowed signatories (as it influences pages needed for seals). Default 14.
-  maxSignatories: Optional[IntScalar] = Field(default=None)
+  maxSignatories: Optional[IntScalarInput] = Field(default=None)
   signatories: Optional[list[CreateSignatureOrderSignatoryInput]] = Field(default=None)
   # Configure appearance of signatures inside documents
   signatureAppearance: Optional[SignatureAppearanceInput] = Field(default=None)
   # Timezone to render signature seals in, default UTC.
-  timezone: Optional[StringScalar] = Field(default=None)
-  title: Optional[StringScalar] = Field(default=None)
+  timezone: Optional[StringScalarInput] = Field(default=None)
+  title: Optional[StringScalarInput] = Field(default=None)
   # Various settings for how the UI is presented to the signatory.
   ui: Optional[CreateSignatureOrderUIInput] = Field(default=None)
   # Signature order webhook settings
@@ -276,9 +285,9 @@ class CreateSignatureOrderSignatoryInput(BaseModel):
     default=None
   )
   # Will not be displayed to signatories, can be used as a reference to your own system.
-  reference: Optional[StringScalar] = Field(default=None)
+  reference: Optional[StringScalarInput] = Field(default=None)
   # Define a role for the signatory, i.e. 'Chairman'. Will be visible in the document output.
-  role: Optional[StringScalar] = Field(default=None)
+  role: Optional[StringScalarInput] = Field(default=None)
   signatureAppearance: Optional[SignatureAppearanceInput] = Field(default=None)
   # Override UI settings for signatory, defaults to UI settings for signature order
   ui: Optional[SignatoryUIInput] = Field(default=None)
@@ -286,67 +295,67 @@ class CreateSignatureOrderSignatoryInput(BaseModel):
 
 class CreateSignatureOrderUIInput(BaseModel):
   # Removes the UI options to reject a document or signature order.
-  disableRejection: Optional[BooleanScalar] = Field(default=None)
+  disableRejection: Optional[BooleanScalarInput] = Field(default=None)
   # The language of texts rendered to the signatory.
   language: Optional[Language] = Field(default=None)
   # Define a logo to be shown in the signatory UI.
   logo: Optional[SignatureOrderUILogoInput] = Field(default=None)
   # Renders a UI layer for PDF annotations, such as links, making them interactive in the UI/browser
-  renderPdfAnnotationLayer: Optional[BooleanScalar] = Field(default=None)
+  renderPdfAnnotationLayer: Optional[BooleanScalarInput] = Field(default=None)
   # The signatory will be redirected to this URL after signing or rejected the signature order.
-  signatoryRedirectUri: Optional[StringScalar] = Field(default=None)
+  signatoryRedirectUri: Optional[StringScalarInput] = Field(default=None)
   # Add stylesheet/css via an absolute HTTPS URL.
-  stylesheet: Optional[StringScalar] = Field(default=None)
+  stylesheet: Optional[StringScalarInput] = Field(default=None)
 
 
 class CreateSignatureOrderWebhookInput(BaseModel):
   # If defined, webhook invocations will have a X-Criipto-Signature header containing a HMAC-SHA256 signature (as a base64 string) of the webhook request body (utf-8). The secret should be between 256 and 512 bits.
-  secret: Optional[BlobScalar] = Field(default=None)
+  secret: Optional[BlobScalarInput] = Field(default=None)
   # Webhook url. POST requests will be executed towards this URL on certain signatory events.
-  url: StringScalar
+  url: StringScalarInput
   # Validates webhook connectivity by triggering a WEBHOOK_VALIDATION event, your webhook must respond within 5 seconds with 200/OK or the signature order creation will fail.
-  validateConnectivity: Optional[BooleanScalar] = Field(default=None)
+  validateConnectivity: Optional[BooleanScalarInput] = Field(default=None)
 
 
 class CriiptoVerifyEvidenceProviderRedirect(BaseModel):
-  redirectUri: StringScalar
-  state: StringScalar
+  redirectUri: StringScalarOutput
+  state: StringScalarOutput
 
 
 # Criipto Verify based evidence for signatures.
 class CriiptoVerifyProviderInput(BaseModel):
-  acrValues: Optional[list[StringScalar]] = Field(default=None)
-  alwaysRedirect: Optional[BooleanScalar] = Field(default=None)
+  acrValues: Optional[list[StringScalarInput]] = Field(default=None)
+  alwaysRedirect: Optional[BooleanScalarInput] = Field(default=None)
   # Define additional valid audiences (besides the main client_id) for the Criipto Verify domain/issuer underlying the application.
-  audiences: Optional[list[StringScalar]] = Field(default=None)
+  audiences: Optional[list[StringScalarInput]] = Field(default=None)
   # Set a custom login_hint for the underlying authentication request.
-  loginHint: Optional[StringScalar] = Field(default=None)
+  loginHint: Optional[StringScalarInput] = Field(default=None)
   # Messages displayed when performing authentication (only supported by DKMitID currently).
-  message: Optional[StringScalar] = Field(default=None)
+  message: Optional[StringScalarInput] = Field(default=None)
   # Set a custom scope for the underlying authentication request.
-  scope: Optional[StringScalar] = Field(default=None)
+  scope: Optional[StringScalarInput] = Field(default=None)
   # Enforces that signatories sign by unique evidence by comparing the values of previous evidence on the key you define. For Criipto Verify you likely want to use `sub` which is a unique pseudonym value present in all e-ID tokens issued.
-  uniqueEvidenceKey: Optional[StringScalar] = Field(default=None)
+  uniqueEvidenceKey: Optional[StringScalarInput] = Field(default=None)
 
 
 class CriiptoVerifySignatureEvidenceProvider(BaseModel):
-  acrValues: list[StringScalar]
-  alwaysRedirect: BooleanScalar
-  audience: StringScalar
-  audiences: list[StringScalar]
-  clientID: StringScalar
-  domain: StringScalar
+  acrValues: list[StringScalarOutput]
+  alwaysRedirect: BooleanScalarOutput
+  audience: StringScalarOutput
+  audiences: list[StringScalarOutput]
+  clientID: StringScalarOutput
+  domain: StringScalarOutput
   environment: Optional[VerifyApplicationEnvironment] = Field(default=None)
-  id: IDScalar
-  loginHint: Optional[StringScalar] = Field(default=None)
-  message: Optional[StringScalar] = Field(default=None)
-  name: StringScalar
-  scope: Optional[StringScalar] = Field(default=None)
+  id: IDScalarOutput
+  loginHint: Optional[StringScalarOutput] = Field(default=None)
+  message: Optional[StringScalarOutput] = Field(default=None)
+  name: StringScalarOutput
+  scope: Optional[StringScalarOutput] = Field(default=None)
 
 
 class DeleteApplicationApiKeyInput(BaseModel):
-  apiKeyId: IDScalar
-  applicationId: IDScalar
+  apiKeyId: IDScalarInput
+  applicationId: IDScalarInput
 
 
 class DeleteApplicationApiKeyOutput(BaseModel):
@@ -354,8 +363,8 @@ class DeleteApplicationApiKeyOutput(BaseModel):
 
 
 class DeleteSignatoryInput(BaseModel):
-  signatoryId: IDScalar
-  signatureOrderId: IDScalar
+  signatoryId: IDScalarInput
+  signatureOrderId: IDScalarInput
 
 
 class DeleteSignatoryOutput(BaseModel):
@@ -375,7 +384,7 @@ class DocumentIDLocation(StrEnum):
 class DocumentInput(BaseModel):
   pdf: Optional[PadesDocumentInput] = Field(default=None)
   # When enabled, will remove any existing signatures from the document before storing. (PDF only)
-  removePreviousSignatures: Optional[BooleanScalar] = Field(default=None)
+  removePreviousSignatures: Optional[BooleanScalarInput] = Field(default=None)
   # XML signing is coming soon, reach out to learn more.
   xml: Optional[XadesDocumentInput] = Field(default=None)
 
@@ -386,7 +395,7 @@ class DocumentStorageMode(StrEnum):
 
 
 class DownloadVerificationCriiptoVerifyInput(BaseModel):
-  jwt: StringScalar
+  jwt: StringScalarInput
 
 
 class DownloadVerificationInput(BaseModel):
@@ -395,29 +404,29 @@ class DownloadVerificationInput(BaseModel):
 
 
 class DownloadVerificationOidcInput(BaseModel):
-  jwt: StringScalar
+  jwt: StringScalarInput
 
 
 # Hand drawn signature evidence for signatures.
 class DrawableEvidenceProviderInput(BaseModel):
   # Required minimum height of drawed area in pixels.
-  minimumHeight: Optional[IntScalar] = Field(default=None)
+  minimumHeight: Optional[IntScalarInput] = Field(default=None)
   # Required minimum width of drawed area in pixels.
-  minimumWidth: Optional[IntScalar] = Field(default=None)
-  requireName: Optional[BooleanScalar] = Field(default=None)
+  minimumWidth: Optional[IntScalarInput] = Field(default=None)
+  requireName: Optional[BooleanScalarInput] = Field(default=None)
 
 
 class DrawableSignature(BaseModel):
-  image: BlobScalar
-  name: Optional[StringScalar] = Field(default=None)
+  image: BlobScalarOutput
+  name: Optional[StringScalarOutput] = Field(default=None)
   signatory: Optional[Signatory] = Field(default=None)
 
 
 class DrawableSignatureEvidenceProvider(BaseModel):
-  id: IDScalar
-  minimumHeight: Optional[IntScalar] = Field(default=None)
-  minimumWidth: Optional[IntScalar] = Field(default=None)
-  requireName: BooleanScalar
+  id: IDScalarOutput
+  minimumHeight: Optional[IntScalarOutput] = Field(default=None)
+  minimumWidth: Optional[IntScalarOutput] = Field(default=None)
+  requireName: BooleanScalarOutput
 
 
 class EmptySignature(BaseModel):
@@ -432,7 +441,7 @@ class EvidenceProviderInput(BaseModel):
   # Hand drawn signature evidence for signatures.
   drawable: Optional[DrawableEvidenceProviderInput] = Field(default=None)
   # Determined if this evidence provider should be enabled by signatories by default. Default true
-  enabledByDefault: Optional[BooleanScalar] = Field(default=None)
+  enabledByDefault: Optional[BooleanScalarInput] = Field(default=None)
   # TEST environment only. Does not manipulate the PDF, use for integration or webhook testing.
   noop: Optional[NoopEvidenceProviderInput] = Field(default=None)
   # Deprecated
@@ -446,8 +455,8 @@ class EvidenceValidationStage(StrEnum):
 
 class ExtendSignatureOrderInput(BaseModel):
   # Expiration to add to order, in days, max 30.
-  additionalExpirationInDays: IntScalar
-  signatureOrderId: IDScalar
+  additionalExpirationInDays: IntScalarInput
+  signatureOrderId: IDScalarInput
 
 
 class ExtendSignatureOrderOutput(BaseModel):
@@ -455,14 +464,14 @@ class ExtendSignatureOrderOutput(BaseModel):
 
 
 class JWTClaim(BaseModel):
-  name: StringScalar
-  value: StringScalar
+  name: StringScalarOutput
+  value: StringScalarOutput
 
 
 class JWTSignature(BaseModel):
   claims: list[JWTClaim]
-  jwks: StringScalar
-  jwt: StringScalar
+  jwks: StringScalarOutput
+  jwt: StringScalarOutput
   signatory: Optional[Signatory] = Field(default=None)
 
 
@@ -534,102 +543,102 @@ class Mutation(BaseModel):
 
 # TEST only. Allows empty signatures for testing.
 class NoopEvidenceProviderInput(BaseModel):
-  name: StringScalar
+  name: StringScalarInput
 
 
 class NoopSignatureEvidenceProvider(BaseModel):
-  id: IDScalar
-  name: StringScalar
+  id: IDScalarOutput
+  name: StringScalarOutput
 
 
 # OIDC/JWT based evidence for signatures.
 class OidcEvidenceProviderInput(BaseModel):
-  acrValues: Optional[list[StringScalar]] = Field(default=None)
-  alwaysRedirect: Optional[BooleanScalar] = Field(default=None)
-  audience: StringScalar
-  clientID: StringScalar
-  domain: StringScalar
-  name: StringScalar
+  acrValues: Optional[list[StringScalarInput]] = Field(default=None)
+  alwaysRedirect: Optional[BooleanScalarInput] = Field(default=None)
+  audience: StringScalarInput
+  clientID: StringScalarInput
+  domain: StringScalarInput
+  name: StringScalarInput
   # Enforces that signatories sign by unique evidence by comparing the values of previous evidence on the key you define.
-  uniqueEvidenceKey: Optional[StringScalar] = Field(default=None)
+  uniqueEvidenceKey: Optional[StringScalarInput] = Field(default=None)
 
 
 class OidcJWTSignatureEvidenceProvider(BaseModel):
-  acrValues: list[StringScalar]
-  alwaysRedirect: BooleanScalar
-  clientID: StringScalar
-  domain: StringScalar
-  id: IDScalar
-  name: StringScalar
+  acrValues: list[StringScalarOutput]
+  alwaysRedirect: BooleanScalarOutput
+  clientID: StringScalarOutput
+  domain: StringScalarOutput
+  id: IDScalarOutput
+  name: StringScalarOutput
 
 
 class PadesDocumentFormInput(BaseModel):
-  enabled: BooleanScalar
+  enabled: BooleanScalarInput
 
 
 class PadesDocumentInput(BaseModel):
-  blob: BlobScalar
+  blob: BlobScalarInput
   # Will add a unique identifier for the document to the specified margin of each page. Useful when printing signed documents.
   displayDocumentID: Optional[DocumentIDLocation] = Field(default=None)
   form: Optional[PadesDocumentFormInput] = Field(default=None)
   # Will not be displayed to signatories, can be used as a reference to your own system.
-  reference: Optional[StringScalar] = Field(default=None)
+  reference: Optional[StringScalarInput] = Field(default=None)
   sealsPageTemplate: Optional[PadesDocumentSealsPageTemplateInput] = Field(default=None)
   storageMode: DocumentStorageMode
-  title: StringScalar
+  title: StringScalarInput
 
 
 class PadesDocumentSealsPageTemplateInput(BaseModel):
   # Using the PDF coordinate system, with (x1, y1) being bottom-left
   area: PdfBoundingBoxInput
   # Must be a PDF containing a SINGLE page
-  blob: BlobScalar
+  blob: BlobScalarInput
   # Validate that the defined seal area produces the expected number of columns, will error if expectation is not met
-  expectedColumns: Optional[IntScalar] = Field(default=None)
+  expectedColumns: Optional[IntScalarInput] = Field(default=None)
   # Validate that the defined seal area produces the expected number of rows, will error if expectation is not met
-  expectedRows: Optional[IntScalar] = Field(default=None)
+  expectedRows: Optional[IntScalarInput] = Field(default=None)
 
 
 # Information about pagination in a connection.
 class PageInfo(BaseModel):
   # When paginating forwards, the cursor to continue.
-  endCursor: Optional[StringScalar] = Field(default=None)
+  endCursor: Optional[StringScalarOutput] = Field(default=None)
   # When paginating forwards, are there more items?
-  hasNextPage: BooleanScalar
+  hasNextPage: BooleanScalarOutput
   # When paginating backwards, are there more items?
-  hasPreviousPage: BooleanScalar
+  hasPreviousPage: BooleanScalarOutput
   # When paginating backwards, the cursor to continue.
-  startCursor: Optional[StringScalar] = Field(default=None)
+  startCursor: Optional[StringScalarOutput] = Field(default=None)
 
 
 class PdfBoundingBoxInput(BaseModel):
-  x1: FloatScalar
-  x2: FloatScalar
-  y1: FloatScalar
-  y2: FloatScalar
+  x1: FloatScalarInput
+  x2: FloatScalarInput
+  y1: FloatScalarInput
+  y2: FloatScalarInput
 
 
 class PdfDocument(BaseModel):
-  blob: Optional[BlobScalar] = Field(default=None)
+  blob: Optional[BlobScalarOutput] = Field(default=None)
   # Same value as stamped on document when using displayDocumentID
-  documentID: StringScalar
+  documentID: StringScalarOutput
   form: Optional[PdfDocumentForm] = Field(default=None)
-  id: IDScalar
-  originalBlob: Optional[BlobScalar] = Field(default=None)
-  reference: Optional[StringScalar] = Field(default=None)
+  id: IDScalarOutput
+  originalBlob: Optional[BlobScalarOutput] = Field(default=None)
+  reference: Optional[StringScalarOutput] = Field(default=None)
   signatoryViewerStatus: Optional[SignatoryDocumentStatus] = Field(default=None)
   signatures: Optional[list[Signature]] = Field(default=None)
-  title: StringScalar
+  title: StringScalarOutput
 
 
 class PdfDocumentForm(BaseModel):
-  enabled: BooleanScalar
+  enabled: BooleanScalarOutput
 
 
 class PdfSealPosition(BaseModel):
-  page: IntScalar
-  x: FloatScalar
-  y: FloatScalar
+  page: IntScalarInput
+  x: FloatScalarInput
+  y: FloatScalarInput
 
 
 class Query(BaseModel):
@@ -641,13 +650,13 @@ class Query(BaseModel):
   signatureOrder: Optional[SignatureOrder] = Field(default=None)
   # Tenants are only accessable from user viewers
   tenant: Optional[Tenant] = Field(default=None)
-  timezones: list[StringScalar]
+  timezones: list[StringScalarOutput]
   viewer: Viewer
 
 
 class RefreshApplicationApiKeyInput(BaseModel):
-  apiKeyId: IDScalar
-  applicationId: IDScalar
+  apiKeyId: IDScalarInput
+  applicationId: IDScalarInput
 
 
 class RefreshApplicationApiKeyOutput(BaseModel):
@@ -656,8 +665,8 @@ class RefreshApplicationApiKeyOutput(BaseModel):
 
 
 class RejectSignatureOrderInput(BaseModel):
-  dummy: BooleanScalar
-  reason: Optional[StringScalar] = Field(default=None)
+  dummy: BooleanScalarInput
+  reason: Optional[StringScalarInput] = Field(default=None)
 
 
 class RejectSignatureOrderOutput(BaseModel):
@@ -665,8 +674,8 @@ class RejectSignatureOrderOutput(BaseModel):
 
 
 class RetrySignatureOrderWebhookInput(BaseModel):
-  retryPayload: StringScalar
-  signatureOrderId: IDScalar
+  retryPayload: StringScalarInput
+  signatureOrderId: IDScalarInput
 
 
 class RetrySignatureOrderWebhookOutput(BaseModel):
@@ -675,7 +684,7 @@ class RetrySignatureOrderWebhookOutput(BaseModel):
 
 class SignActingAsInput(BaseModel):
   evidence: SignInput
-  signatoryId: IDScalar
+  signatoryId: IDScalarInput
 
 
 class SignActingAsOutput(BaseModel):
@@ -686,17 +695,17 @@ class SignActingAsOutput(BaseModel):
 class SignAllOfInput(BaseModel):
   criiptoVerify: Optional[SignCriiptoVerifyInput] = Field(default=None)
   drawable: Optional[SignDrawableInput] = Field(default=None)
-  noop: Optional[BooleanScalar] = Field(default=None)
+  noop: Optional[BooleanScalarInput] = Field(default=None)
   oidc: Optional[SignOidcInput] = Field(default=None)
 
 
 class SignCriiptoVerifyInput(BaseModel):
-  jwt: StringScalar
+  jwt: StringScalarInput
 
 
 class SignDocumentFormFieldInput(BaseModel):
-  field: StringScalar
-  value: StringScalar
+  field: StringScalarInput
+  value: StringScalarInput
 
 
 class SignDocumentFormInput(BaseModel):
@@ -705,12 +714,12 @@ class SignDocumentFormInput(BaseModel):
 
 class SignDocumentInput(BaseModel):
   form: Optional[SignDocumentFormInput] = Field(default=None)
-  id: IDScalar
+  id: IDScalarInput
 
 
 class SignDrawableInput(BaseModel):
-  image: BlobScalar
-  name: Optional[StringScalar] = Field(default=None)
+  image: BlobScalarInput
+  name: Optional[StringScalarInput] = Field(default=None)
 
 
 class SignInput(BaseModel):
@@ -719,13 +728,13 @@ class SignInput(BaseModel):
   documents: Optional[list[SignDocumentInput]] = Field(default=None)
   drawable: Optional[SignDrawableInput] = Field(default=None)
   # EvidenceProvider id
-  id: IDScalar
-  noop: Optional[BooleanScalar] = Field(default=None)
+  id: IDScalarInput
+  noop: Optional[BooleanScalarInput] = Field(default=None)
   oidc: Optional[SignOidcInput] = Field(default=None)
 
 
 class SignOidcInput(BaseModel):
-  jwt: StringScalar
+  jwt: StringScalarInput
 
 
 class SignOutput(BaseModel):
@@ -735,28 +744,28 @@ class SignOutput(BaseModel):
 class Signatory(BaseModel):
   documents: SignatoryDocumentConnection
   # A download link for signatories to download their signed documents. Signatories must verify their identity before downloading. Can be used when signature order is closed with document retention.
-  downloadHref: Optional[StringScalar] = Field(default=None)
+  downloadHref: Optional[StringScalarOutput] = Field(default=None)
   evidenceProviders: list[SignatureEvidenceProvider]
   # A link to the signatures frontend, you can send this link to your users to enable them to sign your documents.
-  href: StringScalar
-  id: IDScalar
-  reference: Optional[StringScalar] = Field(default=None)
-  role: Optional[StringScalar] = Field(default=None)
+  href: StringScalarOutput
+  id: IDScalarOutput
+  reference: Optional[StringScalarOutput] = Field(default=None)
+  role: Optional[StringScalarOutput] = Field(default=None)
   # Signature order for the signatory.
   signatureOrder: SignatureOrder
-  spanId: StringScalar
+  spanId: StringScalarOutput
   # The current status of the signatory.
   status: SignatoryStatus
   # The reason for the signatory status (rejection reason when rejected).
-  statusReason: Optional[StringScalar] = Field(default=None)
+  statusReason: Optional[StringScalarOutput] = Field(default=None)
   # The signature frontend authentication token, only required if you need to build a custom url.
-  token: StringScalar
-  traceId: StringScalar
+  token: StringScalarOutput
+  traceId: StringScalarOutput
   ui: SignatureOrderUI
 
 
 class SignatoryBeaconInput(BaseModel):
-  lastActionAt: DateTimeScalar
+  lastActionAt: DateTimeScalarInput
 
 
 class SignatoryBeaconOutput(BaseModel):
@@ -773,10 +782,10 @@ class SignatoryDocumentEdge(BaseModel):
 
 
 class SignatoryDocumentInput(BaseModel):
-  id: IDScalar
+  id: IDScalarInput
   # Define custom position for PDF seal. Uses PDF coordinate system (bottom-left as 0,0). If defined for one signatory/document, must be defined for all.
   pdfSealPosition: Optional[PdfSealPosition] = Field(default=None)
-  preapproved: Optional[BooleanScalar] = Field(default=None)
+  preapproved: Optional[BooleanScalarInput] = Field(default=None)
 
 
 class SignatoryDocumentStatus(StrEnum):
@@ -793,7 +802,7 @@ class SignatoryEvidenceProviderInput(BaseModel):
   criiptoVerify: Optional[CriiptoVerifyProviderInput] = Field(default=None)
   # Hand drawn signature evidence for signatures.
   drawable: Optional[DrawableEvidenceProviderInput] = Field(default=None)
-  id: IDScalar
+  id: IDScalarInput
   # TEST environment only. Does not manipulate the PDF, use for integration or webhook testing.
   noop: Optional[NoopEvidenceProviderInput] = Field(default=None)
   # Deprecated
@@ -801,9 +810,9 @@ class SignatoryEvidenceProviderInput(BaseModel):
 
 
 class SignatoryEvidenceValidationInput(BaseModel):
-  boolean: Optional[BooleanScalar] = Field(default=None)
-  key: StringScalar
-  value: Optional[StringScalar] = Field(default=None)
+  boolean: Optional[BooleanScalarInput] = Field(default=None)
+  key: StringScalarInput
+  value: Optional[StringScalarInput] = Field(default=None)
 
 
 class SignatoryFrontendEvent(StrEnum):
@@ -821,39 +830,39 @@ class SignatoryStatus(StrEnum):
 
 class SignatoryUIInput(BaseModel):
   # Removes the UI options to reject a document or signature order.
-  disableRejection: Optional[BooleanScalar] = Field(default=None)
+  disableRejection: Optional[BooleanScalarInput] = Field(default=None)
   # The language of texts rendered to the signatory.
   language: Optional[Language] = Field(default=None)
   # Define a logo to be shown in the signatory UI.
   logo: Optional[SignatureOrderUILogoInput] = Field(default=None)
   # Renders a UI layer for PDF annotations, such as links, making them interactive in the UI/browser
-  renderPdfAnnotationLayer: Optional[BooleanScalar] = Field(default=None)
+  renderPdfAnnotationLayer: Optional[BooleanScalarInput] = Field(default=None)
   # The signatory will be redirected to this URL after signing or rejected the signature order.
-  signatoryRedirectUri: Optional[StringScalar] = Field(default=None)
+  signatoryRedirectUri: Optional[StringScalarInput] = Field(default=None)
   # Add stylesheet/css via an absolute HTTPS URL.
-  stylesheet: Optional[StringScalar] = Field(default=None)
+  stylesheet: Optional[StringScalarInput] = Field(default=None)
 
 
 class SignatoryViewer(BaseModel):
-  authenticated: BooleanScalar
+  authenticated: BooleanScalarOutput
   documents: SignatoryDocumentConnection
   download: Optional[SignatoryViewerDownload] = Field(default=None)
   evidenceProviders: list[SignatureEvidenceProvider]
-  id: IDScalar
-  signatoryId: IDScalar
+  id: IDScalarOutput
+  signatoryId: IDScalarOutput
   signatureOrderStatus: SignatureOrderStatus
-  signer: BooleanScalar
+  signer: BooleanScalarOutput
   status: SignatoryStatus
   ui: SignatureOrderUI
 
 
 class SignatoryViewerDownload(BaseModel):
   documents: Optional[SignatoryDocumentConnection] = Field(default=None)
-  expired: BooleanScalar
+  expired: BooleanScalarOutput
   verificationEvidenceProvider: Optional[SignatureEvidenceProvider] = Field(
     default=None
   )
-  verificationRequired: BooleanScalar
+  verificationRequired: BooleanScalarOutput
 
 
 # Represents a signature on a document.
@@ -865,19 +874,19 @@ class SignatureAppearanceInput(BaseModel):
   footer: Optional[list[SignatureAppearanceTemplateInput]] = Field(default=None)
   headerLeft: Optional[list[SignatureAppearanceTemplateInput]] = Field(default=None)
   # Render evidence claim as identifier in the signature appearance inside the document. You can supply multiple keys and they will be tried in order. If no key is found a GUID will be rendered.
-  identifierFromEvidence: list[StringScalar]
+  identifierFromEvidence: list[StringScalarInput]
 
 
 class SignatureAppearanceTemplateInput(BaseModel):
   replacements: Optional[list[SignatureAppearanceTemplateReplacementInput]] = Field(
     default=None
   )
-  template: StringScalar
+  template: StringScalarInput
 
 
 class SignatureAppearanceTemplateReplacementInput(BaseModel):
-  fromEvidence: list[StringScalar]
-  placeholder: StringScalar
+  fromEvidence: list[StringScalarInput]
+  placeholder: StringScalarInput
 
 
 type SignatureEvidenceProvider = (
@@ -891,22 +900,22 @@ type SignatureEvidenceProvider = (
 
 class SignatureOrder(BaseModel):
   application: Optional[Application] = Field(default=None)
-  closedAt: Optional[DateTimeScalar] = Field(default=None)
-  createdAt: DateTimeScalar
+  closedAt: Optional[DateTimeScalarOutput] = Field(default=None)
+  createdAt: DateTimeScalarOutput
   documents: list[Document]
   evidenceProviders: list[SignatureEvidenceProvider]
-  expiresAt: DateTimeScalar
-  id: IDScalar
+  expiresAt: DateTimeScalarOutput
+  id: IDScalarOutput
   # Number of max signatories for the signature order
-  maxSignatories: IntScalar
+  maxSignatories: IntScalarOutput
   # List of signatories for the signature order.
   signatories: list[Signatory]
   status: SignatureOrderStatus
   # Tenants are only accessable from user viewers
   tenant: Optional[Tenant] = Field(default=None)
-  timezone: StringScalar
-  title: Optional[StringScalar] = Field(default=None)
-  traceId: StringScalar
+  timezone: StringScalarOutput
+  title: Optional[StringScalarOutput] = Field(default=None)
+  traceId: StringScalarOutput
   ui: SignatureOrderUI
   webhook: Optional[SignatureOrderWebhook] = Field(default=None)
 
@@ -918,13 +927,13 @@ class SignatureOrderConnection(BaseModel):
   # Information to aid in pagination.
   pageInfo: PageInfo
   # A count of the total number of objects in this connection, ignoring pagination. This allows a client to fetch the first five objects by passing \"5\" as the argument to `first`, then fetch the total count so it could display \"5 of 83\", for example. In cases where we employ infinite scrolling or don't have an exact count of entries, this field will return `null`.
-  totalCount: Optional[IntScalar] = Field(default=None)
+  totalCount: Optional[IntScalarOutput] = Field(default=None)
 
 
 # An edge in a connection from an object to another object of type SignatureOrder
 class SignatureOrderEdge(BaseModel):
   # A cursor for use in pagination
-  cursor: StringScalar
+  cursor: StringScalarOutput
   # The item at the end of the edge. Must NOT be an enumerable collection.
   node: SignatureOrder
 
@@ -937,29 +946,29 @@ class SignatureOrderStatus(StrEnum):
 
 
 class SignatureOrderUI(BaseModel):
-  disableRejection: BooleanScalar
+  disableRejection: BooleanScalarOutput
   language: Language
   logo: Optional[SignatureOrderUILogo] = Field(default=None)
-  renderPdfAnnotationLayer: BooleanScalar
-  signatoryRedirectUri: Optional[StringScalar] = Field(default=None)
-  stylesheet: Optional[StringScalar] = Field(default=None)
+  renderPdfAnnotationLayer: BooleanScalarOutput
+  signatoryRedirectUri: Optional[StringScalarOutput] = Field(default=None)
+  stylesheet: Optional[StringScalarOutput] = Field(default=None)
 
 
 class SignatureOrderUILogo(BaseModel):
-  href: Optional[StringScalar] = Field(default=None)
-  src: StringScalar
+  href: Optional[StringScalarOutput] = Field(default=None)
+  src: StringScalarOutput
 
 
 class SignatureOrderUILogoInput(BaseModel):
   # Turns your logo into a link with the defined href.
-  href: Optional[StringScalar] = Field(default=None)
+  href: Optional[StringScalarInput] = Field(default=None)
   # The image source for the logo. Must be an absolute HTTPS URL or a valid data: url
-  src: StringScalar
+  src: StringScalarInput
 
 
 class SignatureOrderWebhook(BaseModel):
   logs: list[WebhookInvocation]
-  url: StringScalar
+  url: StringScalarOutput
 
 
 # Must define a evidence provider subsection.
@@ -985,9 +994,9 @@ type SingleSignatureEvidenceProvider = (
 
 
 class StartCriiptoVerifyEvidenceProviderInput(BaseModel):
-  acrValue: StringScalar
-  id: IDScalar
-  redirectUri: StringScalar
+  acrValue: StringScalarInput
+  id: IDScalarInput
+  redirectUri: StringScalarInput
   stage: EvidenceValidationStage
 
 
@@ -996,7 +1005,7 @@ type StartCriiptoVerifyEvidenceProviderOutput = CriiptoVerifyEvidenceProviderRed
 
 class Tenant(BaseModel):
   applications: list[Application]
-  id: IDScalar
+  id: IDScalarOutput
   webhookLogs: list[WebhookInvocation]
 
 
@@ -1009,16 +1018,16 @@ class TrackSignatoryOutput(BaseModel):
 
 
 class UnvalidatedSignatoryViewer(BaseModel):
-  authenticated: BooleanScalar
+  authenticated: BooleanScalarOutput
   download: Optional[SignatoryViewerDownload] = Field(default=None)
   evidenceProviders: list[SignatureEvidenceProvider]
-  id: IDScalar
-  signatoryId: IDScalar
+  id: IDScalarOutput
+  signatoryId: IDScalarOutput
   ui: SignatureOrderUI
 
 
 class UpdateSignatoryDocumentStatusInput(BaseModel):
-  documentId: IDScalar
+  documentId: IDScalarInput
   status: SignatoryDocumentStatus
 
 
@@ -1028,29 +1037,29 @@ class UpdateSignatoryDocumentStatusOutput(BaseModel):
 
 
 class UserViewer(BaseModel):
-  authenticated: BooleanScalar
-  id: IDScalar
+  authenticated: BooleanScalarOutput
+  id: IDScalarOutput
   tenants: list[Tenant]
 
 
 class ValidateDocumentInput(BaseModel):
-  pdf: Optional[BlobScalar] = Field(default=None)
-  xml: Optional[BlobScalar] = Field(default=None)
+  pdf: Optional[BlobScalarInput] = Field(default=None)
+  xml: Optional[BlobScalarInput] = Field(default=None)
 
 
 class ValidateDocumentOutput(BaseModel):
-  errors: Optional[list[StringScalar]] = Field(default=None)
+  errors: Optional[list[StringScalarOutput]] = Field(default=None)
   # Whether or not the errors are fixable using 'fixDocumentFormattingErrors'
-  fixable: Optional[BooleanScalar] = Field(default=None)
+  fixable: Optional[BooleanScalarOutput] = Field(default=None)
   # `true` if the document contains signatures. If value is `null`, we were unable to determine whether the document has been previously signed.
-  previouslySigned: Optional[BooleanScalar] = Field(default=None)
-  valid: BooleanScalar
+  previouslySigned: Optional[BooleanScalarOutput] = Field(default=None)
+  valid: BooleanScalarOutput
 
 
 class VerifyApplication(BaseModel):
-  domain: StringScalar
+  domain: StringScalarOutput
   environment: VerifyApplicationEnvironment
-  realm: StringScalar
+  realm: StringScalarOutput
 
 
 class VerifyApplicationEnvironment(StrEnum):
@@ -1059,9 +1068,9 @@ class VerifyApplicationEnvironment(StrEnum):
 
 
 class VerifyApplicationQueryInput(BaseModel):
-  domain: StringScalar
-  realm: StringScalar
-  tenantId: IDScalar
+  domain: StringScalarInput
+  realm: StringScalarInput
+  tenantId: IDScalarInput
 
 
 type Viewer = (
@@ -1075,29 +1084,29 @@ type Viewer = (
 
 
 class WebhookExceptionInvocation(BaseModel):
-  correlationId: StringScalar
+  correlationId: StringScalarOutput
   event: Optional[WebhookInvocationEvent] = Field(default=None)
-  exception: StringScalar
-  requestBody: StringScalar
-  responseBody: Optional[StringScalar] = Field(default=None)
-  retryPayload: StringScalar
-  retryingAt: Optional[StringScalar] = Field(default=None)
-  signatureOrderId: Optional[StringScalar] = Field(default=None)
-  timestamp: StringScalar
-  url: StringScalar
+  exception: StringScalarOutput
+  requestBody: StringScalarOutput
+  responseBody: Optional[StringScalarOutput] = Field(default=None)
+  retryPayload: StringScalarOutput
+  retryingAt: Optional[StringScalarOutput] = Field(default=None)
+  signatureOrderId: Optional[StringScalarOutput] = Field(default=None)
+  timestamp: StringScalarOutput
+  url: StringScalarOutput
 
 
 class WebhookHttpErrorInvocation(BaseModel):
-  correlationId: StringScalar
+  correlationId: StringScalarOutput
   event: Optional[WebhookInvocationEvent] = Field(default=None)
-  requestBody: StringScalar
-  responseBody: Optional[StringScalar] = Field(default=None)
-  responseStatusCode: IntScalar
-  retryPayload: StringScalar
-  retryingAt: Optional[StringScalar] = Field(default=None)
-  signatureOrderId: Optional[StringScalar] = Field(default=None)
-  timestamp: StringScalar
-  url: StringScalar
+  requestBody: StringScalarOutput
+  responseBody: Optional[StringScalarOutput] = Field(default=None)
+  responseStatusCode: IntScalarOutput
+  retryPayload: StringScalarOutput
+  retryingAt: Optional[StringScalarOutput] = Field(default=None)
+  signatureOrderId: Optional[StringScalarOutput] = Field(default=None)
+  timestamp: StringScalarOutput
+  url: StringScalarOutput
 
 
 type WebhookInvocation = (
@@ -1119,45 +1128,45 @@ class WebhookInvocationEvent(StrEnum):
 
 
 class WebhookSuccessfulInvocation(BaseModel):
-  correlationId: StringScalar
+  correlationId: StringScalarOutput
   event: Optional[WebhookInvocationEvent] = Field(default=None)
-  requestBody: StringScalar
-  responseBody: Optional[StringScalar] = Field(default=None)
-  responseStatusCode: IntScalar
-  signatureOrderId: Optional[StringScalar] = Field(default=None)
-  timestamp: StringScalar
-  url: StringScalar
+  requestBody: StringScalarOutput
+  responseBody: Optional[StringScalarOutput] = Field(default=None)
+  responseStatusCode: IntScalarOutput
+  signatureOrderId: Optional[StringScalarOutput] = Field(default=None)
+  timestamp: StringScalarOutput
+  url: StringScalarOutput
 
 
 class WebhookTimeoutInvocation(BaseModel):
-  correlationId: StringScalar
+  correlationId: StringScalarOutput
   event: Optional[WebhookInvocationEvent] = Field(default=None)
-  requestBody: StringScalar
-  responseBody: Optional[StringScalar] = Field(default=None)
-  responseTimeout: IntScalar
-  retryPayload: StringScalar
-  retryingAt: Optional[StringScalar] = Field(default=None)
-  signatureOrderId: Optional[StringScalar] = Field(default=None)
-  timestamp: StringScalar
-  url: StringScalar
+  requestBody: StringScalarOutput
+  responseBody: Optional[StringScalarOutput] = Field(default=None)
+  responseTimeout: IntScalarOutput
+  retryPayload: StringScalarOutput
+  retryingAt: Optional[StringScalarOutput] = Field(default=None)
+  signatureOrderId: Optional[StringScalarOutput] = Field(default=None)
+  timestamp: StringScalarOutput
+  url: StringScalarOutput
 
 
 class XadesDocumentInput(BaseModel):
-  blob: BlobScalar
+  blob: BlobScalarInput
   # Will not be displayed to signatories, can be used as a reference to your own system.
-  reference: Optional[StringScalar] = Field(default=None)
+  reference: Optional[StringScalarInput] = Field(default=None)
   storageMode: DocumentStorageMode
-  title: StringScalar
+  title: StringScalarInput
 
 
 class XmlDocument(BaseModel):
-  blob: Optional[BlobScalar] = Field(default=None)
-  id: IDScalar
-  originalBlob: Optional[BlobScalar] = Field(default=None)
-  reference: Optional[StringScalar] = Field(default=None)
+  blob: Optional[BlobScalarOutput] = Field(default=None)
+  id: IDScalarOutput
+  originalBlob: Optional[BlobScalarOutput] = Field(default=None)
+  reference: Optional[StringScalarOutput] = Field(default=None)
   signatoryViewerStatus: Optional[SignatoryDocumentStatus] = Field(default=None)
   signatures: Optional[list[Signature]] = Field(default=None)
-  title: StringScalar
+  title: StringScalarOutput
 
 
 AddSignatoriesInput.model_rebuild()

--- a/packages/python/src/criipto_signatures/models.py
+++ b/packages/python/src/criipto_signatures/models.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from .utils import CustomBlobInput
 from enum import StrEnum
 from typing import Optional
 from pydantic import BaseModel, Field
@@ -13,7 +14,7 @@ type FloatScalarInput = float
 type FloatScalarOutput = float
 type BooleanScalarInput = bool
 type BooleanScalarOutput = bool
-type BlobScalarInput = str
+type BlobScalarInput = CustomBlobInput
 type BlobScalarOutput = str
 type DateScalarInput = str
 type DateScalarOutput = str

--- a/packages/python/src/criipto_signatures/models.py
+++ b/packages/python/src/criipto_signatures/models.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from enum import StrEnum
 from typing import Optional
 from pydantic import BaseModel, Field
@@ -14,71 +15,71 @@ type URIScalar = str
 
 
 class AddSignatoriesInput(BaseModel):
-  signatories: "list[CreateSignatureOrderSignatoryInput]"
-  signatureOrderId: "IDScalar"
+  signatories: list[CreateSignatureOrderSignatoryInput]
+  signatureOrderId: IDScalar
 
 
 class AddSignatoriesOutput(BaseModel):
-  signatories: "list[Signatory]"
-  signatureOrder: "SignatureOrder"
+  signatories: list[Signatory]
+  signatureOrder: SignatureOrder
 
 
 class AddSignatoryInput(BaseModel):
   # Define a subset of documents for the signatory. Must be a non-empty list. Leave null for all documents.
-  documents: "Optional[list[SignatoryDocumentInput]]" = Field(default=None)
+  documents: Optional[list[SignatoryDocumentInput]] = Field(default=None)
   # Selectively enable evidence providers for this signatory.
-  evidenceProviders: "Optional[list[SignatoryEvidenceProviderInput]]" = Field(
+  evidenceProviders: Optional[list[SignatoryEvidenceProviderInput]] = Field(
     default=None
   )
-  evidenceValidation: "Optional[list[SignatoryEvidenceValidationInput]]" = Field(
+  evidenceValidation: Optional[list[SignatoryEvidenceValidationInput]] = Field(
     default=None
   )
   # Will not be displayed to signatories, can be used as a reference to your own system.
-  reference: "Optional[StringScalar]" = Field(default=None)
+  reference: Optional[StringScalar] = Field(default=None)
   # Define a role for the signatory, i.e. 'Chairman'. Will be visible in the document output.
-  role: "Optional[StringScalar]" = Field(default=None)
-  signatureAppearance: "Optional[SignatureAppearanceInput]" = Field(default=None)
-  signatureOrderId: "IDScalar"
+  role: Optional[StringScalar] = Field(default=None)
+  signatureAppearance: Optional[SignatureAppearanceInput] = Field(default=None)
+  signatureOrderId: IDScalar
   # Override UI settings for signatory, defaults to UI settings for signature order
-  ui: "Optional[SignatoryUIInput]" = Field(default=None)
+  ui: Optional[SignatoryUIInput] = Field(default=None)
 
 
 class AddSignatoryOutput(BaseModel):
-  signatory: "Signatory"
-  signatureOrder: "SignatureOrder"
+  signatory: Signatory
+  signatureOrder: SignatureOrder
 
 
 class AllOfEvidenceProviderInput(BaseModel):
-  providers: "list[SingleEvidenceProviderInput]"
+  providers: list[SingleEvidenceProviderInput]
 
 
 class AllOfSignatureEvidenceProvider(BaseModel):
-  id: "IDScalar"
-  providers: "list[SingleSignatureEvidenceProvider]"
+  id: IDScalar
+  providers: list[SingleSignatureEvidenceProvider]
 
 
 class AnonymousViewer(BaseModel):
-  authenticated: "BooleanScalar"
-  id: "IDScalar"
+  authenticated: BooleanScalar
+  id: IDScalar
 
 
 class Application(BaseModel):
-  apiKeys: "list[ApplicationApiKey]"
-  id: "IDScalar"
-  name: "StringScalar"
-  signatureOrders: "SignatureOrderConnection"
+  apiKeys: list[ApplicationApiKey]
+  id: IDScalar
+  name: StringScalar
+  signatureOrders: SignatureOrderConnection
   # Tenants are only accessable from user viewers
-  tenant: "Optional[Tenant]" = Field(default=None)
-  verifyApplication: "VerifyApplication"
-  webhookLogs: "list[WebhookInvocation]"
+  tenant: Optional[Tenant] = Field(default=None)
+  verifyApplication: VerifyApplication
+  webhookLogs: list[WebhookInvocation]
 
 
 class ApplicationApiKey(BaseModel):
-  clientId: "StringScalar"
-  clientSecret: "Optional[StringScalar]" = Field(default=None)
-  id: "IDScalar"
-  mode: "ApplicationApiKeyMode"
-  note: "Optional[StringScalar]" = Field(default=None)
+  clientId: StringScalar
+  clientSecret: Optional[StringScalar] = Field(default=None)
+  id: IDScalar
+  mode: ApplicationApiKeyMode
+  note: Optional[StringScalar] = Field(default=None)
 
 
 class ApplicationApiKeyMode(StrEnum):
@@ -87,280 +88,278 @@ class ApplicationApiKeyMode(StrEnum):
 
 
 class BatchSignatory(BaseModel):
-  href: "StringScalar"
-  id: "IDScalar"
-  items: "list[BatchSignatoryItem]"
+  href: StringScalar
+  id: IDScalar
+  items: list[BatchSignatoryItem]
   # The authentication token required for performing batch operations.
-  token: "StringScalar"
-  traceId: "StringScalar"
-  ui: "SignatureOrderUI"
+  token: StringScalar
+  traceId: StringScalar
+  ui: SignatureOrderUI
 
 
 class BatchSignatoryItem(BaseModel):
-  signatory: "Signatory"
-  signatureOrder: "SignatureOrder"
+  signatory: Signatory
+  signatureOrder: SignatureOrder
 
 
 class BatchSignatoryItemInput(BaseModel):
-  signatoryId: "StringScalar"
-  signatureOrderId: "StringScalar"
+  signatoryId: StringScalar
+  signatureOrderId: StringScalar
 
 
 class BatchSignatoryViewer(BaseModel):
-  authenticated: "BooleanScalar"
-  batchSignatoryId: "IDScalar"
-  documents: "SignatoryDocumentConnection"
-  evidenceProviders: "list[SignatureEvidenceProvider]"
-  id: "IDScalar"
-  signer: "BooleanScalar"
-  status: "SignatoryStatus"
-  ui: "SignatureOrderUI"
+  authenticated: BooleanScalar
+  batchSignatoryId: IDScalar
+  documents: SignatoryDocumentConnection
+  evidenceProviders: list[SignatureEvidenceProvider]
+  id: IDScalar
+  signer: BooleanScalar
+  status: SignatoryStatus
+  ui: SignatureOrderUI
 
 
 class CancelSignatureOrderInput(BaseModel):
-  signatureOrderId: "IDScalar"
+  signatureOrderId: IDScalar
 
 
 class CancelSignatureOrderOutput(BaseModel):
-  signatureOrder: "SignatureOrder"
+  signatureOrder: SignatureOrder
 
 
 class ChangeSignatoryInput(BaseModel):
   # Define a subset of documents for the signatory. Must be a non-empty list. Leave null for all documents.
-  documents: "Optional[list[SignatoryDocumentInput]]" = Field(default=None)
+  documents: Optional[list[SignatoryDocumentInput]] = Field(default=None)
   # Selectively enable evidence providers for this signatory.
-  evidenceProviders: "Optional[list[SignatoryEvidenceProviderInput]]" = Field(
+  evidenceProviders: Optional[list[SignatoryEvidenceProviderInput]] = Field(
     default=None
   )
-  evidenceValidation: "Optional[list[SignatoryEvidenceValidationInput]]" = Field(
+  evidenceValidation: Optional[list[SignatoryEvidenceValidationInput]] = Field(
     default=None
   )
   # Will not be displayed to signatories, can be used as a reference to your own system.
-  reference: "Optional[StringScalar]" = Field(default=None)
+  reference: Optional[StringScalar] = Field(default=None)
   # Define a role for the signatory, i.e. 'Chairman'. Will be visible in the document output.
-  role: "Optional[StringScalar]" = Field(default=None)
-  signatoryId: "IDScalar"
-  signatureAppearance: "Optional[SignatureAppearanceInput]" = Field(default=None)
+  role: Optional[StringScalar] = Field(default=None)
+  signatoryId: IDScalar
+  signatureAppearance: Optional[SignatureAppearanceInput] = Field(default=None)
   # Override UI settings for signatory, defaults to UI settings for signature order
-  ui: "Optional[SignatoryUIInput]" = Field(default=None)
+  ui: Optional[SignatoryUIInput] = Field(default=None)
 
 
 class ChangeSignatoryOutput(BaseModel):
-  signatory: "Signatory"
-  signatureOrder: "SignatureOrder"
+  signatory: Signatory
+  signatureOrder: SignatureOrder
 
 
 class ChangeSignatureOrderInput(BaseModel):
   # Max allowed signatories (as it influences pages needed for seals). Cannot be changed after first signer.
-  maxSignatories: "Optional[IntScalar]" = Field(default=None)
-  signatureOrderId: "IDScalar"
+  maxSignatories: Optional[IntScalar] = Field(default=None)
+  signatureOrderId: IDScalar
   # Signature order webhook settings
-  webhook: "Optional[CreateSignatureOrderWebhookInput]" = Field(default=None)
+  webhook: Optional[CreateSignatureOrderWebhookInput] = Field(default=None)
 
 
 class ChangeSignatureOrderOutput(BaseModel):
-  signatureOrder: "SignatureOrder"
+  signatureOrder: SignatureOrder
 
 
 class CleanupSignatureOrderInput(BaseModel):
-  signatureOrderId: "IDScalar"
+  signatureOrderId: IDScalar
 
 
 class CleanupSignatureOrderOutput(BaseModel):
-  signatureOrder: "SignatureOrder"
+  signatureOrder: SignatureOrder
 
 
 class CloseSignatureOrderInput(BaseModel):
   # Retains documents on Criipto servers after closing a signature order. You MUST manually call the cleanupSignatureOrder mutation when you are sure you have downloaded the blobs. Maximum value is 7 days.
-  retainDocumentsForDays: "Optional[IntScalar]" = Field(default=None)
-  signatureOrderId: "IDScalar"
+  retainDocumentsForDays: Optional[IntScalar] = Field(default=None)
+  signatureOrderId: IDScalar
 
 
 class CloseSignatureOrderOutput(BaseModel):
-  signatureOrder: "SignatureOrder"
+  signatureOrder: SignatureOrder
 
 
 class CompleteCriiptoVerifyEvidenceProviderInput(BaseModel):
-  code: "StringScalar"
-  state: "StringScalar"
+  code: StringScalar
+  state: StringScalar
 
 
 class CompleteCriiptoVerifyEvidenceProviderOutput(BaseModel):
-  jwt: "StringScalar"
+  jwt: StringScalar
 
 
 class CompositeSignature(BaseModel):
-  signatory: "Optional[Signatory]" = Field(default=None)
-  signatures: "list[SingleSignature]"
+  signatory: Optional[Signatory] = Field(default=None)
+  signatures: list[SingleSignature]
 
 
 class CreateApplicationApiKeyInput(BaseModel):
-  applicationId: "IDScalar"
-  mode: "Optional[ApplicationApiKeyMode]" = Field(default=None)
-  note: "Optional[StringScalar]" = Field(default=None)
+  applicationId: IDScalar
+  mode: Optional[ApplicationApiKeyMode] = Field(default=None)
+  note: Optional[StringScalar] = Field(default=None)
 
 
 class CreateApplicationApiKeyOutput(BaseModel):
-  apiKey: "ApplicationApiKey"
-  application: "Application"
+  apiKey: ApplicationApiKey
+  application: Application
 
 
 class CreateApplicationInput(BaseModel):
-  name: "StringScalar"
-  tenantId: "IDScalar"
-  verifyApplicationDomain: "StringScalar"
-  verifyApplicationEnvironment: "VerifyApplicationEnvironment"
-  verifyApplicationRealm: "StringScalar"
+  name: StringScalar
+  tenantId: IDScalar
+  verifyApplicationDomain: StringScalar
+  verifyApplicationEnvironment: VerifyApplicationEnvironment
+  verifyApplicationRealm: StringScalar
 
 
 class CreateApplicationOutput(BaseModel):
-  apiKey: "ApplicationApiKey"
-  application: "Application"
-  tenant: "Tenant"
+  apiKey: ApplicationApiKey
+  application: Application
+  tenant: Tenant
 
 
 class CreateBatchSignatoryInput(BaseModel):
-  items: "list[BatchSignatoryItemInput]"
+  items: list[BatchSignatoryItemInput]
   # UI settings for batch signatory, will use defaults otherwise (will not use UI settings from sub signatories)
-  ui: "Optional[SignatoryUIInput]" = Field(default=None)
+  ui: Optional[SignatoryUIInput] = Field(default=None)
 
 
 class CreateBatchSignatoryOutput(BaseModel):
-  batchSignatory: "BatchSignatory"
+  batchSignatory: BatchSignatory
 
 
 class CreateSignatureOrderInput(BaseModel):
   # By default signatories will be prompted to sign with a Criipto Verify based e-ID, this setting disables it.
-  disableVerifyEvidenceProvider: "Optional[BooleanScalar]" = Field(default=None)
-  documents: "list[DocumentInput]"
+  disableVerifyEvidenceProvider: Optional[BooleanScalar] = Field(default=None)
+  documents: list[DocumentInput]
   # Define evidence providers for signature order if not using built-in Criipto Verify for e-IDs
-  evidenceProviders: "Optional[list[EvidenceProviderInput]]" = Field(default=None)
+  evidenceProviders: Optional[list[EvidenceProviderInput]] = Field(default=None)
   # Defines when a signatory must be validated, default is when signing, but can be expanded to also be required when viewing documents.
-  evidenceValidationStages: "Optional[list[EvidenceValidationStage]]" = Field(
+  evidenceValidationStages: Optional[list[EvidenceValidationStage]] = Field(
     default=None
   )
   # When this signature order will auto-close/expire at exactly in one of the following ISO-8601 formats: yyyy-MM-ddTHH:mm:ssZ, yyyy-MM-ddTHH:mm:ss.ffZ, yyyy-MM-ddTHH:mm:ss.fffZ, yyyy-MM-ddTHH:mm:ssK, yyyy-MM-ddTHH:mm:ss.ffK, yyyy-MM-ddTHH:mm:ss.fffK. Cannot be provided with `expiresInDays`.
-  expiresAt: "Optional[StringScalar]" = Field(default=None)
+  expiresAt: Optional[StringScalar] = Field(default=None)
   # When this signature order will auto-close/expire. Default 90 days. Cannot be provided with `expiresAt`
-  expiresInDays: "Optional[IntScalar]" = Field(default=None)
+  expiresInDays: Optional[IntScalar] = Field(default=None)
   # Attempt to automatically fix document formatting errors if possible. Default 'true'.
-  fixDocumentFormattingErrors: "Optional[BooleanScalar]" = Field(default=None)
+  fixDocumentFormattingErrors: Optional[BooleanScalar] = Field(default=None)
   # Max allowed signatories (as it influences pages needed for seals). Default 14.
-  maxSignatories: "Optional[IntScalar]" = Field(default=None)
-  signatories: "Optional[list[CreateSignatureOrderSignatoryInput]]" = Field(
-    default=None
-  )
+  maxSignatories: Optional[IntScalar] = Field(default=None)
+  signatories: Optional[list[CreateSignatureOrderSignatoryInput]] = Field(default=None)
   # Configure appearance of signatures inside documents
-  signatureAppearance: "Optional[SignatureAppearanceInput]" = Field(default=None)
+  signatureAppearance: Optional[SignatureAppearanceInput] = Field(default=None)
   # Timezone to render signature seals in, default UTC.
-  timezone: "Optional[StringScalar]" = Field(default=None)
-  title: "Optional[StringScalar]" = Field(default=None)
+  timezone: Optional[StringScalar] = Field(default=None)
+  title: Optional[StringScalar] = Field(default=None)
   # Various settings for how the UI is presented to the signatory.
-  ui: "Optional[CreateSignatureOrderUIInput]" = Field(default=None)
+  ui: Optional[CreateSignatureOrderUIInput] = Field(default=None)
   # Signature order webhook settings
-  webhook: "Optional[CreateSignatureOrderWebhookInput]" = Field(default=None)
+  webhook: Optional[CreateSignatureOrderWebhookInput] = Field(default=None)
 
 
 class CreateSignatureOrderOutput(BaseModel):
-  application: "Application"
-  signatureOrder: "SignatureOrder"
+  application: Application
+  signatureOrder: SignatureOrder
 
 
 class CreateSignatureOrderSignatoryInput(BaseModel):
   # Define a subset of documents for the signatory. Must be a non-empty list. Leave null for all documents.
-  documents: "Optional[list[SignatoryDocumentInput]]" = Field(default=None)
+  documents: Optional[list[SignatoryDocumentInput]] = Field(default=None)
   # Selectively enable evidence providers for this signatory.
-  evidenceProviders: "Optional[list[SignatoryEvidenceProviderInput]]" = Field(
+  evidenceProviders: Optional[list[SignatoryEvidenceProviderInput]] = Field(
     default=None
   )
-  evidenceValidation: "Optional[list[SignatoryEvidenceValidationInput]]" = Field(
+  evidenceValidation: Optional[list[SignatoryEvidenceValidationInput]] = Field(
     default=None
   )
   # Will not be displayed to signatories, can be used as a reference to your own system.
-  reference: "Optional[StringScalar]" = Field(default=None)
+  reference: Optional[StringScalar] = Field(default=None)
   # Define a role for the signatory, i.e. 'Chairman'. Will be visible in the document output.
-  role: "Optional[StringScalar]" = Field(default=None)
-  signatureAppearance: "Optional[SignatureAppearanceInput]" = Field(default=None)
+  role: Optional[StringScalar] = Field(default=None)
+  signatureAppearance: Optional[SignatureAppearanceInput] = Field(default=None)
   # Override UI settings for signatory, defaults to UI settings for signature order
-  ui: "Optional[SignatoryUIInput]" = Field(default=None)
+  ui: Optional[SignatoryUIInput] = Field(default=None)
 
 
 class CreateSignatureOrderUIInput(BaseModel):
   # Removes the UI options to reject a document or signature order.
-  disableRejection: "Optional[BooleanScalar]" = Field(default=None)
+  disableRejection: Optional[BooleanScalar] = Field(default=None)
   # The language of texts rendered to the signatory.
-  language: "Optional[Language]" = Field(default=None)
+  language: Optional[Language] = Field(default=None)
   # Define a logo to be shown in the signatory UI.
-  logo: "Optional[SignatureOrderUILogoInput]" = Field(default=None)
+  logo: Optional[SignatureOrderUILogoInput] = Field(default=None)
   # Renders a UI layer for PDF annotations, such as links, making them interactive in the UI/browser
-  renderPdfAnnotationLayer: "Optional[BooleanScalar]" = Field(default=None)
+  renderPdfAnnotationLayer: Optional[BooleanScalar] = Field(default=None)
   # The signatory will be redirected to this URL after signing or rejected the signature order.
-  signatoryRedirectUri: "Optional[StringScalar]" = Field(default=None)
+  signatoryRedirectUri: Optional[StringScalar] = Field(default=None)
   # Add stylesheet/css via an absolute HTTPS URL.
-  stylesheet: "Optional[StringScalar]" = Field(default=None)
+  stylesheet: Optional[StringScalar] = Field(default=None)
 
 
 class CreateSignatureOrderWebhookInput(BaseModel):
   # If defined, webhook invocations will have a X-Criipto-Signature header containing a HMAC-SHA256 signature (as a base64 string) of the webhook request body (utf-8). The secret should be between 256 and 512 bits.
-  secret: "Optional[BlobScalar]" = Field(default=None)
+  secret: Optional[BlobScalar] = Field(default=None)
   # Webhook url. POST requests will be executed towards this URL on certain signatory events.
-  url: "StringScalar"
+  url: StringScalar
   # Validates webhook connectivity by triggering a WEBHOOK_VALIDATION event, your webhook must respond within 5 seconds with 200/OK or the signature order creation will fail.
-  validateConnectivity: "Optional[BooleanScalar]" = Field(default=None)
+  validateConnectivity: Optional[BooleanScalar] = Field(default=None)
 
 
 class CriiptoVerifyEvidenceProviderRedirect(BaseModel):
-  redirectUri: "StringScalar"
-  state: "StringScalar"
+  redirectUri: StringScalar
+  state: StringScalar
 
 
 # Criipto Verify based evidence for signatures.
 class CriiptoVerifyProviderInput(BaseModel):
-  acrValues: "Optional[list[StringScalar]]" = Field(default=None)
-  alwaysRedirect: "Optional[BooleanScalar]" = Field(default=None)
+  acrValues: Optional[list[StringScalar]] = Field(default=None)
+  alwaysRedirect: Optional[BooleanScalar] = Field(default=None)
   # Define additional valid audiences (besides the main client_id) for the Criipto Verify domain/issuer underlying the application.
-  audiences: "Optional[list[StringScalar]]" = Field(default=None)
+  audiences: Optional[list[StringScalar]] = Field(default=None)
   # Set a custom login_hint for the underlying authentication request.
-  loginHint: "Optional[StringScalar]" = Field(default=None)
+  loginHint: Optional[StringScalar] = Field(default=None)
   # Messages displayed when performing authentication (only supported by DKMitID currently).
-  message: "Optional[StringScalar]" = Field(default=None)
+  message: Optional[StringScalar] = Field(default=None)
   # Set a custom scope for the underlying authentication request.
-  scope: "Optional[StringScalar]" = Field(default=None)
+  scope: Optional[StringScalar] = Field(default=None)
   # Enforces that signatories sign by unique evidence by comparing the values of previous evidence on the key you define. For Criipto Verify you likely want to use `sub` which is a unique pseudonym value present in all e-ID tokens issued.
-  uniqueEvidenceKey: "Optional[StringScalar]" = Field(default=None)
+  uniqueEvidenceKey: Optional[StringScalar] = Field(default=None)
 
 
 class CriiptoVerifySignatureEvidenceProvider(BaseModel):
-  acrValues: "list[StringScalar]"
-  alwaysRedirect: "BooleanScalar"
-  audience: "StringScalar"
-  audiences: "list[StringScalar]"
-  clientID: "StringScalar"
-  domain: "StringScalar"
-  environment: "Optional[VerifyApplicationEnvironment]" = Field(default=None)
-  id: "IDScalar"
-  loginHint: "Optional[StringScalar]" = Field(default=None)
-  message: "Optional[StringScalar]" = Field(default=None)
-  name: "StringScalar"
-  scope: "Optional[StringScalar]" = Field(default=None)
+  acrValues: list[StringScalar]
+  alwaysRedirect: BooleanScalar
+  audience: StringScalar
+  audiences: list[StringScalar]
+  clientID: StringScalar
+  domain: StringScalar
+  environment: Optional[VerifyApplicationEnvironment] = Field(default=None)
+  id: IDScalar
+  loginHint: Optional[StringScalar] = Field(default=None)
+  message: Optional[StringScalar] = Field(default=None)
+  name: StringScalar
+  scope: Optional[StringScalar] = Field(default=None)
 
 
 class DeleteApplicationApiKeyInput(BaseModel):
-  apiKeyId: "IDScalar"
-  applicationId: "IDScalar"
+  apiKeyId: IDScalar
+  applicationId: IDScalar
 
 
 class DeleteApplicationApiKeyOutput(BaseModel):
-  application: "Application"
+  application: Application
 
 
 class DeleteSignatoryInput(BaseModel):
-  signatoryId: "IDScalar"
-  signatureOrderId: "IDScalar"
+  signatoryId: IDScalar
+  signatureOrderId: IDScalar
 
 
 class DeleteSignatoryOutput(BaseModel):
-  signatureOrder: "SignatureOrder"
+  signatureOrder: SignatureOrder
 
 
 type Document = PdfDocument | XmlDocument
@@ -374,11 +373,11 @@ class DocumentIDLocation(StrEnum):
 
 
 class DocumentInput(BaseModel):
-  pdf: "Optional[PadesDocumentInput]" = Field(default=None)
+  pdf: Optional[PadesDocumentInput] = Field(default=None)
   # When enabled, will remove any existing signatures from the document before storing. (PDF only)
-  removePreviousSignatures: "Optional[BooleanScalar]" = Field(default=None)
+  removePreviousSignatures: Optional[BooleanScalar] = Field(default=None)
   # XML signing is coming soon, reach out to learn more.
-  xml: "Optional[XadesDocumentInput]" = Field(default=None)
+  xml: Optional[XadesDocumentInput] = Field(default=None)
 
 
 # Document storage mode. Temporary documents will be deleted once completed.
@@ -387,59 +386,57 @@ class DocumentStorageMode(StrEnum):
 
 
 class DownloadVerificationCriiptoVerifyInput(BaseModel):
-  jwt: "StringScalar"
+  jwt: StringScalar
 
 
 class DownloadVerificationInput(BaseModel):
-  criiptoVerify: "Optional[DownloadVerificationCriiptoVerifyInput]" = Field(
-    default=None
-  )
-  oidc: "Optional[DownloadVerificationOidcInput]" = Field(default=None)
+  criiptoVerify: Optional[DownloadVerificationCriiptoVerifyInput] = Field(default=None)
+  oidc: Optional[DownloadVerificationOidcInput] = Field(default=None)
 
 
 class DownloadVerificationOidcInput(BaseModel):
-  jwt: "StringScalar"
+  jwt: StringScalar
 
 
 # Hand drawn signature evidence for signatures.
 class DrawableEvidenceProviderInput(BaseModel):
   # Required minimum height of drawed area in pixels.
-  minimumHeight: "Optional[IntScalar]" = Field(default=None)
+  minimumHeight: Optional[IntScalar] = Field(default=None)
   # Required minimum width of drawed area in pixels.
-  minimumWidth: "Optional[IntScalar]" = Field(default=None)
-  requireName: "Optional[BooleanScalar]" = Field(default=None)
+  minimumWidth: Optional[IntScalar] = Field(default=None)
+  requireName: Optional[BooleanScalar] = Field(default=None)
 
 
 class DrawableSignature(BaseModel):
-  image: "BlobScalar"
-  name: "Optional[StringScalar]" = Field(default=None)
-  signatory: "Optional[Signatory]" = Field(default=None)
+  image: BlobScalar
+  name: Optional[StringScalar] = Field(default=None)
+  signatory: Optional[Signatory] = Field(default=None)
 
 
 class DrawableSignatureEvidenceProvider(BaseModel):
-  id: "IDScalar"
-  minimumHeight: "Optional[IntScalar]" = Field(default=None)
-  minimumWidth: "Optional[IntScalar]" = Field(default=None)
-  requireName: "BooleanScalar"
+  id: IDScalar
+  minimumHeight: Optional[IntScalar] = Field(default=None)
+  minimumWidth: Optional[IntScalar] = Field(default=None)
+  requireName: BooleanScalar
 
 
 class EmptySignature(BaseModel):
-  signatory: "Optional[Signatory]" = Field(default=None)
+  signatory: Optional[Signatory] = Field(default=None)
 
 
 # Must define a evidence provider subsection.
 class EvidenceProviderInput(BaseModel):
-  allOf: "Optional[AllOfEvidenceProviderInput]" = Field(default=None)
+  allOf: Optional[AllOfEvidenceProviderInput] = Field(default=None)
   # Criipto Verify based evidence for signatures.
-  criiptoVerify: "Optional[CriiptoVerifyProviderInput]" = Field(default=None)
+  criiptoVerify: Optional[CriiptoVerifyProviderInput] = Field(default=None)
   # Hand drawn signature evidence for signatures.
-  drawable: "Optional[DrawableEvidenceProviderInput]" = Field(default=None)
+  drawable: Optional[DrawableEvidenceProviderInput] = Field(default=None)
   # Determined if this evidence provider should be enabled by signatories by default. Default true
-  enabledByDefault: "Optional[BooleanScalar]" = Field(default=None)
+  enabledByDefault: Optional[BooleanScalar] = Field(default=None)
   # TEST environment only. Does not manipulate the PDF, use for integration or webhook testing.
-  noop: "Optional[NoopEvidenceProviderInput]" = Field(default=None)
+  noop: Optional[NoopEvidenceProviderInput] = Field(default=None)
   # Deprecated
-  oidc: "Optional[OidcEvidenceProviderInput]" = Field(default=None)
+  oidc: Optional[OidcEvidenceProviderInput] = Field(default=None)
 
 
 class EvidenceValidationStage(StrEnum):
@@ -449,24 +446,24 @@ class EvidenceValidationStage(StrEnum):
 
 class ExtendSignatureOrderInput(BaseModel):
   # Expiration to add to order, in days, max 30.
-  additionalExpirationInDays: "IntScalar"
-  signatureOrderId: "IDScalar"
+  additionalExpirationInDays: IntScalar
+  signatureOrderId: IDScalar
 
 
 class ExtendSignatureOrderOutput(BaseModel):
-  signatureOrder: "SignatureOrder"
+  signatureOrder: SignatureOrder
 
 
 class JWTClaim(BaseModel):
-  name: "StringScalar"
-  value: "StringScalar"
+  name: StringScalar
+  value: StringScalar
 
 
 class JWTSignature(BaseModel):
-  claims: "list[JWTClaim]"
-  jwks: "StringScalar"
-  jwt: "StringScalar"
-  signatory: "Optional[Signatory]" = Field(default=None)
+  claims: list[JWTClaim]
+  jwks: StringScalar
+  jwt: StringScalar
+  signatory: Optional[Signatory] = Field(default=None)
 
 
 class Language(StrEnum):
@@ -478,314 +475,308 @@ class Language(StrEnum):
 
 class Mutation(BaseModel):
   # Add multiple signatures to your signature order.
-  addSignatories: "Optional[AddSignatoriesOutput]" = Field(default=None)
+  addSignatories: Optional[AddSignatoriesOutput] = Field(default=None)
   # Add a signatory to your signature order.
-  addSignatory: "Optional[AddSignatoryOutput]" = Field(default=None)
+  addSignatory: Optional[AddSignatoryOutput] = Field(default=None)
   # Cancels the signature order without closing it, use if you no longer need a signature order. Documents are deleted from storage after cancelling.
-  cancelSignatureOrder: "Optional[CancelSignatureOrderOutput]" = Field(default=None)
+  cancelSignatureOrder: Optional[CancelSignatureOrderOutput] = Field(default=None)
   # Change an existing signatory
-  changeSignatory: "Optional[ChangeSignatoryOutput]" = Field(default=None)
+  changeSignatory: Optional[ChangeSignatoryOutput] = Field(default=None)
   # Change an existing signature order
-  changeSignatureOrder: "Optional[ChangeSignatureOrderOutput]" = Field(default=None)
+  changeSignatureOrder: Optional[ChangeSignatureOrderOutput] = Field(default=None)
   # Cleans up the signature order and removes any saved documents from the servers.
-  cleanupSignatureOrder: "Optional[CleanupSignatureOrderOutput]" = Field(default=None)
+  cleanupSignatureOrder: Optional[CleanupSignatureOrderOutput] = Field(default=None)
   # Finalizes the documents in the signature order and returns them to you as blobs. Documents are deleted from storage after closing.
-  closeSignatureOrder: "Optional[CloseSignatureOrderOutput]" = Field(default=None)
-  completeCriiptoVerifyEvidenceProvider: "Optional[CompleteCriiptoVerifyEvidenceProviderOutput]" = Field(
-    default=None
-  )
+  closeSignatureOrder: Optional[CloseSignatureOrderOutput] = Field(default=None)
+  completeCriiptoVerifyEvidenceProvider: Optional[
+    CompleteCriiptoVerifyEvidenceProviderOutput
+  ] = Field(default=None)
   # Creates a signature application for a given tenant.
-  createApplication: "Optional[CreateApplicationOutput]" = Field(default=None)
+  createApplication: Optional[CreateApplicationOutput] = Field(default=None)
   # Creates a new set of api credentials for an existing application.
-  createApplicationApiKey: "Optional[CreateApplicationApiKeyOutput]" = Field(
-    default=None
-  )
-  createBatchSignatory: "Optional[CreateBatchSignatoryOutput]" = Field(default=None)
+  createApplicationApiKey: Optional[CreateApplicationApiKeyOutput] = Field(default=None)
+  createBatchSignatory: Optional[CreateBatchSignatoryOutput] = Field(default=None)
   # Creates a signature order to be signed.
-  createSignatureOrder: "Optional[CreateSignatureOrderOutput]" = Field(default=None)
+  createSignatureOrder: Optional[CreateSignatureOrderOutput] = Field(default=None)
   # Deletes a set of API credentials for an application.
-  deleteApplicationApiKey: "Optional[DeleteApplicationApiKeyOutput]" = Field(
-    default=None
-  )
+  deleteApplicationApiKey: Optional[DeleteApplicationApiKeyOutput] = Field(default=None)
   # Delete a signatory from a signature order
-  deleteSignatory: "Optional[DeleteSignatoryOutput]" = Field(default=None)
+  deleteSignatory: Optional[DeleteSignatoryOutput] = Field(default=None)
   # Extends the expiration of the signature order.
-  extendSignatureOrder: "Optional[ExtendSignatureOrderOutput]" = Field(default=None)
+  extendSignatureOrder: Optional[ExtendSignatureOrderOutput] = Field(default=None)
   # Refreshes the client secret for an existing set of API credentials. Warning: The old client secret will stop working immediately.
-  refreshApplicationApiKey: "Optional[RefreshApplicationApiKeyOutput]" = Field(
+  refreshApplicationApiKey: Optional[RefreshApplicationApiKeyOutput] = Field(
     default=None
   )
   # Used by Signatory frontends to reject a signature order in full.
-  rejectSignatureOrder: "Optional[RejectSignatureOrderOutput]" = Field(default=None)
-  retrySignatureOrderWebhook: "Optional[RetrySignatureOrderWebhookOutput]" = Field(
+  rejectSignatureOrder: Optional[RejectSignatureOrderOutput] = Field(default=None)
+  retrySignatureOrderWebhook: Optional[RetrySignatureOrderWebhookOutput] = Field(
     default=None
   )
   # Used by Signatory frontends to sign the documents in a signature order.
-  sign: "Optional[SignOutput]" = Field(default=None)
+  sign: Optional[SignOutput] = Field(default=None)
   # Sign with API credentials acting as a specific signatory. The signatory MUST be preapproved in this case.
-  signActingAs: "Optional[SignActingAsOutput]" = Field(default=None)
+  signActingAs: Optional[SignActingAsOutput] = Field(default=None)
   # Signatory frontend use only.
-  signatoryBeacon: "Optional[SignatoryBeaconOutput]" = Field(default=None)
+  signatoryBeacon: Optional[SignatoryBeaconOutput] = Field(default=None)
   # Signatory frontend use only.
-  startCriiptoVerifyEvidenceProvider: "Optional[StartCriiptoVerifyEvidenceProviderOutput]" = Field(
+  startCriiptoVerifyEvidenceProvider: Optional[
+    StartCriiptoVerifyEvidenceProviderOutput
+  ] = Field(default=None)
+  # Signatory frontend use only.
+  trackSignatory: Optional[TrackSignatoryOutput] = Field(default=None)
+  # Used by Signatory frontends to mark documents as opened, approved or rejected.
+  updateSignatoryDocumentStatus: Optional[UpdateSignatoryDocumentStatusOutput] = Field(
     default=None
   )
-  # Signatory frontend use only.
-  trackSignatory: "Optional[TrackSignatoryOutput]" = Field(default=None)
-  # Used by Signatory frontends to mark documents as opened, approved or rejected.
-  updateSignatoryDocumentStatus: "Optional[UpdateSignatoryDocumentStatusOutput]" = (
-    Field(default=None)
-  )
-  validateDocument: "Optional[ValidateDocumentOutput]" = Field(default=None)
+  validateDocument: Optional[ValidateDocumentOutput] = Field(default=None)
 
 
 # TEST only. Allows empty signatures for testing.
 class NoopEvidenceProviderInput(BaseModel):
-  name: "StringScalar"
+  name: StringScalar
 
 
 class NoopSignatureEvidenceProvider(BaseModel):
-  id: "IDScalar"
-  name: "StringScalar"
+  id: IDScalar
+  name: StringScalar
 
 
 # OIDC/JWT based evidence for signatures.
 class OidcEvidenceProviderInput(BaseModel):
-  acrValues: "Optional[list[StringScalar]]" = Field(default=None)
-  alwaysRedirect: "Optional[BooleanScalar]" = Field(default=None)
-  audience: "StringScalar"
-  clientID: "StringScalar"
-  domain: "StringScalar"
-  name: "StringScalar"
+  acrValues: Optional[list[StringScalar]] = Field(default=None)
+  alwaysRedirect: Optional[BooleanScalar] = Field(default=None)
+  audience: StringScalar
+  clientID: StringScalar
+  domain: StringScalar
+  name: StringScalar
   # Enforces that signatories sign by unique evidence by comparing the values of previous evidence on the key you define.
-  uniqueEvidenceKey: "Optional[StringScalar]" = Field(default=None)
+  uniqueEvidenceKey: Optional[StringScalar] = Field(default=None)
 
 
 class OidcJWTSignatureEvidenceProvider(BaseModel):
-  acrValues: "list[StringScalar]"
-  alwaysRedirect: "BooleanScalar"
-  clientID: "StringScalar"
-  domain: "StringScalar"
-  id: "IDScalar"
-  name: "StringScalar"
+  acrValues: list[StringScalar]
+  alwaysRedirect: BooleanScalar
+  clientID: StringScalar
+  domain: StringScalar
+  id: IDScalar
+  name: StringScalar
 
 
 class PadesDocumentFormInput(BaseModel):
-  enabled: "BooleanScalar"
+  enabled: BooleanScalar
 
 
 class PadesDocumentInput(BaseModel):
-  blob: "BlobScalar"
+  blob: BlobScalar
   # Will add a unique identifier for the document to the specified margin of each page. Useful when printing signed documents.
-  displayDocumentID: "Optional[DocumentIDLocation]" = Field(default=None)
-  form: "Optional[PadesDocumentFormInput]" = Field(default=None)
+  displayDocumentID: Optional[DocumentIDLocation] = Field(default=None)
+  form: Optional[PadesDocumentFormInput] = Field(default=None)
   # Will not be displayed to signatories, can be used as a reference to your own system.
-  reference: "Optional[StringScalar]" = Field(default=None)
-  sealsPageTemplate: "Optional[PadesDocumentSealsPageTemplateInput]" = Field(
-    default=None
-  )
-  storageMode: "DocumentStorageMode"
-  title: "StringScalar"
+  reference: Optional[StringScalar] = Field(default=None)
+  sealsPageTemplate: Optional[PadesDocumentSealsPageTemplateInput] = Field(default=None)
+  storageMode: DocumentStorageMode
+  title: StringScalar
 
 
 class PadesDocumentSealsPageTemplateInput(BaseModel):
   # Using the PDF coordinate system, with (x1, y1) being bottom-left
-  area: "PdfBoundingBoxInput"
+  area: PdfBoundingBoxInput
   # Must be a PDF containing a SINGLE page
-  blob: "BlobScalar"
+  blob: BlobScalar
   # Validate that the defined seal area produces the expected number of columns, will error if expectation is not met
-  expectedColumns: "Optional[IntScalar]" = Field(default=None)
+  expectedColumns: Optional[IntScalar] = Field(default=None)
   # Validate that the defined seal area produces the expected number of rows, will error if expectation is not met
-  expectedRows: "Optional[IntScalar]" = Field(default=None)
+  expectedRows: Optional[IntScalar] = Field(default=None)
 
 
 # Information about pagination in a connection.
 class PageInfo(BaseModel):
   # When paginating forwards, the cursor to continue.
-  endCursor: "Optional[StringScalar]" = Field(default=None)
+  endCursor: Optional[StringScalar] = Field(default=None)
   # When paginating forwards, are there more items?
-  hasNextPage: "BooleanScalar"
+  hasNextPage: BooleanScalar
   # When paginating backwards, are there more items?
-  hasPreviousPage: "BooleanScalar"
+  hasPreviousPage: BooleanScalar
   # When paginating backwards, the cursor to continue.
-  startCursor: "Optional[StringScalar]" = Field(default=None)
+  startCursor: Optional[StringScalar] = Field(default=None)
 
 
 class PdfBoundingBoxInput(BaseModel):
-  x1: "FloatScalar"
-  x2: "FloatScalar"
-  y1: "FloatScalar"
-  y2: "FloatScalar"
+  x1: FloatScalar
+  x2: FloatScalar
+  y1: FloatScalar
+  y2: FloatScalar
 
 
 class PdfDocument(BaseModel):
-  blob: "Optional[BlobScalar]" = Field(default=None)
+  blob: Optional[BlobScalar] = Field(default=None)
   # Same value as stamped on document when using displayDocumentID
-  documentID: "StringScalar"
-  form: "Optional[PdfDocumentForm]" = Field(default=None)
-  id: "IDScalar"
-  originalBlob: "Optional[BlobScalar]" = Field(default=None)
-  reference: "Optional[StringScalar]" = Field(default=None)
-  signatoryViewerStatus: "Optional[SignatoryDocumentStatus]" = Field(default=None)
-  signatures: "Optional[list[Signature]]" = Field(default=None)
-  title: "StringScalar"
+  documentID: StringScalar
+  form: Optional[PdfDocumentForm] = Field(default=None)
+  id: IDScalar
+  originalBlob: Optional[BlobScalar] = Field(default=None)
+  reference: Optional[StringScalar] = Field(default=None)
+  signatoryViewerStatus: Optional[SignatoryDocumentStatus] = Field(default=None)
+  signatures: Optional[list[Signature]] = Field(default=None)
+  title: StringScalar
 
 
 class PdfDocumentForm(BaseModel):
-  enabled: "BooleanScalar"
+  enabled: BooleanScalar
 
 
 class PdfSealPosition(BaseModel):
-  page: "IntScalar"
-  x: "FloatScalar"
-  y: "FloatScalar"
+  page: IntScalar
+  x: FloatScalar
+  y: FloatScalar
 
 
 class Query(BaseModel):
-  application: "Optional[Application]" = Field(default=None)
-  batchSignatory: "Optional[BatchSignatory]" = Field(default=None)
-  document: "Optional[Document]" = Field(default=None)
+  application: Optional[Application] = Field(default=None)
+  batchSignatory: Optional[BatchSignatory] = Field(default=None)
+  document: Optional[Document] = Field(default=None)
   # Query a signatory by id. Useful when using webhooks.
-  signatory: "Optional[Signatory]" = Field(default=None)
-  signatureOrder: "Optional[SignatureOrder]" = Field(default=None)
+  signatory: Optional[Signatory] = Field(default=None)
+  signatureOrder: Optional[SignatureOrder] = Field(default=None)
   # Tenants are only accessable from user viewers
-  tenant: "Optional[Tenant]" = Field(default=None)
-  timezones: "list[StringScalar]"
-  viewer: "Viewer"
+  tenant: Optional[Tenant] = Field(default=None)
+  timezones: list[StringScalar]
+  viewer: Viewer
 
 
 class RefreshApplicationApiKeyInput(BaseModel):
-  apiKeyId: "IDScalar"
-  applicationId: "IDScalar"
+  apiKeyId: IDScalar
+  applicationId: IDScalar
 
 
 class RefreshApplicationApiKeyOutput(BaseModel):
-  apiKey: "ApplicationApiKey"
-  application: "Application"
+  apiKey: ApplicationApiKey
+  application: Application
 
 
 class RejectSignatureOrderInput(BaseModel):
-  dummy: "BooleanScalar"
-  reason: "Optional[StringScalar]" = Field(default=None)
+  dummy: BooleanScalar
+  reason: Optional[StringScalar] = Field(default=None)
 
 
 class RejectSignatureOrderOutput(BaseModel):
-  viewer: "Viewer"
+  viewer: Viewer
 
 
 class RetrySignatureOrderWebhookInput(BaseModel):
-  retryPayload: "StringScalar"
-  signatureOrderId: "IDScalar"
+  retryPayload: StringScalar
+  signatureOrderId: IDScalar
 
 
 class RetrySignatureOrderWebhookOutput(BaseModel):
-  invocation: "WebhookInvocation"
+  invocation: WebhookInvocation
 
 
 class SignActingAsInput(BaseModel):
-  evidence: "SignInput"
-  signatoryId: "IDScalar"
+  evidence: SignInput
+  signatoryId: IDScalar
 
 
 class SignActingAsOutput(BaseModel):
-  signatory: "Signatory"
-  signatureOrder: "SignatureOrder"
+  signatory: Signatory
+  signatureOrder: SignatureOrder
 
 
 class SignAllOfInput(BaseModel):
-  criiptoVerify: "Optional[SignCriiptoVerifyInput]" = Field(default=None)
-  drawable: "Optional[SignDrawableInput]" = Field(default=None)
-  noop: "Optional[BooleanScalar]" = Field(default=None)
-  oidc: "Optional[SignOidcInput]" = Field(default=None)
+  criiptoVerify: Optional[SignCriiptoVerifyInput] = Field(default=None)
+  drawable: Optional[SignDrawableInput] = Field(default=None)
+  noop: Optional[BooleanScalar] = Field(default=None)
+  oidc: Optional[SignOidcInput] = Field(default=None)
 
 
 class SignCriiptoVerifyInput(BaseModel):
-  jwt: "StringScalar"
+  jwt: StringScalar
 
 
 class SignDocumentFormFieldInput(BaseModel):
-  field: "StringScalar"
-  value: "StringScalar"
+  field: StringScalar
+  value: StringScalar
 
 
 class SignDocumentFormInput(BaseModel):
-  fields: "list[SignDocumentFormFieldInput]"
+  fields: list[SignDocumentFormFieldInput]
 
 
 class SignDocumentInput(BaseModel):
-  form: "Optional[SignDocumentFormInput]" = Field(default=None)
-  id: "IDScalar"
+  form: Optional[SignDocumentFormInput] = Field(default=None)
+  id: IDScalar
 
 
 class SignDrawableInput(BaseModel):
-  image: "BlobScalar"
-  name: "Optional[StringScalar]" = Field(default=None)
+  image: BlobScalar
+  name: Optional[StringScalar] = Field(default=None)
 
 
 class SignInput(BaseModel):
-  allOf: "Optional[SignAllOfInput]" = Field(default=None)
-  criiptoVerify: "Optional[SignCriiptoVerifyInput]" = Field(default=None)
-  documents: "Optional[list[SignDocumentInput]]" = Field(default=None)
-  drawable: "Optional[SignDrawableInput]" = Field(default=None)
+  allOf: Optional[SignAllOfInput] = Field(default=None)
+  criiptoVerify: Optional[SignCriiptoVerifyInput] = Field(default=None)
+  documents: Optional[list[SignDocumentInput]] = Field(default=None)
+  drawable: Optional[SignDrawableInput] = Field(default=None)
   # EvidenceProvider id
-  id: "IDScalar"
-  noop: "Optional[BooleanScalar]" = Field(default=None)
-  oidc: "Optional[SignOidcInput]" = Field(default=None)
+  id: IDScalar
+  noop: Optional[BooleanScalar] = Field(default=None)
+  oidc: Optional[SignOidcInput] = Field(default=None)
 
 
 class SignOidcInput(BaseModel):
-  jwt: "StringScalar"
+  jwt: StringScalar
 
 
 class SignOutput(BaseModel):
-  viewer: "Viewer"
+  viewer: Viewer
 
 
 class Signatory(BaseModel):
-  documents: "SignatoryDocumentConnection"
+  documents: SignatoryDocumentConnection
   # A download link for signatories to download their signed documents. Signatories must verify their identity before downloading. Can be used when signature order is closed with document retention.
-  downloadHref: "Optional[StringScalar]" = Field(default=None)
-  evidenceProviders: "list[SignatureEvidenceProvider]"
+  downloadHref: Optional[StringScalar] = Field(default=None)
+  evidenceProviders: list[SignatureEvidenceProvider]
   # A link to the signatures frontend, you can send this link to your users to enable them to sign your documents.
-  href: "StringScalar"
-  id: "IDScalar"
-  reference: "Optional[StringScalar]" = Field(default=None)
-  role: "Optional[StringScalar]" = Field(default=None)
+  href: StringScalar
+  id: IDScalar
+  reference: Optional[StringScalar] = Field(default=None)
+  role: Optional[StringScalar] = Field(default=None)
   # Signature order for the signatory.
-  signatureOrder: "SignatureOrder"
-  spanId: "StringScalar"
+  signatureOrder: SignatureOrder
+  spanId: StringScalar
   # The current status of the signatory.
-  status: "SignatoryStatus"
+  status: SignatoryStatus
   # The reason for the signatory status (rejection reason when rejected).
-  statusReason: "Optional[StringScalar]" = Field(default=None)
+  statusReason: Optional[StringScalar] = Field(default=None)
   # The signature frontend authentication token, only required if you need to build a custom url.
-  token: "StringScalar"
-  traceId: "StringScalar"
-  ui: "SignatureOrderUI"
+  token: StringScalar
+  traceId: StringScalar
+  ui: SignatureOrderUI
 
 
 class SignatoryBeaconInput(BaseModel):
-  lastActionAt: "DateTimeScalar"
+  lastActionAt: DateTimeScalar
 
 
 class SignatoryBeaconOutput(BaseModel):
-  viewer: "Viewer"
+  viewer: Viewer
 
 
 class SignatoryDocumentConnection(BaseModel):
-  edges: "list[SignatoryDocumentEdge]"
+  edges: list[SignatoryDocumentEdge]
 
 
 class SignatoryDocumentEdge(BaseModel):
-  node: "Document"
-  status: "Optional[SignatoryDocumentStatus]" = Field(default=None)
+  node: Document
+  status: Optional[SignatoryDocumentStatus] = Field(default=None)
 
 
 class SignatoryDocumentInput(BaseModel):
-  id: "IDScalar"
+  id: IDScalar
   # Define custom position for PDF seal. Uses PDF coordinate system (bottom-left as 0,0). If defined for one signatory/document, must be defined for all.
-  pdfSealPosition: "Optional[PdfSealPosition]" = Field(default=None)
-  preapproved: "Optional[BooleanScalar]" = Field(default=None)
+  pdfSealPosition: Optional[PdfSealPosition] = Field(default=None)
+  preapproved: Optional[BooleanScalar] = Field(default=None)
 
 
 class SignatoryDocumentStatus(StrEnum):
@@ -797,22 +788,22 @@ class SignatoryDocumentStatus(StrEnum):
 
 
 class SignatoryEvidenceProviderInput(BaseModel):
-  allOf: "Optional[AllOfEvidenceProviderInput]" = Field(default=None)
+  allOf: Optional[AllOfEvidenceProviderInput] = Field(default=None)
   # Criipto Verify based evidence for signatures.
-  criiptoVerify: "Optional[CriiptoVerifyProviderInput]" = Field(default=None)
+  criiptoVerify: Optional[CriiptoVerifyProviderInput] = Field(default=None)
   # Hand drawn signature evidence for signatures.
-  drawable: "Optional[DrawableEvidenceProviderInput]" = Field(default=None)
-  id: "IDScalar"
+  drawable: Optional[DrawableEvidenceProviderInput] = Field(default=None)
+  id: IDScalar
   # TEST environment only. Does not manipulate the PDF, use for integration or webhook testing.
-  noop: "Optional[NoopEvidenceProviderInput]" = Field(default=None)
+  noop: Optional[NoopEvidenceProviderInput] = Field(default=None)
   # Deprecated
-  oidc: "Optional[OidcEvidenceProviderInput]" = Field(default=None)
+  oidc: Optional[OidcEvidenceProviderInput] = Field(default=None)
 
 
 class SignatoryEvidenceValidationInput(BaseModel):
-  boolean: "Optional[BooleanScalar]" = Field(default=None)
-  key: "StringScalar"
-  value: "Optional[StringScalar]" = Field(default=None)
+  boolean: Optional[BooleanScalar] = Field(default=None)
+  key: StringScalar
+  value: Optional[StringScalar] = Field(default=None)
 
 
 class SignatoryFrontendEvent(StrEnum):
@@ -830,39 +821,39 @@ class SignatoryStatus(StrEnum):
 
 class SignatoryUIInput(BaseModel):
   # Removes the UI options to reject a document or signature order.
-  disableRejection: "Optional[BooleanScalar]" = Field(default=None)
+  disableRejection: Optional[BooleanScalar] = Field(default=None)
   # The language of texts rendered to the signatory.
-  language: "Optional[Language]" = Field(default=None)
+  language: Optional[Language] = Field(default=None)
   # Define a logo to be shown in the signatory UI.
-  logo: "Optional[SignatureOrderUILogoInput]" = Field(default=None)
+  logo: Optional[SignatureOrderUILogoInput] = Field(default=None)
   # Renders a UI layer for PDF annotations, such as links, making them interactive in the UI/browser
-  renderPdfAnnotationLayer: "Optional[BooleanScalar]" = Field(default=None)
+  renderPdfAnnotationLayer: Optional[BooleanScalar] = Field(default=None)
   # The signatory will be redirected to this URL after signing or rejected the signature order.
-  signatoryRedirectUri: "Optional[StringScalar]" = Field(default=None)
+  signatoryRedirectUri: Optional[StringScalar] = Field(default=None)
   # Add stylesheet/css via an absolute HTTPS URL.
-  stylesheet: "Optional[StringScalar]" = Field(default=None)
+  stylesheet: Optional[StringScalar] = Field(default=None)
 
 
 class SignatoryViewer(BaseModel):
-  authenticated: "BooleanScalar"
-  documents: "SignatoryDocumentConnection"
-  download: "Optional[SignatoryViewerDownload]" = Field(default=None)
-  evidenceProviders: "list[SignatureEvidenceProvider]"
-  id: "IDScalar"
-  signatoryId: "IDScalar"
-  signatureOrderStatus: "SignatureOrderStatus"
-  signer: "BooleanScalar"
-  status: "SignatoryStatus"
-  ui: "SignatureOrderUI"
+  authenticated: BooleanScalar
+  documents: SignatoryDocumentConnection
+  download: Optional[SignatoryViewerDownload] = Field(default=None)
+  evidenceProviders: list[SignatureEvidenceProvider]
+  id: IDScalar
+  signatoryId: IDScalar
+  signatureOrderStatus: SignatureOrderStatus
+  signer: BooleanScalar
+  status: SignatoryStatus
+  ui: SignatureOrderUI
 
 
 class SignatoryViewerDownload(BaseModel):
-  documents: "Optional[SignatoryDocumentConnection]" = Field(default=None)
-  expired: "BooleanScalar"
-  verificationEvidenceProvider: "Optional[SignatureEvidenceProvider]" = Field(
+  documents: Optional[SignatoryDocumentConnection] = Field(default=None)
+  expired: BooleanScalar
+  verificationEvidenceProvider: Optional[SignatureEvidenceProvider] = Field(
     default=None
   )
-  verificationRequired: "BooleanScalar"
+  verificationRequired: BooleanScalar
 
 
 # Represents a signature on a document.
@@ -870,23 +861,23 @@ type Signature = CompositeSignature | DrawableSignature | EmptySignature | JWTSi
 
 
 class SignatureAppearanceInput(BaseModel):
-  displayName: "Optional[list[SignatureAppearanceTemplateInput]]" = Field(default=None)
-  footer: "Optional[list[SignatureAppearanceTemplateInput]]" = Field(default=None)
-  headerLeft: "Optional[list[SignatureAppearanceTemplateInput]]" = Field(default=None)
+  displayName: Optional[list[SignatureAppearanceTemplateInput]] = Field(default=None)
+  footer: Optional[list[SignatureAppearanceTemplateInput]] = Field(default=None)
+  headerLeft: Optional[list[SignatureAppearanceTemplateInput]] = Field(default=None)
   # Render evidence claim as identifier in the signature appearance inside the document. You can supply multiple keys and they will be tried in order. If no key is found a GUID will be rendered.
-  identifierFromEvidence: "list[StringScalar]"
+  identifierFromEvidence: list[StringScalar]
 
 
 class SignatureAppearanceTemplateInput(BaseModel):
-  replacements: "Optional[list[SignatureAppearanceTemplateReplacementInput]]" = Field(
+  replacements: Optional[list[SignatureAppearanceTemplateReplacementInput]] = Field(
     default=None
   )
-  template: "StringScalar"
+  template: StringScalar
 
 
 class SignatureAppearanceTemplateReplacementInput(BaseModel):
-  fromEvidence: "list[StringScalar]"
-  placeholder: "StringScalar"
+  fromEvidence: list[StringScalar]
+  placeholder: StringScalar
 
 
 type SignatureEvidenceProvider = (
@@ -899,43 +890,43 @@ type SignatureEvidenceProvider = (
 
 
 class SignatureOrder(BaseModel):
-  application: "Optional[Application]" = Field(default=None)
-  closedAt: "Optional[DateTimeScalar]" = Field(default=None)
-  createdAt: "DateTimeScalar"
-  documents: "list[Document]"
-  evidenceProviders: "list[SignatureEvidenceProvider]"
-  expiresAt: "DateTimeScalar"
-  id: "IDScalar"
+  application: Optional[Application] = Field(default=None)
+  closedAt: Optional[DateTimeScalar] = Field(default=None)
+  createdAt: DateTimeScalar
+  documents: list[Document]
+  evidenceProviders: list[SignatureEvidenceProvider]
+  expiresAt: DateTimeScalar
+  id: IDScalar
   # Number of max signatories for the signature order
-  maxSignatories: "IntScalar"
+  maxSignatories: IntScalar
   # List of signatories for the signature order.
-  signatories: "list[Signatory]"
-  status: "SignatureOrderStatus"
+  signatories: list[Signatory]
+  status: SignatureOrderStatus
   # Tenants are only accessable from user viewers
-  tenant: "Optional[Tenant]" = Field(default=None)
-  timezone: "StringScalar"
-  title: "Optional[StringScalar]" = Field(default=None)
-  traceId: "StringScalar"
-  ui: "SignatureOrderUI"
-  webhook: "Optional[SignatureOrderWebhook]" = Field(default=None)
+  tenant: Optional[Tenant] = Field(default=None)
+  timezone: StringScalar
+  title: Optional[StringScalar] = Field(default=None)
+  traceId: StringScalar
+  ui: SignatureOrderUI
+  webhook: Optional[SignatureOrderWebhook] = Field(default=None)
 
 
 # A connection from an object to a list of objects of type SignatureOrder
 class SignatureOrderConnection(BaseModel):
   # Information to aid in pagination.
-  edges: "list[SignatureOrderEdge]"
+  edges: list[SignatureOrderEdge]
   # Information to aid in pagination.
-  pageInfo: "PageInfo"
+  pageInfo: PageInfo
   # A count of the total number of objects in this connection, ignoring pagination. This allows a client to fetch the first five objects by passing \"5\" as the argument to `first`, then fetch the total count so it could display \"5 of 83\", for example. In cases where we employ infinite scrolling or don't have an exact count of entries, this field will return `null`.
-  totalCount: "Optional[IntScalar]" = Field(default=None)
+  totalCount: Optional[IntScalar] = Field(default=None)
 
 
 # An edge in a connection from an object to another object of type SignatureOrder
 class SignatureOrderEdge(BaseModel):
   # A cursor for use in pagination
-  cursor: "StringScalar"
+  cursor: StringScalar
   # The item at the end of the edge. Must NOT be an enumerable collection.
-  node: "SignatureOrder"
+  node: SignatureOrder
 
 
 class SignatureOrderStatus(StrEnum):
@@ -946,41 +937,41 @@ class SignatureOrderStatus(StrEnum):
 
 
 class SignatureOrderUI(BaseModel):
-  disableRejection: "BooleanScalar"
-  language: "Language"
-  logo: "Optional[SignatureOrderUILogo]" = Field(default=None)
-  renderPdfAnnotationLayer: "BooleanScalar"
-  signatoryRedirectUri: "Optional[StringScalar]" = Field(default=None)
-  stylesheet: "Optional[StringScalar]" = Field(default=None)
+  disableRejection: BooleanScalar
+  language: Language
+  logo: Optional[SignatureOrderUILogo] = Field(default=None)
+  renderPdfAnnotationLayer: BooleanScalar
+  signatoryRedirectUri: Optional[StringScalar] = Field(default=None)
+  stylesheet: Optional[StringScalar] = Field(default=None)
 
 
 class SignatureOrderUILogo(BaseModel):
-  href: "Optional[StringScalar]" = Field(default=None)
-  src: "StringScalar"
+  href: Optional[StringScalar] = Field(default=None)
+  src: StringScalar
 
 
 class SignatureOrderUILogoInput(BaseModel):
   # Turns your logo into a link with the defined href.
-  href: "Optional[StringScalar]" = Field(default=None)
+  href: Optional[StringScalar] = Field(default=None)
   # The image source for the logo. Must be an absolute HTTPS URL or a valid data: url
-  src: "StringScalar"
+  src: StringScalar
 
 
 class SignatureOrderWebhook(BaseModel):
-  logs: "list[WebhookInvocation]"
-  url: "StringScalar"
+  logs: list[WebhookInvocation]
+  url: StringScalar
 
 
 # Must define a evidence provider subsection.
 class SingleEvidenceProviderInput(BaseModel):
   # Criipto Verify based evidence for signatures.
-  criiptoVerify: "Optional[CriiptoVerifyProviderInput]" = Field(default=None)
+  criiptoVerify: Optional[CriiptoVerifyProviderInput] = Field(default=None)
   # Hand drawn signature evidence for signatures.
-  drawable: "Optional[DrawableEvidenceProviderInput]" = Field(default=None)
+  drawable: Optional[DrawableEvidenceProviderInput] = Field(default=None)
   # TEST environment only. Does not manipulate the PDF, use for integration or webhook testing.
-  noop: "Optional[NoopEvidenceProviderInput]" = Field(default=None)
+  noop: Optional[NoopEvidenceProviderInput] = Field(default=None)
   # Deprecated
-  oidc: "Optional[OidcEvidenceProviderInput]" = Field(default=None)
+  oidc: Optional[OidcEvidenceProviderInput] = Field(default=None)
 
 
 type SingleSignature = DrawableSignature | EmptySignature | JWTSignature
@@ -994,72 +985,72 @@ type SingleSignatureEvidenceProvider = (
 
 
 class StartCriiptoVerifyEvidenceProviderInput(BaseModel):
-  acrValue: "StringScalar"
-  id: "IDScalar"
-  redirectUri: "StringScalar"
-  stage: "EvidenceValidationStage"
+  acrValue: StringScalar
+  id: IDScalar
+  redirectUri: StringScalar
+  stage: EvidenceValidationStage
 
 
 type StartCriiptoVerifyEvidenceProviderOutput = CriiptoVerifyEvidenceProviderRedirect
 
 
 class Tenant(BaseModel):
-  applications: "list[Application]"
-  id: "IDScalar"
-  webhookLogs: "list[WebhookInvocation]"
+  applications: list[Application]
+  id: IDScalar
+  webhookLogs: list[WebhookInvocation]
 
 
 class TrackSignatoryInput(BaseModel):
-  event: "SignatoryFrontendEvent"
+  event: SignatoryFrontendEvent
 
 
 class TrackSignatoryOutput(BaseModel):
-  viewer: "Viewer"
+  viewer: Viewer
 
 
 class UnvalidatedSignatoryViewer(BaseModel):
-  authenticated: "BooleanScalar"
-  download: "Optional[SignatoryViewerDownload]" = Field(default=None)
-  evidenceProviders: "list[SignatureEvidenceProvider]"
-  id: "IDScalar"
-  signatoryId: "IDScalar"
-  ui: "SignatureOrderUI"
+  authenticated: BooleanScalar
+  download: Optional[SignatoryViewerDownload] = Field(default=None)
+  evidenceProviders: list[SignatureEvidenceProvider]
+  id: IDScalar
+  signatoryId: IDScalar
+  ui: SignatureOrderUI
 
 
 class UpdateSignatoryDocumentStatusInput(BaseModel):
-  documentId: "IDScalar"
-  status: "SignatoryDocumentStatus"
+  documentId: IDScalar
+  status: SignatoryDocumentStatus
 
 
 class UpdateSignatoryDocumentStatusOutput(BaseModel):
-  documentEdge: "SignatoryDocumentEdge"
-  viewer: "Viewer"
+  documentEdge: SignatoryDocumentEdge
+  viewer: Viewer
 
 
 class UserViewer(BaseModel):
-  authenticated: "BooleanScalar"
-  id: "IDScalar"
-  tenants: "list[Tenant]"
+  authenticated: BooleanScalar
+  id: IDScalar
+  tenants: list[Tenant]
 
 
 class ValidateDocumentInput(BaseModel):
-  pdf: "Optional[BlobScalar]" = Field(default=None)
-  xml: "Optional[BlobScalar]" = Field(default=None)
+  pdf: Optional[BlobScalar] = Field(default=None)
+  xml: Optional[BlobScalar] = Field(default=None)
 
 
 class ValidateDocumentOutput(BaseModel):
-  errors: "Optional[list[StringScalar]]" = Field(default=None)
+  errors: Optional[list[StringScalar]] = Field(default=None)
   # Whether or not the errors are fixable using 'fixDocumentFormattingErrors'
-  fixable: "Optional[BooleanScalar]" = Field(default=None)
+  fixable: Optional[BooleanScalar] = Field(default=None)
   # `true` if the document contains signatures. If value is `null`, we were unable to determine whether the document has been previously signed.
-  previouslySigned: "Optional[BooleanScalar]" = Field(default=None)
-  valid: "BooleanScalar"
+  previouslySigned: Optional[BooleanScalar] = Field(default=None)
+  valid: BooleanScalar
 
 
 class VerifyApplication(BaseModel):
-  domain: "StringScalar"
-  environment: "VerifyApplicationEnvironment"
-  realm: "StringScalar"
+  domain: StringScalar
+  environment: VerifyApplicationEnvironment
+  realm: StringScalar
 
 
 class VerifyApplicationEnvironment(StrEnum):
@@ -1068,9 +1059,9 @@ class VerifyApplicationEnvironment(StrEnum):
 
 
 class VerifyApplicationQueryInput(BaseModel):
-  domain: "StringScalar"
-  realm: "StringScalar"
-  tenantId: "IDScalar"
+  domain: StringScalar
+  realm: StringScalar
+  tenantId: IDScalar
 
 
 type Viewer = (
@@ -1084,29 +1075,29 @@ type Viewer = (
 
 
 class WebhookExceptionInvocation(BaseModel):
-  correlationId: "StringScalar"
-  event: "Optional[WebhookInvocationEvent]" = Field(default=None)
-  exception: "StringScalar"
-  requestBody: "StringScalar"
-  responseBody: "Optional[StringScalar]" = Field(default=None)
-  retryPayload: "StringScalar"
-  retryingAt: "Optional[StringScalar]" = Field(default=None)
-  signatureOrderId: "Optional[StringScalar]" = Field(default=None)
-  timestamp: "StringScalar"
-  url: "StringScalar"
+  correlationId: StringScalar
+  event: Optional[WebhookInvocationEvent] = Field(default=None)
+  exception: StringScalar
+  requestBody: StringScalar
+  responseBody: Optional[StringScalar] = Field(default=None)
+  retryPayload: StringScalar
+  retryingAt: Optional[StringScalar] = Field(default=None)
+  signatureOrderId: Optional[StringScalar] = Field(default=None)
+  timestamp: StringScalar
+  url: StringScalar
 
 
 class WebhookHttpErrorInvocation(BaseModel):
-  correlationId: "StringScalar"
-  event: "Optional[WebhookInvocationEvent]" = Field(default=None)
-  requestBody: "StringScalar"
-  responseBody: "Optional[StringScalar]" = Field(default=None)
-  responseStatusCode: "IntScalar"
-  retryPayload: "StringScalar"
-  retryingAt: "Optional[StringScalar]" = Field(default=None)
-  signatureOrderId: "Optional[StringScalar]" = Field(default=None)
-  timestamp: "StringScalar"
-  url: "StringScalar"
+  correlationId: StringScalar
+  event: Optional[WebhookInvocationEvent] = Field(default=None)
+  requestBody: StringScalar
+  responseBody: Optional[StringScalar] = Field(default=None)
+  responseStatusCode: IntScalar
+  retryPayload: StringScalar
+  retryingAt: Optional[StringScalar] = Field(default=None)
+  signatureOrderId: Optional[StringScalar] = Field(default=None)
+  timestamp: StringScalar
+  url: StringScalar
 
 
 type WebhookInvocation = (
@@ -1128,45 +1119,45 @@ class WebhookInvocationEvent(StrEnum):
 
 
 class WebhookSuccessfulInvocation(BaseModel):
-  correlationId: "StringScalar"
-  event: "Optional[WebhookInvocationEvent]" = Field(default=None)
-  requestBody: "StringScalar"
-  responseBody: "Optional[StringScalar]" = Field(default=None)
-  responseStatusCode: "IntScalar"
-  signatureOrderId: "Optional[StringScalar]" = Field(default=None)
-  timestamp: "StringScalar"
-  url: "StringScalar"
+  correlationId: StringScalar
+  event: Optional[WebhookInvocationEvent] = Field(default=None)
+  requestBody: StringScalar
+  responseBody: Optional[StringScalar] = Field(default=None)
+  responseStatusCode: IntScalar
+  signatureOrderId: Optional[StringScalar] = Field(default=None)
+  timestamp: StringScalar
+  url: StringScalar
 
 
 class WebhookTimeoutInvocation(BaseModel):
-  correlationId: "StringScalar"
-  event: "Optional[WebhookInvocationEvent]" = Field(default=None)
-  requestBody: "StringScalar"
-  responseBody: "Optional[StringScalar]" = Field(default=None)
-  responseTimeout: "IntScalar"
-  retryPayload: "StringScalar"
-  retryingAt: "Optional[StringScalar]" = Field(default=None)
-  signatureOrderId: "Optional[StringScalar]" = Field(default=None)
-  timestamp: "StringScalar"
-  url: "StringScalar"
+  correlationId: StringScalar
+  event: Optional[WebhookInvocationEvent] = Field(default=None)
+  requestBody: StringScalar
+  responseBody: Optional[StringScalar] = Field(default=None)
+  responseTimeout: IntScalar
+  retryPayload: StringScalar
+  retryingAt: Optional[StringScalar] = Field(default=None)
+  signatureOrderId: Optional[StringScalar] = Field(default=None)
+  timestamp: StringScalar
+  url: StringScalar
 
 
 class XadesDocumentInput(BaseModel):
-  blob: "BlobScalar"
+  blob: BlobScalar
   # Will not be displayed to signatories, can be used as a reference to your own system.
-  reference: "Optional[StringScalar]" = Field(default=None)
-  storageMode: "DocumentStorageMode"
-  title: "StringScalar"
+  reference: Optional[StringScalar] = Field(default=None)
+  storageMode: DocumentStorageMode
+  title: StringScalar
 
 
 class XmlDocument(BaseModel):
-  blob: "Optional[BlobScalar]" = Field(default=None)
-  id: "IDScalar"
-  originalBlob: "Optional[BlobScalar]" = Field(default=None)
-  reference: "Optional[StringScalar]" = Field(default=None)
-  signatoryViewerStatus: "Optional[SignatoryDocumentStatus]" = Field(default=None)
-  signatures: "Optional[list[Signature]]" = Field(default=None)
-  title: "StringScalar"
+  blob: Optional[BlobScalar] = Field(default=None)
+  id: IDScalar
+  originalBlob: Optional[BlobScalar] = Field(default=None)
+  reference: Optional[StringScalar] = Field(default=None)
+  signatoryViewerStatus: Optional[SignatoryDocumentStatus] = Field(default=None)
+  signatures: Optional[list[Signature]] = Field(default=None)
+  title: StringScalar
 
 
 AddSignatoriesInput.model_rebuild()

--- a/packages/python/src/criipto_signatures/operations.py
+++ b/packages/python/src/criipto_signatures/operations.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from enum import StrEnum
 from typing import Optional
 from pydantic import BaseModel, Field
@@ -128,93 +129,99 @@ BasicBatchSignatoryFragment = """fragment BasicBatchSignatory on BatchSignatory 
 
 
 class CreateSignatureOrder_CreateSignatureOrderOutput(BaseModel):
-  signatureOrder: "CreateSignatureOrder_CreateSignatureOrderOutput_SignatureOrder"
+  signatureOrder: CreateSignatureOrder_CreateSignatureOrderOutput_SignatureOrder
 
 
 class CreateSignatureOrder_CreateSignatureOrderOutput_SignatureOrder(BaseModel):
-  closedAt: "Optional[DateTimeScalar]" = Field(default=None)
-  documents: (
-    "list[CreateSignatureOrder_CreateSignatureOrderOutput_SignatureOrder_Document]"
-  )
-  evidenceProviders: "list[CreateSignatureOrder_CreateSignatureOrderOutput_SignatureOrder_SignatureEvidenceProvider]"
-  expiresAt: "DateTimeScalar"
-  id: "IDScalar"
+  closedAt: Optional[DateTimeScalar] = Field(default=None)
+  documents: list[
+    CreateSignatureOrder_CreateSignatureOrderOutput_SignatureOrder_Document
+  ]
+  evidenceProviders: list[
+    CreateSignatureOrder_CreateSignatureOrderOutput_SignatureOrder_SignatureEvidenceProvider
+  ]
+  expiresAt: DateTimeScalar
+  id: IDScalar
   # Number of max signatories for the signature order
-  maxSignatories: "IntScalar"
+  maxSignatories: IntScalar
   # List of signatories for the signature order.
-  signatories: (
-    "list[CreateSignatureOrder_CreateSignatureOrderOutput_SignatureOrder_Signatory]"
-  )
-  status: "SignatureOrderStatus"
-  title: "Optional[StringScalar]" = Field(default=None)
+  signatories: list[
+    CreateSignatureOrder_CreateSignatureOrderOutput_SignatureOrder_Signatory
+  ]
+  status: SignatureOrderStatus
+  title: Optional[StringScalar] = Field(default=None)
 
 
 class CreateSignatureOrder_CreateSignatureOrderOutput_SignatureOrder_Document(
   BaseModel
 ):
-  id: "IDScalar"
-  reference: "Optional[StringScalar]" = Field(default=None)
-  title: "StringScalar"
+  id: IDScalar
+  reference: Optional[StringScalar] = Field(default=None)
+  title: StringScalar
 
 
 class CreateSignatureOrder_CreateSignatureOrderOutput_SignatureOrder_SignatureEvidenceProvider(
   BaseModel
 ):
-  id: "IDScalar"
+  id: IDScalar
 
 
 class CreateSignatureOrder_CreateSignatureOrderOutput_SignatureOrder_Signatory(
   BaseModel
 ):
-  documents: "CreateSignatureOrder_CreateSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection"
+  documents: CreateSignatureOrder_CreateSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection
   # A download link for signatories to download their signed documents. Signatories must verify their identity before downloading. Can be used when signature order is closed with document retention.
-  downloadHref: "Optional[StringScalar]" = Field(default=None)
-  evidenceProviders: "list[CreateSignatureOrder_CreateSignatureOrderOutput_SignatureOrder_Signatory_SignatureEvidenceProvider]"
+  downloadHref: Optional[StringScalar] = Field(default=None)
+  evidenceProviders: list[
+    CreateSignatureOrder_CreateSignatureOrderOutput_SignatureOrder_Signatory_SignatureEvidenceProvider
+  ]
   # A link to the signatures frontend, you can send this link to your users to enable them to sign your documents.
-  href: "StringScalar"
-  id: "IDScalar"
-  reference: "Optional[StringScalar]" = Field(default=None)
-  role: "Optional[StringScalar]" = Field(default=None)
+  href: StringScalar
+  id: IDScalar
+  reference: Optional[StringScalar] = Field(default=None)
+  role: Optional[StringScalar] = Field(default=None)
   # Signature order for the signatory.
-  signatureOrder: "CreateSignatureOrder_CreateSignatureOrderOutput_SignatureOrder_Signatory_SignatureOrder"
+  signatureOrder: CreateSignatureOrder_CreateSignatureOrderOutput_SignatureOrder_Signatory_SignatureOrder
   # The current status of the signatory.
-  status: "SignatoryStatus"
+  status: SignatoryStatus
   # The reason for the signatory status (rejection reason when rejected).
-  statusReason: "Optional[StringScalar]" = Field(default=None)
+  statusReason: Optional[StringScalar] = Field(default=None)
 
 
 class CreateSignatureOrder_CreateSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection(
   BaseModel
 ):
-  edges: "list[CreateSignatureOrder_CreateSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge]"
+  edges: list[
+    CreateSignatureOrder_CreateSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge
+  ]
 
 
 class CreateSignatureOrder_CreateSignatureOrderOutput_SignatureOrder_Signatory_SignatureEvidenceProvider(
   BaseModel
 ):
-  id: "IDScalar"
+  id: IDScalar
 
 
 class CreateSignatureOrder_CreateSignatureOrderOutput_SignatureOrder_Signatory_SignatureOrder(
   BaseModel
 ):
-  closedAt: "Optional[DateTimeScalar]" = Field(default=None)
-  expiresAt: "DateTimeScalar"
-  id: "IDScalar"
-  status: "SignatureOrderStatus"
+  closedAt: Optional[DateTimeScalar] = Field(default=None)
+  expiresAt: DateTimeScalar
+  id: IDScalar
+  status: SignatureOrderStatus
 
 
 class CreateSignatureOrder_CreateSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge(
   BaseModel
 ):
-  node: "CreateSignatureOrder_CreateSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document"
-  status: "Optional[SignatoryDocumentStatus]" = Field(default=None)
+  node: CreateSignatureOrder_CreateSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document
+  status: Optional[SignatoryDocumentStatus] = Field(default=None)
 
 
 class CreateSignatureOrder_CreateSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document(
   BaseModel
 ):
-  id: "IDScalar"
+  id: IDScalar
 
 
 createSignatureOrderDocument = f"""mutation createSignatureOrder($input: CreateSignatureOrderInput!) {{
@@ -233,93 +240,99 @@ createSignatureOrderDocument = f"""mutation createSignatureOrder($input: CreateS
 
 
 class CleanupSignatureOrder_CleanupSignatureOrderOutput(BaseModel):
-  signatureOrder: "CleanupSignatureOrder_CleanupSignatureOrderOutput_SignatureOrder"
+  signatureOrder: CleanupSignatureOrder_CleanupSignatureOrderOutput_SignatureOrder
 
 
 class CleanupSignatureOrder_CleanupSignatureOrderOutput_SignatureOrder(BaseModel):
-  closedAt: "Optional[DateTimeScalar]" = Field(default=None)
-  documents: (
-    "list[CleanupSignatureOrder_CleanupSignatureOrderOutput_SignatureOrder_Document]"
-  )
-  evidenceProviders: "list[CleanupSignatureOrder_CleanupSignatureOrderOutput_SignatureOrder_SignatureEvidenceProvider]"
-  expiresAt: "DateTimeScalar"
-  id: "IDScalar"
+  closedAt: Optional[DateTimeScalar] = Field(default=None)
+  documents: list[
+    CleanupSignatureOrder_CleanupSignatureOrderOutput_SignatureOrder_Document
+  ]
+  evidenceProviders: list[
+    CleanupSignatureOrder_CleanupSignatureOrderOutput_SignatureOrder_SignatureEvidenceProvider
+  ]
+  expiresAt: DateTimeScalar
+  id: IDScalar
   # Number of max signatories for the signature order
-  maxSignatories: "IntScalar"
+  maxSignatories: IntScalar
   # List of signatories for the signature order.
-  signatories: (
-    "list[CleanupSignatureOrder_CleanupSignatureOrderOutput_SignatureOrder_Signatory]"
-  )
-  status: "SignatureOrderStatus"
-  title: "Optional[StringScalar]" = Field(default=None)
+  signatories: list[
+    CleanupSignatureOrder_CleanupSignatureOrderOutput_SignatureOrder_Signatory
+  ]
+  status: SignatureOrderStatus
+  title: Optional[StringScalar] = Field(default=None)
 
 
 class CleanupSignatureOrder_CleanupSignatureOrderOutput_SignatureOrder_Document(
   BaseModel
 ):
-  id: "IDScalar"
-  reference: "Optional[StringScalar]" = Field(default=None)
-  title: "StringScalar"
+  id: IDScalar
+  reference: Optional[StringScalar] = Field(default=None)
+  title: StringScalar
 
 
 class CleanupSignatureOrder_CleanupSignatureOrderOutput_SignatureOrder_SignatureEvidenceProvider(
   BaseModel
 ):
-  id: "IDScalar"
+  id: IDScalar
 
 
 class CleanupSignatureOrder_CleanupSignatureOrderOutput_SignatureOrder_Signatory(
   BaseModel
 ):
-  documents: "CleanupSignatureOrder_CleanupSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection"
+  documents: CleanupSignatureOrder_CleanupSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection
   # A download link for signatories to download their signed documents. Signatories must verify their identity before downloading. Can be used when signature order is closed with document retention.
-  downloadHref: "Optional[StringScalar]" = Field(default=None)
-  evidenceProviders: "list[CleanupSignatureOrder_CleanupSignatureOrderOutput_SignatureOrder_Signatory_SignatureEvidenceProvider]"
+  downloadHref: Optional[StringScalar] = Field(default=None)
+  evidenceProviders: list[
+    CleanupSignatureOrder_CleanupSignatureOrderOutput_SignatureOrder_Signatory_SignatureEvidenceProvider
+  ]
   # A link to the signatures frontend, you can send this link to your users to enable them to sign your documents.
-  href: "StringScalar"
-  id: "IDScalar"
-  reference: "Optional[StringScalar]" = Field(default=None)
-  role: "Optional[StringScalar]" = Field(default=None)
+  href: StringScalar
+  id: IDScalar
+  reference: Optional[StringScalar] = Field(default=None)
+  role: Optional[StringScalar] = Field(default=None)
   # Signature order for the signatory.
-  signatureOrder: "CleanupSignatureOrder_CleanupSignatureOrderOutput_SignatureOrder_Signatory_SignatureOrder"
+  signatureOrder: CleanupSignatureOrder_CleanupSignatureOrderOutput_SignatureOrder_Signatory_SignatureOrder
   # The current status of the signatory.
-  status: "SignatoryStatus"
+  status: SignatoryStatus
   # The reason for the signatory status (rejection reason when rejected).
-  statusReason: "Optional[StringScalar]" = Field(default=None)
+  statusReason: Optional[StringScalar] = Field(default=None)
 
 
 class CleanupSignatureOrder_CleanupSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection(
   BaseModel
 ):
-  edges: "list[CleanupSignatureOrder_CleanupSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge]"
+  edges: list[
+    CleanupSignatureOrder_CleanupSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge
+  ]
 
 
 class CleanupSignatureOrder_CleanupSignatureOrderOutput_SignatureOrder_Signatory_SignatureEvidenceProvider(
   BaseModel
 ):
-  id: "IDScalar"
+  id: IDScalar
 
 
 class CleanupSignatureOrder_CleanupSignatureOrderOutput_SignatureOrder_Signatory_SignatureOrder(
   BaseModel
 ):
-  closedAt: "Optional[DateTimeScalar]" = Field(default=None)
-  expiresAt: "DateTimeScalar"
-  id: "IDScalar"
-  status: "SignatureOrderStatus"
+  closedAt: Optional[DateTimeScalar] = Field(default=None)
+  expiresAt: DateTimeScalar
+  id: IDScalar
+  status: SignatureOrderStatus
 
 
 class CleanupSignatureOrder_CleanupSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge(
   BaseModel
 ):
-  node: "CleanupSignatureOrder_CleanupSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document"
-  status: "Optional[SignatoryDocumentStatus]" = Field(default=None)
+  node: CleanupSignatureOrder_CleanupSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document
+  status: Optional[SignatoryDocumentStatus] = Field(default=None)
 
 
 class CleanupSignatureOrder_CleanupSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document(
   BaseModel
 ):
-  id: "IDScalar"
+  id: IDScalar
 
 
 cleanupSignatureOrderDocument = f"""mutation cleanupSignatureOrder($input: CleanupSignatureOrderInput!) {{
@@ -338,55 +351,57 @@ cleanupSignatureOrderDocument = f"""mutation cleanupSignatureOrder($input: Clean
 
 
 class AddSignatory_AddSignatoryOutput(BaseModel):
-  signatory: "AddSignatory_AddSignatoryOutput_Signatory"
+  signatory: AddSignatory_AddSignatoryOutput_Signatory
 
 
 class AddSignatory_AddSignatoryOutput_Signatory(BaseModel):
-  documents: "AddSignatory_AddSignatoryOutput_Signatory_SignatoryDocumentConnection"
+  documents: AddSignatory_AddSignatoryOutput_Signatory_SignatoryDocumentConnection
   # A download link for signatories to download their signed documents. Signatories must verify their identity before downloading. Can be used when signature order is closed with document retention.
-  downloadHref: "Optional[StringScalar]" = Field(default=None)
-  evidenceProviders: (
-    "list[AddSignatory_AddSignatoryOutput_Signatory_SignatureEvidenceProvider]"
-  )
+  downloadHref: Optional[StringScalar] = Field(default=None)
+  evidenceProviders: list[
+    AddSignatory_AddSignatoryOutput_Signatory_SignatureEvidenceProvider
+  ]
   # A link to the signatures frontend, you can send this link to your users to enable them to sign your documents.
-  href: "StringScalar"
-  id: "IDScalar"
-  reference: "Optional[StringScalar]" = Field(default=None)
-  role: "Optional[StringScalar]" = Field(default=None)
+  href: StringScalar
+  id: IDScalar
+  reference: Optional[StringScalar] = Field(default=None)
+  role: Optional[StringScalar] = Field(default=None)
   # Signature order for the signatory.
-  signatureOrder: "AddSignatory_AddSignatoryOutput_Signatory_SignatureOrder"
+  signatureOrder: AddSignatory_AddSignatoryOutput_Signatory_SignatureOrder
   # The current status of the signatory.
-  status: "SignatoryStatus"
+  status: SignatoryStatus
   # The reason for the signatory status (rejection reason when rejected).
-  statusReason: "Optional[StringScalar]" = Field(default=None)
+  statusReason: Optional[StringScalar] = Field(default=None)
 
 
 class AddSignatory_AddSignatoryOutput_Signatory_SignatoryDocumentConnection(BaseModel):
-  edges: "list[AddSignatory_AddSignatoryOutput_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge]"
+  edges: list[
+    AddSignatory_AddSignatoryOutput_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge
+  ]
 
 
 class AddSignatory_AddSignatoryOutput_Signatory_SignatureEvidenceProvider(BaseModel):
-  id: "IDScalar"
+  id: IDScalar
 
 
 class AddSignatory_AddSignatoryOutput_Signatory_SignatureOrder(BaseModel):
-  closedAt: "Optional[DateTimeScalar]" = Field(default=None)
-  expiresAt: "DateTimeScalar"
-  id: "IDScalar"
-  status: "SignatureOrderStatus"
+  closedAt: Optional[DateTimeScalar] = Field(default=None)
+  expiresAt: DateTimeScalar
+  id: IDScalar
+  status: SignatureOrderStatus
 
 
 class AddSignatory_AddSignatoryOutput_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge(
   BaseModel
 ):
-  node: "AddSignatory_AddSignatoryOutput_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document"
-  status: "Optional[SignatoryDocumentStatus]" = Field(default=None)
+  node: AddSignatory_AddSignatoryOutput_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document
+  status: Optional[SignatoryDocumentStatus] = Field(default=None)
 
 
 class AddSignatory_AddSignatoryOutput_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document(
   BaseModel
 ):
-  id: "IDScalar"
+  id: IDScalar
 
 
 addSignatoryDocument = f"""mutation addSignatory($input: AddSignatoryInput!) {{
@@ -400,59 +415,61 @@ addSignatoryDocument = f"""mutation addSignatory($input: AddSignatoryInput!) {{
 
 
 class AddSignatories_AddSignatoriesOutput(BaseModel):
-  signatories: "list[AddSignatories_AddSignatoriesOutput_Signatory]"
+  signatories: list[AddSignatories_AddSignatoriesOutput_Signatory]
 
 
 class AddSignatories_AddSignatoriesOutput_Signatory(BaseModel):
-  documents: "AddSignatories_AddSignatoriesOutput_Signatory_SignatoryDocumentConnection"
+  documents: AddSignatories_AddSignatoriesOutput_Signatory_SignatoryDocumentConnection
   # A download link for signatories to download their signed documents. Signatories must verify their identity before downloading. Can be used when signature order is closed with document retention.
-  downloadHref: "Optional[StringScalar]" = Field(default=None)
-  evidenceProviders: (
-    "list[AddSignatories_AddSignatoriesOutput_Signatory_SignatureEvidenceProvider]"
-  )
+  downloadHref: Optional[StringScalar] = Field(default=None)
+  evidenceProviders: list[
+    AddSignatories_AddSignatoriesOutput_Signatory_SignatureEvidenceProvider
+  ]
   # A link to the signatures frontend, you can send this link to your users to enable them to sign your documents.
-  href: "StringScalar"
-  id: "IDScalar"
-  reference: "Optional[StringScalar]" = Field(default=None)
-  role: "Optional[StringScalar]" = Field(default=None)
+  href: StringScalar
+  id: IDScalar
+  reference: Optional[StringScalar] = Field(default=None)
+  role: Optional[StringScalar] = Field(default=None)
   # Signature order for the signatory.
-  signatureOrder: "AddSignatories_AddSignatoriesOutput_Signatory_SignatureOrder"
+  signatureOrder: AddSignatories_AddSignatoriesOutput_Signatory_SignatureOrder
   # The current status of the signatory.
-  status: "SignatoryStatus"
+  status: SignatoryStatus
   # The reason for the signatory status (rejection reason when rejected).
-  statusReason: "Optional[StringScalar]" = Field(default=None)
+  statusReason: Optional[StringScalar] = Field(default=None)
 
 
 class AddSignatories_AddSignatoriesOutput_Signatory_SignatoryDocumentConnection(
   BaseModel
 ):
-  edges: "list[AddSignatories_AddSignatoriesOutput_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge]"
+  edges: list[
+    AddSignatories_AddSignatoriesOutput_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge
+  ]
 
 
 class AddSignatories_AddSignatoriesOutput_Signatory_SignatureEvidenceProvider(
   BaseModel
 ):
-  id: "IDScalar"
+  id: IDScalar
 
 
 class AddSignatories_AddSignatoriesOutput_Signatory_SignatureOrder(BaseModel):
-  closedAt: "Optional[DateTimeScalar]" = Field(default=None)
-  expiresAt: "DateTimeScalar"
-  id: "IDScalar"
-  status: "SignatureOrderStatus"
+  closedAt: Optional[DateTimeScalar] = Field(default=None)
+  expiresAt: DateTimeScalar
+  id: IDScalar
+  status: SignatureOrderStatus
 
 
 class AddSignatories_AddSignatoriesOutput_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge(
   BaseModel
 ):
-  node: "AddSignatories_AddSignatoriesOutput_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document"
-  status: "Optional[SignatoryDocumentStatus]" = Field(default=None)
+  node: AddSignatories_AddSignatoriesOutput_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document
+  status: Optional[SignatoryDocumentStatus] = Field(default=None)
 
 
 class AddSignatories_AddSignatoriesOutput_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document(
   BaseModel
 ):
-  id: "IDScalar"
+  id: IDScalar
 
 
 addSignatoriesDocument = f"""mutation addSignatories($input: AddSignatoriesInput!) {{
@@ -466,61 +483,61 @@ addSignatoriesDocument = f"""mutation addSignatories($input: AddSignatoriesInput
 
 
 class ChangeSignatory_ChangeSignatoryOutput(BaseModel):
-  signatory: "ChangeSignatory_ChangeSignatoryOutput_Signatory"
+  signatory: ChangeSignatory_ChangeSignatoryOutput_Signatory
 
 
 class ChangeSignatory_ChangeSignatoryOutput_Signatory(BaseModel):
-  documents: (
-    "ChangeSignatory_ChangeSignatoryOutput_Signatory_SignatoryDocumentConnection"
-  )
+  documents: ChangeSignatory_ChangeSignatoryOutput_Signatory_SignatoryDocumentConnection
   # A download link for signatories to download their signed documents. Signatories must verify their identity before downloading. Can be used when signature order is closed with document retention.
-  downloadHref: "Optional[StringScalar]" = Field(default=None)
-  evidenceProviders: (
-    "list[ChangeSignatory_ChangeSignatoryOutput_Signatory_SignatureEvidenceProvider]"
-  )
+  downloadHref: Optional[StringScalar] = Field(default=None)
+  evidenceProviders: list[
+    ChangeSignatory_ChangeSignatoryOutput_Signatory_SignatureEvidenceProvider
+  ]
   # A link to the signatures frontend, you can send this link to your users to enable them to sign your documents.
-  href: "StringScalar"
-  id: "IDScalar"
-  reference: "Optional[StringScalar]" = Field(default=None)
-  role: "Optional[StringScalar]" = Field(default=None)
+  href: StringScalar
+  id: IDScalar
+  reference: Optional[StringScalar] = Field(default=None)
+  role: Optional[StringScalar] = Field(default=None)
   # Signature order for the signatory.
-  signatureOrder: "ChangeSignatory_ChangeSignatoryOutput_Signatory_SignatureOrder"
+  signatureOrder: ChangeSignatory_ChangeSignatoryOutput_Signatory_SignatureOrder
   # The current status of the signatory.
-  status: "SignatoryStatus"
+  status: SignatoryStatus
   # The reason for the signatory status (rejection reason when rejected).
-  statusReason: "Optional[StringScalar]" = Field(default=None)
+  statusReason: Optional[StringScalar] = Field(default=None)
 
 
 class ChangeSignatory_ChangeSignatoryOutput_Signatory_SignatoryDocumentConnection(
   BaseModel
 ):
-  edges: "list[ChangeSignatory_ChangeSignatoryOutput_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge]"
+  edges: list[
+    ChangeSignatory_ChangeSignatoryOutput_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge
+  ]
 
 
 class ChangeSignatory_ChangeSignatoryOutput_Signatory_SignatureEvidenceProvider(
   BaseModel
 ):
-  id: "IDScalar"
+  id: IDScalar
 
 
 class ChangeSignatory_ChangeSignatoryOutput_Signatory_SignatureOrder(BaseModel):
-  closedAt: "Optional[DateTimeScalar]" = Field(default=None)
-  expiresAt: "DateTimeScalar"
-  id: "IDScalar"
-  status: "SignatureOrderStatus"
+  closedAt: Optional[DateTimeScalar] = Field(default=None)
+  expiresAt: DateTimeScalar
+  id: IDScalar
+  status: SignatureOrderStatus
 
 
 class ChangeSignatory_ChangeSignatoryOutput_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge(
   BaseModel
 ):
-  node: "ChangeSignatory_ChangeSignatoryOutput_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document"
-  status: "Optional[SignatoryDocumentStatus]" = Field(default=None)
+  node: ChangeSignatory_ChangeSignatoryOutput_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document
+  status: Optional[SignatoryDocumentStatus] = Field(default=None)
 
 
 class ChangeSignatory_ChangeSignatoryOutput_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document(
   BaseModel
 ):
-  id: "IDScalar"
+  id: IDScalar
 
 
 changeSignatoryDocument = f"""mutation changeSignatory($input: ChangeSignatoryInput!) {{
@@ -534,108 +551,114 @@ changeSignatoryDocument = f"""mutation changeSignatory($input: ChangeSignatoryIn
 
 
 class CloseSignatureOrder_CloseSignatureOrderOutput(BaseModel):
-  signatureOrder: "CloseSignatureOrder_CloseSignatureOrderOutput_SignatureOrder"
+  signatureOrder: CloseSignatureOrder_CloseSignatureOrderOutput_SignatureOrder
 
 
 class CloseSignatureOrder_CloseSignatureOrderOutput_SignatureOrder(BaseModel):
-  closedAt: "Optional[DateTimeScalar]" = Field(default=None)
-  documents: (
-    "list[CloseSignatureOrder_CloseSignatureOrderOutput_SignatureOrder_Document]"
-  )
-  evidenceProviders: "list[CloseSignatureOrder_CloseSignatureOrderOutput_SignatureOrder_SignatureEvidenceProvider]"
-  expiresAt: "DateTimeScalar"
-  id: "IDScalar"
+  closedAt: Optional[DateTimeScalar] = Field(default=None)
+  documents: list[CloseSignatureOrder_CloseSignatureOrderOutput_SignatureOrder_Document]
+  evidenceProviders: list[
+    CloseSignatureOrder_CloseSignatureOrderOutput_SignatureOrder_SignatureEvidenceProvider
+  ]
+  expiresAt: DateTimeScalar
+  id: IDScalar
   # Number of max signatories for the signature order
-  maxSignatories: "IntScalar"
+  maxSignatories: IntScalar
   # List of signatories for the signature order.
-  signatories: (
-    "list[CloseSignatureOrder_CloseSignatureOrderOutput_SignatureOrder_Signatory]"
-  )
-  status: "SignatureOrderStatus"
-  title: "Optional[StringScalar]" = Field(default=None)
+  signatories: list[
+    CloseSignatureOrder_CloseSignatureOrderOutput_SignatureOrder_Signatory
+  ]
+  status: SignatureOrderStatus
+  title: Optional[StringScalar] = Field(default=None)
 
 
 class CloseSignatureOrder_CloseSignatureOrderOutput_SignatureOrder_Document(BaseModel):
-  blob: "Optional[BlobScalar]" = Field(default=None)
-  id: "IDScalar"
-  reference: "Optional[StringScalar]" = Field(default=None)
-  signatures: "Optional[list[CloseSignatureOrder_CloseSignatureOrderOutput_SignatureOrder_Document_Signature]]" = Field(
-    default=None
-  )
-  title: "StringScalar"
+  blob: Optional[BlobScalar] = Field(default=None)
+  id: IDScalar
+  reference: Optional[StringScalar] = Field(default=None)
+  signatures: Optional[
+    list[
+      CloseSignatureOrder_CloseSignatureOrderOutput_SignatureOrder_Document_Signature
+    ]
+  ] = Field(default=None)
+  title: StringScalar
 
 
 class CloseSignatureOrder_CloseSignatureOrderOutput_SignatureOrder_SignatureEvidenceProvider(
   BaseModel
 ):
-  id: "IDScalar"
+  id: IDScalar
 
 
 class CloseSignatureOrder_CloseSignatureOrderOutput_SignatureOrder_Signatory(BaseModel):
-  documents: "CloseSignatureOrder_CloseSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection"
+  documents: CloseSignatureOrder_CloseSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection
   # A download link for signatories to download their signed documents. Signatories must verify their identity before downloading. Can be used when signature order is closed with document retention.
-  downloadHref: "Optional[StringScalar]" = Field(default=None)
-  evidenceProviders: "list[CloseSignatureOrder_CloseSignatureOrderOutput_SignatureOrder_Signatory_SignatureEvidenceProvider]"
+  downloadHref: Optional[StringScalar] = Field(default=None)
+  evidenceProviders: list[
+    CloseSignatureOrder_CloseSignatureOrderOutput_SignatureOrder_Signatory_SignatureEvidenceProvider
+  ]
   # A link to the signatures frontend, you can send this link to your users to enable them to sign your documents.
-  href: "StringScalar"
-  id: "IDScalar"
-  reference: "Optional[StringScalar]" = Field(default=None)
-  role: "Optional[StringScalar]" = Field(default=None)
+  href: StringScalar
+  id: IDScalar
+  reference: Optional[StringScalar] = Field(default=None)
+  role: Optional[StringScalar] = Field(default=None)
   # Signature order for the signatory.
-  signatureOrder: "CloseSignatureOrder_CloseSignatureOrderOutput_SignatureOrder_Signatory_SignatureOrder"
+  signatureOrder: CloseSignatureOrder_CloseSignatureOrderOutput_SignatureOrder_Signatory_SignatureOrder
   # The current status of the signatory.
-  status: "SignatoryStatus"
+  status: SignatoryStatus
   # The reason for the signatory status (rejection reason when rejected).
-  statusReason: "Optional[StringScalar]" = Field(default=None)
+  statusReason: Optional[StringScalar] = Field(default=None)
 
 
 # Represents a signature on a document.
 class CloseSignatureOrder_CloseSignatureOrderOutput_SignatureOrder_Document_Signature(
   BaseModel
 ):
-  signatory: "Optional[CloseSignatureOrder_CloseSignatureOrderOutput_SignatureOrder_Document_Signature_Signatory]" = Field(
-    default=None
-  )
+  signatory: Optional[
+    CloseSignatureOrder_CloseSignatureOrderOutput_SignatureOrder_Document_Signature_Signatory
+  ] = Field(default=None)
 
 
 class CloseSignatureOrder_CloseSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection(
   BaseModel
 ):
-  edges: "list[CloseSignatureOrder_CloseSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge]"
+  edges: list[
+    CloseSignatureOrder_CloseSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge
+  ]
 
 
 class CloseSignatureOrder_CloseSignatureOrderOutput_SignatureOrder_Signatory_SignatureEvidenceProvider(
   BaseModel
 ):
-  id: "IDScalar"
+  id: IDScalar
 
 
 class CloseSignatureOrder_CloseSignatureOrderOutput_SignatureOrder_Signatory_SignatureOrder(
   BaseModel
 ):
-  closedAt: "Optional[DateTimeScalar]" = Field(default=None)
-  expiresAt: "DateTimeScalar"
-  id: "IDScalar"
-  status: "SignatureOrderStatus"
+  closedAt: Optional[DateTimeScalar] = Field(default=None)
+  expiresAt: DateTimeScalar
+  id: IDScalar
+  status: SignatureOrderStatus
 
 
 class CloseSignatureOrder_CloseSignatureOrderOutput_SignatureOrder_Document_Signature_Signatory(
   BaseModel
 ):
-  id: "IDScalar"
+  id: IDScalar
 
 
 class CloseSignatureOrder_CloseSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge(
   BaseModel
 ):
-  node: "CloseSignatureOrder_CloseSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document"
-  status: "Optional[SignatoryDocumentStatus]" = Field(default=None)
+  node: CloseSignatureOrder_CloseSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document
+  status: Optional[SignatoryDocumentStatus] = Field(default=None)
 
 
 class CloseSignatureOrder_CloseSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document(
   BaseModel
 ):
-  id: "IDScalar"
+  id: IDScalar
 
 
 closeSignatureOrderDocument = f"""mutation closeSignatureOrder($input: CloseSignatureOrderInput!) {{
@@ -656,93 +679,99 @@ closeSignatureOrderDocument = f"""mutation closeSignatureOrder($input: CloseSign
 
 
 class CancelSignatureOrder_CancelSignatureOrderOutput(BaseModel):
-  signatureOrder: "CancelSignatureOrder_CancelSignatureOrderOutput_SignatureOrder"
+  signatureOrder: CancelSignatureOrder_CancelSignatureOrderOutput_SignatureOrder
 
 
 class CancelSignatureOrder_CancelSignatureOrderOutput_SignatureOrder(BaseModel):
-  closedAt: "Optional[DateTimeScalar]" = Field(default=None)
-  documents: (
-    "list[CancelSignatureOrder_CancelSignatureOrderOutput_SignatureOrder_Document]"
-  )
-  evidenceProviders: "list[CancelSignatureOrder_CancelSignatureOrderOutput_SignatureOrder_SignatureEvidenceProvider]"
-  expiresAt: "DateTimeScalar"
-  id: "IDScalar"
+  closedAt: Optional[DateTimeScalar] = Field(default=None)
+  documents: list[
+    CancelSignatureOrder_CancelSignatureOrderOutput_SignatureOrder_Document
+  ]
+  evidenceProviders: list[
+    CancelSignatureOrder_CancelSignatureOrderOutput_SignatureOrder_SignatureEvidenceProvider
+  ]
+  expiresAt: DateTimeScalar
+  id: IDScalar
   # Number of max signatories for the signature order
-  maxSignatories: "IntScalar"
+  maxSignatories: IntScalar
   # List of signatories for the signature order.
-  signatories: (
-    "list[CancelSignatureOrder_CancelSignatureOrderOutput_SignatureOrder_Signatory]"
-  )
-  status: "SignatureOrderStatus"
-  title: "Optional[StringScalar]" = Field(default=None)
+  signatories: list[
+    CancelSignatureOrder_CancelSignatureOrderOutput_SignatureOrder_Signatory
+  ]
+  status: SignatureOrderStatus
+  title: Optional[StringScalar] = Field(default=None)
 
 
 class CancelSignatureOrder_CancelSignatureOrderOutput_SignatureOrder_Document(
   BaseModel
 ):
-  id: "IDScalar"
-  reference: "Optional[StringScalar]" = Field(default=None)
-  title: "StringScalar"
+  id: IDScalar
+  reference: Optional[StringScalar] = Field(default=None)
+  title: StringScalar
 
 
 class CancelSignatureOrder_CancelSignatureOrderOutput_SignatureOrder_SignatureEvidenceProvider(
   BaseModel
 ):
-  id: "IDScalar"
+  id: IDScalar
 
 
 class CancelSignatureOrder_CancelSignatureOrderOutput_SignatureOrder_Signatory(
   BaseModel
 ):
-  documents: "CancelSignatureOrder_CancelSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection"
+  documents: CancelSignatureOrder_CancelSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection
   # A download link for signatories to download their signed documents. Signatories must verify their identity before downloading. Can be used when signature order is closed with document retention.
-  downloadHref: "Optional[StringScalar]" = Field(default=None)
-  evidenceProviders: "list[CancelSignatureOrder_CancelSignatureOrderOutput_SignatureOrder_Signatory_SignatureEvidenceProvider]"
+  downloadHref: Optional[StringScalar] = Field(default=None)
+  evidenceProviders: list[
+    CancelSignatureOrder_CancelSignatureOrderOutput_SignatureOrder_Signatory_SignatureEvidenceProvider
+  ]
   # A link to the signatures frontend, you can send this link to your users to enable them to sign your documents.
-  href: "StringScalar"
-  id: "IDScalar"
-  reference: "Optional[StringScalar]" = Field(default=None)
-  role: "Optional[StringScalar]" = Field(default=None)
+  href: StringScalar
+  id: IDScalar
+  reference: Optional[StringScalar] = Field(default=None)
+  role: Optional[StringScalar] = Field(default=None)
   # Signature order for the signatory.
-  signatureOrder: "CancelSignatureOrder_CancelSignatureOrderOutput_SignatureOrder_Signatory_SignatureOrder"
+  signatureOrder: CancelSignatureOrder_CancelSignatureOrderOutput_SignatureOrder_Signatory_SignatureOrder
   # The current status of the signatory.
-  status: "SignatoryStatus"
+  status: SignatoryStatus
   # The reason for the signatory status (rejection reason when rejected).
-  statusReason: "Optional[StringScalar]" = Field(default=None)
+  statusReason: Optional[StringScalar] = Field(default=None)
 
 
 class CancelSignatureOrder_CancelSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection(
   BaseModel
 ):
-  edges: "list[CancelSignatureOrder_CancelSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge]"
+  edges: list[
+    CancelSignatureOrder_CancelSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge
+  ]
 
 
 class CancelSignatureOrder_CancelSignatureOrderOutput_SignatureOrder_Signatory_SignatureEvidenceProvider(
   BaseModel
 ):
-  id: "IDScalar"
+  id: IDScalar
 
 
 class CancelSignatureOrder_CancelSignatureOrderOutput_SignatureOrder_Signatory_SignatureOrder(
   BaseModel
 ):
-  closedAt: "Optional[DateTimeScalar]" = Field(default=None)
-  expiresAt: "DateTimeScalar"
-  id: "IDScalar"
-  status: "SignatureOrderStatus"
+  closedAt: Optional[DateTimeScalar] = Field(default=None)
+  expiresAt: DateTimeScalar
+  id: IDScalar
+  status: SignatureOrderStatus
 
 
 class CancelSignatureOrder_CancelSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge(
   BaseModel
 ):
-  node: "CancelSignatureOrder_CancelSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document"
-  status: "Optional[SignatoryDocumentStatus]" = Field(default=None)
+  node: CancelSignatureOrder_CancelSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document
+  status: Optional[SignatoryDocumentStatus] = Field(default=None)
 
 
 class CancelSignatureOrder_CancelSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document(
   BaseModel
 ):
-  id: "IDScalar"
+  id: IDScalar
 
 
 cancelSignatureOrderDocument = f"""mutation cancelSignatureOrder($input: CancelSignatureOrderInput!) {{
@@ -761,55 +790,57 @@ cancelSignatureOrderDocument = f"""mutation cancelSignatureOrder($input: CancelS
 
 
 class SignActingAs_SignActingAsOutput(BaseModel):
-  signatory: "SignActingAs_SignActingAsOutput_Signatory"
+  signatory: SignActingAs_SignActingAsOutput_Signatory
 
 
 class SignActingAs_SignActingAsOutput_Signatory(BaseModel):
-  documents: "SignActingAs_SignActingAsOutput_Signatory_SignatoryDocumentConnection"
+  documents: SignActingAs_SignActingAsOutput_Signatory_SignatoryDocumentConnection
   # A download link for signatories to download their signed documents. Signatories must verify their identity before downloading. Can be used when signature order is closed with document retention.
-  downloadHref: "Optional[StringScalar]" = Field(default=None)
-  evidenceProviders: (
-    "list[SignActingAs_SignActingAsOutput_Signatory_SignatureEvidenceProvider]"
-  )
+  downloadHref: Optional[StringScalar] = Field(default=None)
+  evidenceProviders: list[
+    SignActingAs_SignActingAsOutput_Signatory_SignatureEvidenceProvider
+  ]
   # A link to the signatures frontend, you can send this link to your users to enable them to sign your documents.
-  href: "StringScalar"
-  id: "IDScalar"
-  reference: "Optional[StringScalar]" = Field(default=None)
-  role: "Optional[StringScalar]" = Field(default=None)
+  href: StringScalar
+  id: IDScalar
+  reference: Optional[StringScalar] = Field(default=None)
+  role: Optional[StringScalar] = Field(default=None)
   # Signature order for the signatory.
-  signatureOrder: "SignActingAs_SignActingAsOutput_Signatory_SignatureOrder"
+  signatureOrder: SignActingAs_SignActingAsOutput_Signatory_SignatureOrder
   # The current status of the signatory.
-  status: "SignatoryStatus"
+  status: SignatoryStatus
   # The reason for the signatory status (rejection reason when rejected).
-  statusReason: "Optional[StringScalar]" = Field(default=None)
+  statusReason: Optional[StringScalar] = Field(default=None)
 
 
 class SignActingAs_SignActingAsOutput_Signatory_SignatoryDocumentConnection(BaseModel):
-  edges: "list[SignActingAs_SignActingAsOutput_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge]"
+  edges: list[
+    SignActingAs_SignActingAsOutput_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge
+  ]
 
 
 class SignActingAs_SignActingAsOutput_Signatory_SignatureEvidenceProvider(BaseModel):
-  id: "IDScalar"
+  id: IDScalar
 
 
 class SignActingAs_SignActingAsOutput_Signatory_SignatureOrder(BaseModel):
-  closedAt: "Optional[DateTimeScalar]" = Field(default=None)
-  expiresAt: "DateTimeScalar"
-  id: "IDScalar"
-  status: "SignatureOrderStatus"
+  closedAt: Optional[DateTimeScalar] = Field(default=None)
+  expiresAt: DateTimeScalar
+  id: IDScalar
+  status: SignatureOrderStatus
 
 
 class SignActingAs_SignActingAsOutput_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge(
   BaseModel
 ):
-  node: "SignActingAs_SignActingAsOutput_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document"
-  status: "Optional[SignatoryDocumentStatus]" = Field(default=None)
+  node: SignActingAs_SignActingAsOutput_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document
+  status: Optional[SignatoryDocumentStatus] = Field(default=None)
 
 
 class SignActingAs_SignActingAsOutput_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document(
   BaseModel
 ):
-  id: "IDScalar"
+  id: IDScalar
 
 
 signActingAsDocument = f"""mutation signActingAs($input: SignActingAsInput!) {{
@@ -823,10 +854,10 @@ signActingAsDocument = f"""mutation signActingAs($input: SignActingAsInput!) {{
 
 
 class ValidateDocument_ValidateDocumentOutput(BaseModel):
-  errors: "Optional[list[StringScalar]]" = Field(default=None)
+  errors: Optional[list[StringScalar]] = Field(default=None)
   # Whether or not the errors are fixable using 'fixDocumentFormattingErrors'
-  fixable: "Optional[BooleanScalar]" = Field(default=None)
-  valid: "BooleanScalar"
+  fixable: Optional[BooleanScalar] = Field(default=None)
+  valid: BooleanScalar
 
 
 validateDocumentDocument = """mutation validateDocument($input: ValidateDocumentInput!) {
@@ -839,93 +870,99 @@ validateDocumentDocument = """mutation validateDocument($input: ValidateDocument
 
 
 class ExtendSignatureOrder_ExtendSignatureOrderOutput(BaseModel):
-  signatureOrder: "ExtendSignatureOrder_ExtendSignatureOrderOutput_SignatureOrder"
+  signatureOrder: ExtendSignatureOrder_ExtendSignatureOrderOutput_SignatureOrder
 
 
 class ExtendSignatureOrder_ExtendSignatureOrderOutput_SignatureOrder(BaseModel):
-  closedAt: "Optional[DateTimeScalar]" = Field(default=None)
-  documents: (
-    "list[ExtendSignatureOrder_ExtendSignatureOrderOutput_SignatureOrder_Document]"
-  )
-  evidenceProviders: "list[ExtendSignatureOrder_ExtendSignatureOrderOutput_SignatureOrder_SignatureEvidenceProvider]"
-  expiresAt: "DateTimeScalar"
-  id: "IDScalar"
+  closedAt: Optional[DateTimeScalar] = Field(default=None)
+  documents: list[
+    ExtendSignatureOrder_ExtendSignatureOrderOutput_SignatureOrder_Document
+  ]
+  evidenceProviders: list[
+    ExtendSignatureOrder_ExtendSignatureOrderOutput_SignatureOrder_SignatureEvidenceProvider
+  ]
+  expiresAt: DateTimeScalar
+  id: IDScalar
   # Number of max signatories for the signature order
-  maxSignatories: "IntScalar"
+  maxSignatories: IntScalar
   # List of signatories for the signature order.
-  signatories: (
-    "list[ExtendSignatureOrder_ExtendSignatureOrderOutput_SignatureOrder_Signatory]"
-  )
-  status: "SignatureOrderStatus"
-  title: "Optional[StringScalar]" = Field(default=None)
+  signatories: list[
+    ExtendSignatureOrder_ExtendSignatureOrderOutput_SignatureOrder_Signatory
+  ]
+  status: SignatureOrderStatus
+  title: Optional[StringScalar] = Field(default=None)
 
 
 class ExtendSignatureOrder_ExtendSignatureOrderOutput_SignatureOrder_Document(
   BaseModel
 ):
-  id: "IDScalar"
-  reference: "Optional[StringScalar]" = Field(default=None)
-  title: "StringScalar"
+  id: IDScalar
+  reference: Optional[StringScalar] = Field(default=None)
+  title: StringScalar
 
 
 class ExtendSignatureOrder_ExtendSignatureOrderOutput_SignatureOrder_SignatureEvidenceProvider(
   BaseModel
 ):
-  id: "IDScalar"
+  id: IDScalar
 
 
 class ExtendSignatureOrder_ExtendSignatureOrderOutput_SignatureOrder_Signatory(
   BaseModel
 ):
-  documents: "ExtendSignatureOrder_ExtendSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection"
+  documents: ExtendSignatureOrder_ExtendSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection
   # A download link for signatories to download their signed documents. Signatories must verify their identity before downloading. Can be used when signature order is closed with document retention.
-  downloadHref: "Optional[StringScalar]" = Field(default=None)
-  evidenceProviders: "list[ExtendSignatureOrder_ExtendSignatureOrderOutput_SignatureOrder_Signatory_SignatureEvidenceProvider]"
+  downloadHref: Optional[StringScalar] = Field(default=None)
+  evidenceProviders: list[
+    ExtendSignatureOrder_ExtendSignatureOrderOutput_SignatureOrder_Signatory_SignatureEvidenceProvider
+  ]
   # A link to the signatures frontend, you can send this link to your users to enable them to sign your documents.
-  href: "StringScalar"
-  id: "IDScalar"
-  reference: "Optional[StringScalar]" = Field(default=None)
-  role: "Optional[StringScalar]" = Field(default=None)
+  href: StringScalar
+  id: IDScalar
+  reference: Optional[StringScalar] = Field(default=None)
+  role: Optional[StringScalar] = Field(default=None)
   # Signature order for the signatory.
-  signatureOrder: "ExtendSignatureOrder_ExtendSignatureOrderOutput_SignatureOrder_Signatory_SignatureOrder"
+  signatureOrder: ExtendSignatureOrder_ExtendSignatureOrderOutput_SignatureOrder_Signatory_SignatureOrder
   # The current status of the signatory.
-  status: "SignatoryStatus"
+  status: SignatoryStatus
   # The reason for the signatory status (rejection reason when rejected).
-  statusReason: "Optional[StringScalar]" = Field(default=None)
+  statusReason: Optional[StringScalar] = Field(default=None)
 
 
 class ExtendSignatureOrder_ExtendSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection(
   BaseModel
 ):
-  edges: "list[ExtendSignatureOrder_ExtendSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge]"
+  edges: list[
+    ExtendSignatureOrder_ExtendSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge
+  ]
 
 
 class ExtendSignatureOrder_ExtendSignatureOrderOutput_SignatureOrder_Signatory_SignatureEvidenceProvider(
   BaseModel
 ):
-  id: "IDScalar"
+  id: IDScalar
 
 
 class ExtendSignatureOrder_ExtendSignatureOrderOutput_SignatureOrder_Signatory_SignatureOrder(
   BaseModel
 ):
-  closedAt: "Optional[DateTimeScalar]" = Field(default=None)
-  expiresAt: "DateTimeScalar"
-  id: "IDScalar"
-  status: "SignatureOrderStatus"
+  closedAt: Optional[DateTimeScalar] = Field(default=None)
+  expiresAt: DateTimeScalar
+  id: IDScalar
+  status: SignatureOrderStatus
 
 
 class ExtendSignatureOrder_ExtendSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge(
   BaseModel
 ):
-  node: "ExtendSignatureOrder_ExtendSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document"
-  status: "Optional[SignatoryDocumentStatus]" = Field(default=None)
+  node: ExtendSignatureOrder_ExtendSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document
+  status: Optional[SignatoryDocumentStatus] = Field(default=None)
 
 
 class ExtendSignatureOrder_ExtendSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document(
   BaseModel
 ):
-  id: "IDScalar"
+  id: IDScalar
 
 
 extendSignatureOrderDocument = f"""mutation extendSignatureOrder($input: ExtendSignatureOrderInput!) {{
@@ -944,80 +981,86 @@ extendSignatureOrderDocument = f"""mutation extendSignatureOrder($input: ExtendS
 
 
 class DeleteSignatory_DeleteSignatoryOutput(BaseModel):
-  signatureOrder: "DeleteSignatory_DeleteSignatoryOutput_SignatureOrder"
+  signatureOrder: DeleteSignatory_DeleteSignatoryOutput_SignatureOrder
 
 
 class DeleteSignatory_DeleteSignatoryOutput_SignatureOrder(BaseModel):
-  closedAt: "Optional[DateTimeScalar]" = Field(default=None)
-  evidenceProviders: "list[DeleteSignatory_DeleteSignatoryOutput_SignatureOrder_SignatureEvidenceProvider]"
-  expiresAt: "DateTimeScalar"
-  id: "IDScalar"
+  closedAt: Optional[DateTimeScalar] = Field(default=None)
+  evidenceProviders: list[
+    DeleteSignatory_DeleteSignatoryOutput_SignatureOrder_SignatureEvidenceProvider
+  ]
+  expiresAt: DateTimeScalar
+  id: IDScalar
   # Number of max signatories for the signature order
-  maxSignatories: "IntScalar"
+  maxSignatories: IntScalar
   # List of signatories for the signature order.
-  signatories: "list[DeleteSignatory_DeleteSignatoryOutput_SignatureOrder_Signatory]"
-  status: "SignatureOrderStatus"
-  title: "Optional[StringScalar]" = Field(default=None)
+  signatories: list[DeleteSignatory_DeleteSignatoryOutput_SignatureOrder_Signatory]
+  status: SignatureOrderStatus
+  title: Optional[StringScalar] = Field(default=None)
 
 
 class DeleteSignatory_DeleteSignatoryOutput_SignatureOrder_SignatureEvidenceProvider(
   BaseModel
 ):
-  id: "IDScalar"
+  id: IDScalar
 
 
 class DeleteSignatory_DeleteSignatoryOutput_SignatureOrder_Signatory(BaseModel):
-  documents: "DeleteSignatory_DeleteSignatoryOutput_SignatureOrder_Signatory_SignatoryDocumentConnection"
+  documents: DeleteSignatory_DeleteSignatoryOutput_SignatureOrder_Signatory_SignatoryDocumentConnection
   # A download link for signatories to download their signed documents. Signatories must verify their identity before downloading. Can be used when signature order is closed with document retention.
-  downloadHref: "Optional[StringScalar]" = Field(default=None)
-  evidenceProviders: "list[DeleteSignatory_DeleteSignatoryOutput_SignatureOrder_Signatory_SignatureEvidenceProvider]"
+  downloadHref: Optional[StringScalar] = Field(default=None)
+  evidenceProviders: list[
+    DeleteSignatory_DeleteSignatoryOutput_SignatureOrder_Signatory_SignatureEvidenceProvider
+  ]
   # A link to the signatures frontend, you can send this link to your users to enable them to sign your documents.
-  href: "StringScalar"
-  id: "IDScalar"
-  reference: "Optional[StringScalar]" = Field(default=None)
-  role: "Optional[StringScalar]" = Field(default=None)
+  href: StringScalar
+  id: IDScalar
+  reference: Optional[StringScalar] = Field(default=None)
+  role: Optional[StringScalar] = Field(default=None)
   # Signature order for the signatory.
   signatureOrder: (
-    "DeleteSignatory_DeleteSignatoryOutput_SignatureOrder_Signatory_SignatureOrder"
+    DeleteSignatory_DeleteSignatoryOutput_SignatureOrder_Signatory_SignatureOrder
   )
   # The current status of the signatory.
-  status: "SignatoryStatus"
+  status: SignatoryStatus
   # The reason for the signatory status (rejection reason when rejected).
-  statusReason: "Optional[StringScalar]" = Field(default=None)
+  statusReason: Optional[StringScalar] = Field(default=None)
 
 
 class DeleteSignatory_DeleteSignatoryOutput_SignatureOrder_Signatory_SignatoryDocumentConnection(
   BaseModel
 ):
-  edges: "list[DeleteSignatory_DeleteSignatoryOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge]"
+  edges: list[
+    DeleteSignatory_DeleteSignatoryOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge
+  ]
 
 
 class DeleteSignatory_DeleteSignatoryOutput_SignatureOrder_Signatory_SignatureEvidenceProvider(
   BaseModel
 ):
-  id: "IDScalar"
+  id: IDScalar
 
 
 class DeleteSignatory_DeleteSignatoryOutput_SignatureOrder_Signatory_SignatureOrder(
   BaseModel
 ):
-  closedAt: "Optional[DateTimeScalar]" = Field(default=None)
-  expiresAt: "DateTimeScalar"
-  id: "IDScalar"
-  status: "SignatureOrderStatus"
+  closedAt: Optional[DateTimeScalar] = Field(default=None)
+  expiresAt: DateTimeScalar
+  id: IDScalar
+  status: SignatureOrderStatus
 
 
 class DeleteSignatory_DeleteSignatoryOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge(
   BaseModel
 ):
-  node: "DeleteSignatory_DeleteSignatoryOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document"
-  status: "Optional[SignatoryDocumentStatus]" = Field(default=None)
+  node: DeleteSignatory_DeleteSignatoryOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document
+  status: Optional[SignatoryDocumentStatus] = Field(default=None)
 
 
 class DeleteSignatory_DeleteSignatoryOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document(
   BaseModel
 ):
-  id: "IDScalar"
+  id: IDScalar
 
 
 deleteSignatoryDocument = f"""mutation deleteSignatory($input: DeleteSignatoryInput!) {{
@@ -1032,151 +1075,165 @@ deleteSignatoryDocument = f"""mutation deleteSignatory($input: DeleteSignatoryIn
 
 
 class CreateBatchSignatory_CreateBatchSignatoryOutput(BaseModel):
-  batchSignatory: "CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory"
+  batchSignatory: CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory
 
 
 class CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory(BaseModel):
-  href: "StringScalar"
-  id: "IDScalar"
-  items: "list[CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem]"
+  href: StringScalar
+  id: IDScalar
+  items: list[
+    CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem
+  ]
   # The authentication token required for performing batch operations.
-  token: "StringScalar"
+  token: StringScalar
 
 
 class CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem(
   BaseModel
 ):
-  signatory: "CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_Signatory"
-  signatureOrder: "CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_SignatureOrder"
+  signatory: CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_Signatory
+  signatureOrder: CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_SignatureOrder
 
 
 class CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_Signatory(
   BaseModel
 ):
-  documents: "CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_Signatory_SignatoryDocumentConnection"
+  documents: CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_Signatory_SignatoryDocumentConnection
   # A download link for signatories to download their signed documents. Signatories must verify their identity before downloading. Can be used when signature order is closed with document retention.
-  downloadHref: "Optional[StringScalar]" = Field(default=None)
-  evidenceProviders: "list[CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_Signatory_SignatureEvidenceProvider]"
+  downloadHref: Optional[StringScalar] = Field(default=None)
+  evidenceProviders: list[
+    CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_Signatory_SignatureEvidenceProvider
+  ]
   # A link to the signatures frontend, you can send this link to your users to enable them to sign your documents.
-  href: "StringScalar"
-  id: "IDScalar"
-  reference: "Optional[StringScalar]" = Field(default=None)
-  role: "Optional[StringScalar]" = Field(default=None)
+  href: StringScalar
+  id: IDScalar
+  reference: Optional[StringScalar] = Field(default=None)
+  role: Optional[StringScalar] = Field(default=None)
   # Signature order for the signatory.
-  signatureOrder: "CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_Signatory_SignatureOrder"
+  signatureOrder: CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_Signatory_SignatureOrder
   # The current status of the signatory.
-  status: "SignatoryStatus"
+  status: SignatoryStatus
   # The reason for the signatory status (rejection reason when rejected).
-  statusReason: "Optional[StringScalar]" = Field(default=None)
+  statusReason: Optional[StringScalar] = Field(default=None)
 
 
 class CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_SignatureOrder(
   BaseModel
 ):
-  closedAt: "Optional[DateTimeScalar]" = Field(default=None)
-  evidenceProviders: "list[CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_SignatureOrder_SignatureEvidenceProvider]"
-  expiresAt: "DateTimeScalar"
-  id: "IDScalar"
+  closedAt: Optional[DateTimeScalar] = Field(default=None)
+  evidenceProviders: list[
+    CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_SignatureOrder_SignatureEvidenceProvider
+  ]
+  expiresAt: DateTimeScalar
+  id: IDScalar
   # Number of max signatories for the signature order
-  maxSignatories: "IntScalar"
+  maxSignatories: IntScalar
   # List of signatories for the signature order.
-  signatories: "list[CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory]"
-  status: "SignatureOrderStatus"
-  title: "Optional[StringScalar]" = Field(default=None)
+  signatories: list[
+    CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory
+  ]
+  status: SignatureOrderStatus
+  title: Optional[StringScalar] = Field(default=None)
 
 
 class CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_Signatory_SignatoryDocumentConnection(
   BaseModel
 ):
-  edges: "list[CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge]"
+  edges: list[
+    CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge
+  ]
 
 
 class CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_Signatory_SignatureEvidenceProvider(
   BaseModel
 ):
-  id: "IDScalar"
+  id: IDScalar
 
 
 class CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_Signatory_SignatureOrder(
   BaseModel
 ):
-  closedAt: "Optional[DateTimeScalar]" = Field(default=None)
-  expiresAt: "DateTimeScalar"
-  id: "IDScalar"
-  status: "SignatureOrderStatus"
+  closedAt: Optional[DateTimeScalar] = Field(default=None)
+  expiresAt: DateTimeScalar
+  id: IDScalar
+  status: SignatureOrderStatus
 
 
 class CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_SignatureOrder_SignatureEvidenceProvider(
   BaseModel
 ):
-  id: "IDScalar"
+  id: IDScalar
 
 
 class CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory(
   BaseModel
 ):
-  documents: "CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory_SignatoryDocumentConnection"
+  documents: CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory_SignatoryDocumentConnection
   # A download link for signatories to download their signed documents. Signatories must verify their identity before downloading. Can be used when signature order is closed with document retention.
-  downloadHref: "Optional[StringScalar]" = Field(default=None)
-  evidenceProviders: "list[CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory_SignatureEvidenceProvider]"
+  downloadHref: Optional[StringScalar] = Field(default=None)
+  evidenceProviders: list[
+    CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory_SignatureEvidenceProvider
+  ]
   # A link to the signatures frontend, you can send this link to your users to enable them to sign your documents.
-  href: "StringScalar"
-  id: "IDScalar"
-  reference: "Optional[StringScalar]" = Field(default=None)
-  role: "Optional[StringScalar]" = Field(default=None)
+  href: StringScalar
+  id: IDScalar
+  reference: Optional[StringScalar] = Field(default=None)
+  role: Optional[StringScalar] = Field(default=None)
   # Signature order for the signatory.
-  signatureOrder: "CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory_SignatureOrder"
+  signatureOrder: CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory_SignatureOrder
   # The current status of the signatory.
-  status: "SignatoryStatus"
+  status: SignatoryStatus
   # The reason for the signatory status (rejection reason when rejected).
-  statusReason: "Optional[StringScalar]" = Field(default=None)
+  statusReason: Optional[StringScalar] = Field(default=None)
 
 
 class CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge(
   BaseModel
 ):
-  node: "CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document"
-  status: "Optional[SignatoryDocumentStatus]" = Field(default=None)
+  node: CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document
+  status: Optional[SignatoryDocumentStatus] = Field(default=None)
 
 
 class CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory_SignatoryDocumentConnection(
   BaseModel
 ):
-  edges: "list[CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge]"
+  edges: list[
+    CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge
+  ]
 
 
 class CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory_SignatureEvidenceProvider(
   BaseModel
 ):
-  id: "IDScalar"
+  id: IDScalar
 
 
 class CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory_SignatureOrder(
   BaseModel
 ):
-  closedAt: "Optional[DateTimeScalar]" = Field(default=None)
-  expiresAt: "DateTimeScalar"
-  id: "IDScalar"
-  status: "SignatureOrderStatus"
+  closedAt: Optional[DateTimeScalar] = Field(default=None)
+  expiresAt: DateTimeScalar
+  id: IDScalar
+  status: SignatureOrderStatus
 
 
 class CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document(
   BaseModel
 ):
-  id: "IDScalar"
+  id: IDScalar
 
 
 class CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge(
   BaseModel
 ):
-  node: "CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document"
-  status: "Optional[SignatoryDocumentStatus]" = Field(default=None)
+  node: CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document
+  status: Optional[SignatoryDocumentStatus] = Field(default=None)
 
 
 class CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document(
   BaseModel
 ):
-  id: "IDScalar"
+  id: IDScalar
 
 
 createBatchSignatoryDocument = f"""mutation createBatchSignatory($input: CreateBatchSignatoryInput!) {{
@@ -1200,82 +1257,88 @@ createBatchSignatoryDocument = f"""mutation createBatchSignatory($input: CreateB
 
 
 class ChangeSignatureOrder_ChangeSignatureOrderOutput(BaseModel):
-  signatureOrder: "ChangeSignatureOrder_ChangeSignatureOrderOutput_SignatureOrder"
+  signatureOrder: ChangeSignatureOrder_ChangeSignatureOrderOutput_SignatureOrder
 
 
 class ChangeSignatureOrder_ChangeSignatureOrderOutput_SignatureOrder(BaseModel):
-  closedAt: "Optional[DateTimeScalar]" = Field(default=None)
-  evidenceProviders: "list[ChangeSignatureOrder_ChangeSignatureOrderOutput_SignatureOrder_SignatureEvidenceProvider]"
-  expiresAt: "DateTimeScalar"
-  id: "IDScalar"
+  closedAt: Optional[DateTimeScalar] = Field(default=None)
+  evidenceProviders: list[
+    ChangeSignatureOrder_ChangeSignatureOrderOutput_SignatureOrder_SignatureEvidenceProvider
+  ]
+  expiresAt: DateTimeScalar
+  id: IDScalar
   # Number of max signatories for the signature order
-  maxSignatories: "IntScalar"
+  maxSignatories: IntScalar
   # List of signatories for the signature order.
-  signatories: (
-    "list[ChangeSignatureOrder_ChangeSignatureOrderOutput_SignatureOrder_Signatory]"
-  )
-  status: "SignatureOrderStatus"
-  title: "Optional[StringScalar]" = Field(default=None)
+  signatories: list[
+    ChangeSignatureOrder_ChangeSignatureOrderOutput_SignatureOrder_Signatory
+  ]
+  status: SignatureOrderStatus
+  title: Optional[StringScalar] = Field(default=None)
 
 
 class ChangeSignatureOrder_ChangeSignatureOrderOutput_SignatureOrder_SignatureEvidenceProvider(
   BaseModel
 ):
-  id: "IDScalar"
+  id: IDScalar
 
 
 class ChangeSignatureOrder_ChangeSignatureOrderOutput_SignatureOrder_Signatory(
   BaseModel
 ):
-  documents: "ChangeSignatureOrder_ChangeSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection"
+  documents: ChangeSignatureOrder_ChangeSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection
   # A download link for signatories to download their signed documents. Signatories must verify their identity before downloading. Can be used when signature order is closed with document retention.
-  downloadHref: "Optional[StringScalar]" = Field(default=None)
-  evidenceProviders: "list[ChangeSignatureOrder_ChangeSignatureOrderOutput_SignatureOrder_Signatory_SignatureEvidenceProvider]"
+  downloadHref: Optional[StringScalar] = Field(default=None)
+  evidenceProviders: list[
+    ChangeSignatureOrder_ChangeSignatureOrderOutput_SignatureOrder_Signatory_SignatureEvidenceProvider
+  ]
   # A link to the signatures frontend, you can send this link to your users to enable them to sign your documents.
-  href: "StringScalar"
-  id: "IDScalar"
-  reference: "Optional[StringScalar]" = Field(default=None)
-  role: "Optional[StringScalar]" = Field(default=None)
+  href: StringScalar
+  id: IDScalar
+  reference: Optional[StringScalar] = Field(default=None)
+  role: Optional[StringScalar] = Field(default=None)
   # Signature order for the signatory.
-  signatureOrder: "ChangeSignatureOrder_ChangeSignatureOrderOutput_SignatureOrder_Signatory_SignatureOrder"
+  signatureOrder: ChangeSignatureOrder_ChangeSignatureOrderOutput_SignatureOrder_Signatory_SignatureOrder
   # The current status of the signatory.
-  status: "SignatoryStatus"
+  status: SignatoryStatus
   # The reason for the signatory status (rejection reason when rejected).
-  statusReason: "Optional[StringScalar]" = Field(default=None)
+  statusReason: Optional[StringScalar] = Field(default=None)
 
 
 class ChangeSignatureOrder_ChangeSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection(
   BaseModel
 ):
-  edges: "list[ChangeSignatureOrder_ChangeSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge]"
+  edges: list[
+    ChangeSignatureOrder_ChangeSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge
+  ]
 
 
 class ChangeSignatureOrder_ChangeSignatureOrderOutput_SignatureOrder_Signatory_SignatureEvidenceProvider(
   BaseModel
 ):
-  id: "IDScalar"
+  id: IDScalar
 
 
 class ChangeSignatureOrder_ChangeSignatureOrderOutput_SignatureOrder_Signatory_SignatureOrder(
   BaseModel
 ):
-  closedAt: "Optional[DateTimeScalar]" = Field(default=None)
-  expiresAt: "DateTimeScalar"
-  id: "IDScalar"
-  status: "SignatureOrderStatus"
+  closedAt: Optional[DateTimeScalar] = Field(default=None)
+  expiresAt: DateTimeScalar
+  id: IDScalar
+  status: SignatureOrderStatus
 
 
 class ChangeSignatureOrder_ChangeSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge(
   BaseModel
 ):
-  node: "ChangeSignatureOrder_ChangeSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document"
-  status: "Optional[SignatoryDocumentStatus]" = Field(default=None)
+  node: ChangeSignatureOrder_ChangeSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document
+  status: Optional[SignatoryDocumentStatus] = Field(default=None)
 
 
 class ChangeSignatureOrder_ChangeSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document(
   BaseModel
 ):
-  id: "IDScalar"
+  id: IDScalar
 
 
 changeSignatureOrderDocument = f"""mutation changeSignatureOrder($input: ChangeSignatureOrderInput!) {{
@@ -1290,72 +1353,72 @@ changeSignatureOrderDocument = f"""mutation changeSignatureOrder($input: ChangeS
 
 
 class QuerySignatureOrder_SignatureOrder(BaseModel):
-  closedAt: "Optional[DateTimeScalar]" = Field(default=None)
-  evidenceProviders: (
-    "list[QuerySignatureOrder_SignatureOrder_SignatureEvidenceProvider]"
-  )
-  expiresAt: "DateTimeScalar"
-  id: "IDScalar"
+  closedAt: Optional[DateTimeScalar] = Field(default=None)
+  evidenceProviders: list[QuerySignatureOrder_SignatureOrder_SignatureEvidenceProvider]
+  expiresAt: DateTimeScalar
+  id: IDScalar
   # Number of max signatories for the signature order
-  maxSignatories: "IntScalar"
+  maxSignatories: IntScalar
   # List of signatories for the signature order.
-  signatories: "list[QuerySignatureOrder_SignatureOrder_Signatory]"
-  status: "SignatureOrderStatus"
-  title: "Optional[StringScalar]" = Field(default=None)
+  signatories: list[QuerySignatureOrder_SignatureOrder_Signatory]
+  status: SignatureOrderStatus
+  title: Optional[StringScalar] = Field(default=None)
 
 
 class QuerySignatureOrder_SignatureOrder_SignatureEvidenceProvider(BaseModel):
-  id: "IDScalar"
+  id: IDScalar
 
 
 class QuerySignatureOrder_SignatureOrder_Signatory(BaseModel):
-  documents: "QuerySignatureOrder_SignatureOrder_Signatory_SignatoryDocumentConnection"
+  documents: QuerySignatureOrder_SignatureOrder_Signatory_SignatoryDocumentConnection
   # A download link for signatories to download their signed documents. Signatories must verify their identity before downloading. Can be used when signature order is closed with document retention.
-  downloadHref: "Optional[StringScalar]" = Field(default=None)
-  evidenceProviders: (
-    "list[QuerySignatureOrder_SignatureOrder_Signatory_SignatureEvidenceProvider]"
-  )
+  downloadHref: Optional[StringScalar] = Field(default=None)
+  evidenceProviders: list[
+    QuerySignatureOrder_SignatureOrder_Signatory_SignatureEvidenceProvider
+  ]
   # A link to the signatures frontend, you can send this link to your users to enable them to sign your documents.
-  href: "StringScalar"
-  id: "IDScalar"
-  reference: "Optional[StringScalar]" = Field(default=None)
-  role: "Optional[StringScalar]" = Field(default=None)
+  href: StringScalar
+  id: IDScalar
+  reference: Optional[StringScalar] = Field(default=None)
+  role: Optional[StringScalar] = Field(default=None)
   # Signature order for the signatory.
-  signatureOrder: "QuerySignatureOrder_SignatureOrder_Signatory_SignatureOrder"
+  signatureOrder: QuerySignatureOrder_SignatureOrder_Signatory_SignatureOrder
   # The current status of the signatory.
-  status: "SignatoryStatus"
+  status: SignatoryStatus
   # The reason for the signatory status (rejection reason when rejected).
-  statusReason: "Optional[StringScalar]" = Field(default=None)
+  statusReason: Optional[StringScalar] = Field(default=None)
 
 
 class QuerySignatureOrder_SignatureOrder_Signatory_SignatoryDocumentConnection(
   BaseModel
 ):
-  edges: "list[QuerySignatureOrder_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge]"
+  edges: list[
+    QuerySignatureOrder_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge
+  ]
 
 
 class QuerySignatureOrder_SignatureOrder_Signatory_SignatureEvidenceProvider(BaseModel):
-  id: "IDScalar"
+  id: IDScalar
 
 
 class QuerySignatureOrder_SignatureOrder_Signatory_SignatureOrder(BaseModel):
-  closedAt: "Optional[DateTimeScalar]" = Field(default=None)
-  expiresAt: "DateTimeScalar"
-  id: "IDScalar"
-  status: "SignatureOrderStatus"
+  closedAt: Optional[DateTimeScalar] = Field(default=None)
+  expiresAt: DateTimeScalar
+  id: IDScalar
+  status: SignatureOrderStatus
 
 
 class QuerySignatureOrder_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge(
   BaseModel
 ):
-  node: "QuerySignatureOrder_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document"
-  status: "Optional[SignatoryDocumentStatus]" = Field(default=None)
+  node: QuerySignatureOrder_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document
+  status: Optional[SignatoryDocumentStatus] = Field(default=None)
 
 
 class QuerySignatureOrder_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document(
   BaseModel
 ):
-  id: "IDScalar"
+  id: IDScalar
 
 
 querySignatureOrderDocument = f"""query signatureOrder($id: ID!) {{
@@ -1368,102 +1431,106 @@ querySignatureOrderDocument = f"""query signatureOrder($id: ID!) {{
 
 
 class QuerySignatureOrderWithDocuments_SignatureOrder(BaseModel):
-  closedAt: "Optional[DateTimeScalar]" = Field(default=None)
-  documents: "list[QuerySignatureOrderWithDocuments_SignatureOrder_Document]"
-  evidenceProviders: (
-    "list[QuerySignatureOrderWithDocuments_SignatureOrder_SignatureEvidenceProvider]"
-  )
-  expiresAt: "DateTimeScalar"
-  id: "IDScalar"
+  closedAt: Optional[DateTimeScalar] = Field(default=None)
+  documents: list[QuerySignatureOrderWithDocuments_SignatureOrder_Document]
+  evidenceProviders: list[
+    QuerySignatureOrderWithDocuments_SignatureOrder_SignatureEvidenceProvider
+  ]
+  expiresAt: DateTimeScalar
+  id: IDScalar
   # Number of max signatories for the signature order
-  maxSignatories: "IntScalar"
+  maxSignatories: IntScalar
   # List of signatories for the signature order.
-  signatories: "list[QuerySignatureOrderWithDocuments_SignatureOrder_Signatory]"
-  status: "SignatureOrderStatus"
-  title: "Optional[StringScalar]" = Field(default=None)
+  signatories: list[QuerySignatureOrderWithDocuments_SignatureOrder_Signatory]
+  status: SignatureOrderStatus
+  title: Optional[StringScalar] = Field(default=None)
 
 
 class QuerySignatureOrderWithDocuments_SignatureOrder_Document(BaseModel):
-  blob: "Optional[BlobScalar]" = Field(default=None)
-  id: "IDScalar"
-  reference: "Optional[StringScalar]" = Field(default=None)
-  signatures: "Optional[list[QuerySignatureOrderWithDocuments_SignatureOrder_Document_Signature]]" = Field(
-    default=None
-  )
-  title: "StringScalar"
+  blob: Optional[BlobScalar] = Field(default=None)
+  id: IDScalar
+  reference: Optional[StringScalar] = Field(default=None)
+  signatures: Optional[
+    list[QuerySignatureOrderWithDocuments_SignatureOrder_Document_Signature]
+  ] = Field(default=None)
+  title: StringScalar
 
 
 class QuerySignatureOrderWithDocuments_SignatureOrder_SignatureEvidenceProvider(
   BaseModel
 ):
-  id: "IDScalar"
+  id: IDScalar
 
 
 class QuerySignatureOrderWithDocuments_SignatureOrder_Signatory(BaseModel):
-  documents: "QuerySignatureOrderWithDocuments_SignatureOrder_Signatory_SignatoryDocumentConnection"
+  documents: QuerySignatureOrderWithDocuments_SignatureOrder_Signatory_SignatoryDocumentConnection
   # A download link for signatories to download their signed documents. Signatories must verify their identity before downloading. Can be used when signature order is closed with document retention.
-  downloadHref: "Optional[StringScalar]" = Field(default=None)
-  evidenceProviders: "list[QuerySignatureOrderWithDocuments_SignatureOrder_Signatory_SignatureEvidenceProvider]"
+  downloadHref: Optional[StringScalar] = Field(default=None)
+  evidenceProviders: list[
+    QuerySignatureOrderWithDocuments_SignatureOrder_Signatory_SignatureEvidenceProvider
+  ]
   # A link to the signatures frontend, you can send this link to your users to enable them to sign your documents.
-  href: "StringScalar"
-  id: "IDScalar"
-  reference: "Optional[StringScalar]" = Field(default=None)
-  role: "Optional[StringScalar]" = Field(default=None)
+  href: StringScalar
+  id: IDScalar
+  reference: Optional[StringScalar] = Field(default=None)
+  role: Optional[StringScalar] = Field(default=None)
   # Signature order for the signatory.
   signatureOrder: (
-    "QuerySignatureOrderWithDocuments_SignatureOrder_Signatory_SignatureOrder"
+    QuerySignatureOrderWithDocuments_SignatureOrder_Signatory_SignatureOrder
   )
   # The current status of the signatory.
-  status: "SignatoryStatus"
+  status: SignatoryStatus
   # The reason for the signatory status (rejection reason when rejected).
-  statusReason: "Optional[StringScalar]" = Field(default=None)
+  statusReason: Optional[StringScalar] = Field(default=None)
 
 
 # Represents a signature on a document.
 class QuerySignatureOrderWithDocuments_SignatureOrder_Document_Signature(BaseModel):
-  signatory: "Optional[QuerySignatureOrderWithDocuments_SignatureOrder_Document_Signature_Signatory]" = Field(
-    default=None
-  )
+  signatory: Optional[
+    QuerySignatureOrderWithDocuments_SignatureOrder_Document_Signature_Signatory
+  ] = Field(default=None)
 
 
 class QuerySignatureOrderWithDocuments_SignatureOrder_Signatory_SignatoryDocumentConnection(
   BaseModel
 ):
-  edges: "list[QuerySignatureOrderWithDocuments_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge]"
+  edges: list[
+    QuerySignatureOrderWithDocuments_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge
+  ]
 
 
 class QuerySignatureOrderWithDocuments_SignatureOrder_Signatory_SignatureEvidenceProvider(
   BaseModel
 ):
-  id: "IDScalar"
+  id: IDScalar
 
 
 class QuerySignatureOrderWithDocuments_SignatureOrder_Signatory_SignatureOrder(
   BaseModel
 ):
-  closedAt: "Optional[DateTimeScalar]" = Field(default=None)
-  expiresAt: "DateTimeScalar"
-  id: "IDScalar"
-  status: "SignatureOrderStatus"
+  closedAt: Optional[DateTimeScalar] = Field(default=None)
+  expiresAt: DateTimeScalar
+  id: IDScalar
+  status: SignatureOrderStatus
 
 
 class QuerySignatureOrderWithDocuments_SignatureOrder_Document_Signature_Signatory(
   BaseModel
 ):
-  id: "IDScalar"
+  id: IDScalar
 
 
 class QuerySignatureOrderWithDocuments_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge(
   BaseModel
 ):
-  node: "QuerySignatureOrderWithDocuments_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document"
-  status: "Optional[SignatoryDocumentStatus]" = Field(default=None)
+  node: QuerySignatureOrderWithDocuments_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document
+  status: Optional[SignatoryDocumentStatus] = Field(default=None)
 
 
 class QuerySignatureOrderWithDocuments_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document(
   BaseModel
 ):
-  id: "IDScalar"
+  id: IDScalar
 
 
 querySignatureOrderWithDocumentsDocument = f"""query signatureOrderWithDocuments($id: ID!) {{
@@ -1482,117 +1549,121 @@ querySignatureOrderWithDocumentsDocument = f"""query signatureOrderWithDocuments
 
 
 class QuerySignatory_Signatory(BaseModel):
-  documents: "QuerySignatory_Signatory_SignatoryDocumentConnection"
+  documents: QuerySignatory_Signatory_SignatoryDocumentConnection
   # A download link for signatories to download their signed documents. Signatories must verify their identity before downloading. Can be used when signature order is closed with document retention.
-  downloadHref: "Optional[StringScalar]" = Field(default=None)
-  evidenceProviders: "list[QuerySignatory_Signatory_SignatureEvidenceProvider]"
+  downloadHref: Optional[StringScalar] = Field(default=None)
+  evidenceProviders: list[QuerySignatory_Signatory_SignatureEvidenceProvider]
   # A link to the signatures frontend, you can send this link to your users to enable them to sign your documents.
-  href: "StringScalar"
-  id: "IDScalar"
-  reference: "Optional[StringScalar]" = Field(default=None)
-  role: "Optional[StringScalar]" = Field(default=None)
+  href: StringScalar
+  id: IDScalar
+  reference: Optional[StringScalar] = Field(default=None)
+  role: Optional[StringScalar] = Field(default=None)
   # Signature order for the signatory.
-  signatureOrder: "QuerySignatory_Signatory_SignatureOrder"
+  signatureOrder: QuerySignatory_Signatory_SignatureOrder
   # The current status of the signatory.
-  status: "SignatoryStatus"
+  status: SignatoryStatus
   # The reason for the signatory status (rejection reason when rejected).
-  statusReason: "Optional[StringScalar]" = Field(default=None)
+  statusReason: Optional[StringScalar] = Field(default=None)
 
 
 class QuerySignatory_Signatory_SignatoryDocumentConnection(BaseModel):
-  edges: (
-    "list[QuerySignatory_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge]"
-  )
+  edges: list[
+    QuerySignatory_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge
+  ]
 
 
 class QuerySignatory_Signatory_SignatureEvidenceProvider(BaseModel):
-  id: "IDScalar"
+  id: IDScalar
 
 
 class QuerySignatory_Signatory_SignatureOrder(BaseModel):
-  closedAt: "Optional[DateTimeScalar]" = Field(default=None)
-  evidenceProviders: (
-    "list[QuerySignatory_Signatory_SignatureOrder_SignatureEvidenceProvider]"
-  )
-  expiresAt: "DateTimeScalar"
-  id: "IDScalar"
+  closedAt: Optional[DateTimeScalar] = Field(default=None)
+  evidenceProviders: list[
+    QuerySignatory_Signatory_SignatureOrder_SignatureEvidenceProvider
+  ]
+  expiresAt: DateTimeScalar
+  id: IDScalar
   # Number of max signatories for the signature order
-  maxSignatories: "IntScalar"
+  maxSignatories: IntScalar
   # List of signatories for the signature order.
-  signatories: "list[QuerySignatory_Signatory_SignatureOrder_Signatory]"
-  status: "SignatureOrderStatus"
-  title: "Optional[StringScalar]" = Field(default=None)
+  signatories: list[QuerySignatory_Signatory_SignatureOrder_Signatory]
+  status: SignatureOrderStatus
+  title: Optional[StringScalar] = Field(default=None)
 
 
 class QuerySignatory_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge(
   BaseModel
 ):
-  node: "QuerySignatory_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document"
-  status: "Optional[SignatoryDocumentStatus]" = Field(default=None)
+  node: (
+    QuerySignatory_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document
+  )
+  status: Optional[SignatoryDocumentStatus] = Field(default=None)
 
 
 class QuerySignatory_Signatory_SignatureOrder_SignatureEvidenceProvider(BaseModel):
-  id: "IDScalar"
+  id: IDScalar
 
 
 class QuerySignatory_Signatory_SignatureOrder_Signatory(BaseModel):
   documents: (
-    "QuerySignatory_Signatory_SignatureOrder_Signatory_SignatoryDocumentConnection"
+    QuerySignatory_Signatory_SignatureOrder_Signatory_SignatoryDocumentConnection
   )
   # A download link for signatories to download their signed documents. Signatories must verify their identity before downloading. Can be used when signature order is closed with document retention.
-  downloadHref: "Optional[StringScalar]" = Field(default=None)
-  evidenceProviders: (
-    "list[QuerySignatory_Signatory_SignatureOrder_Signatory_SignatureEvidenceProvider]"
-  )
+  downloadHref: Optional[StringScalar] = Field(default=None)
+  evidenceProviders: list[
+    QuerySignatory_Signatory_SignatureOrder_Signatory_SignatureEvidenceProvider
+  ]
   # A link to the signatures frontend, you can send this link to your users to enable them to sign your documents.
-  href: "StringScalar"
-  id: "IDScalar"
-  reference: "Optional[StringScalar]" = Field(default=None)
-  role: "Optional[StringScalar]" = Field(default=None)
+  href: StringScalar
+  id: IDScalar
+  reference: Optional[StringScalar] = Field(default=None)
+  role: Optional[StringScalar] = Field(default=None)
   # Signature order for the signatory.
-  signatureOrder: "QuerySignatory_Signatory_SignatureOrder_Signatory_SignatureOrder"
+  signatureOrder: QuerySignatory_Signatory_SignatureOrder_Signatory_SignatureOrder
   # The current status of the signatory.
-  status: "SignatoryStatus"
+  status: SignatoryStatus
   # The reason for the signatory status (rejection reason when rejected).
-  statusReason: "Optional[StringScalar]" = Field(default=None)
+  statusReason: Optional[StringScalar] = Field(default=None)
 
 
 class QuerySignatory_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document(
   BaseModel
 ):
-  id: "IDScalar"
+  id: IDScalar
 
 
 class QuerySignatory_Signatory_SignatureOrder_Signatory_SignatoryDocumentConnection(
   BaseModel
 ):
-  edges: "list[QuerySignatory_Signatory_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge]"
+  edges: list[
+    QuerySignatory_Signatory_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge
+  ]
 
 
 class QuerySignatory_Signatory_SignatureOrder_Signatory_SignatureEvidenceProvider(
   BaseModel
 ):
-  id: "IDScalar"
+  id: IDScalar
 
 
 class QuerySignatory_Signatory_SignatureOrder_Signatory_SignatureOrder(BaseModel):
-  closedAt: "Optional[DateTimeScalar]" = Field(default=None)
-  expiresAt: "DateTimeScalar"
-  id: "IDScalar"
-  status: "SignatureOrderStatus"
+  closedAt: Optional[DateTimeScalar] = Field(default=None)
+  expiresAt: DateTimeScalar
+  id: IDScalar
+  status: SignatureOrderStatus
 
 
 class QuerySignatory_Signatory_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge(
   BaseModel
 ):
-  node: "QuerySignatory_Signatory_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document"
-  status: "Optional[SignatoryDocumentStatus]" = Field(default=None)
+  node: QuerySignatory_Signatory_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document
+  status: Optional[SignatoryDocumentStatus] = Field(default=None)
 
 
 class QuerySignatory_Signatory_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document(
   BaseModel
 ):
-  id: "IDScalar"
+  id: IDScalar
 
 
 querySignatoryDocument = f"""query signatory($id: ID!) {{
@@ -1630,143 +1701,155 @@ querySignatureOrdersDocument = f"""query signatureOrders($status: SignatureOrder
 
 
 class QueryBatchSignatory_BatchSignatory(BaseModel):
-  href: "StringScalar"
-  id: "IDScalar"
-  items: "list[QueryBatchSignatory_BatchSignatory_BatchSignatoryItem]"
+  href: StringScalar
+  id: IDScalar
+  items: list[QueryBatchSignatory_BatchSignatory_BatchSignatoryItem]
   # The authentication token required for performing batch operations.
-  token: "StringScalar"
+  token: StringScalar
 
 
 class QueryBatchSignatory_BatchSignatory_BatchSignatoryItem(BaseModel):
-  signatory: "QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_Signatory"
-  signatureOrder: "QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_SignatureOrder"
+  signatory: QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_Signatory
+  signatureOrder: QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_SignatureOrder
 
 
 class QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_Signatory(BaseModel):
-  documents: "QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_Signatory_SignatoryDocumentConnection"
+  documents: QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_Signatory_SignatoryDocumentConnection
   # A download link for signatories to download their signed documents. Signatories must verify their identity before downloading. Can be used when signature order is closed with document retention.
-  downloadHref: "Optional[StringScalar]" = Field(default=None)
-  evidenceProviders: "list[QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_Signatory_SignatureEvidenceProvider]"
+  downloadHref: Optional[StringScalar] = Field(default=None)
+  evidenceProviders: list[
+    QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_Signatory_SignatureEvidenceProvider
+  ]
   # A link to the signatures frontend, you can send this link to your users to enable them to sign your documents.
-  href: "StringScalar"
-  id: "IDScalar"
-  reference: "Optional[StringScalar]" = Field(default=None)
-  role: "Optional[StringScalar]" = Field(default=None)
+  href: StringScalar
+  id: IDScalar
+  reference: Optional[StringScalar] = Field(default=None)
+  role: Optional[StringScalar] = Field(default=None)
   # Signature order for the signatory.
   signatureOrder: (
-    "QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_Signatory_SignatureOrder"
+    QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_Signatory_SignatureOrder
   )
   # The current status of the signatory.
-  status: "SignatoryStatus"
+  status: SignatoryStatus
   # The reason for the signatory status (rejection reason when rejected).
-  statusReason: "Optional[StringScalar]" = Field(default=None)
+  statusReason: Optional[StringScalar] = Field(default=None)
 
 
 class QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_SignatureOrder(BaseModel):
-  closedAt: "Optional[DateTimeScalar]" = Field(default=None)
-  evidenceProviders: "list[QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_SignatureOrder_SignatureEvidenceProvider]"
-  expiresAt: "DateTimeScalar"
-  id: "IDScalar"
+  closedAt: Optional[DateTimeScalar] = Field(default=None)
+  evidenceProviders: list[
+    QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_SignatureOrder_SignatureEvidenceProvider
+  ]
+  expiresAt: DateTimeScalar
+  id: IDScalar
   # Number of max signatories for the signature order
-  maxSignatories: "IntScalar"
+  maxSignatories: IntScalar
   # List of signatories for the signature order.
-  signatories: "list[QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory]"
-  status: "SignatureOrderStatus"
-  title: "Optional[StringScalar]" = Field(default=None)
+  signatories: list[
+    QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory
+  ]
+  status: SignatureOrderStatus
+  title: Optional[StringScalar] = Field(default=None)
 
 
 class QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_Signatory_SignatoryDocumentConnection(
   BaseModel
 ):
-  edges: "list[QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge]"
+  edges: list[
+    QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge
+  ]
 
 
 class QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_Signatory_SignatureEvidenceProvider(
   BaseModel
 ):
-  id: "IDScalar"
+  id: IDScalar
 
 
 class QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_Signatory_SignatureOrder(
   BaseModel
 ):
-  closedAt: "Optional[DateTimeScalar]" = Field(default=None)
-  expiresAt: "DateTimeScalar"
-  id: "IDScalar"
-  status: "SignatureOrderStatus"
+  closedAt: Optional[DateTimeScalar] = Field(default=None)
+  expiresAt: DateTimeScalar
+  id: IDScalar
+  status: SignatureOrderStatus
 
 
 class QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_SignatureOrder_SignatureEvidenceProvider(
   BaseModel
 ):
-  id: "IDScalar"
+  id: IDScalar
 
 
 class QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory(
   BaseModel
 ):
-  documents: "QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory_SignatoryDocumentConnection"
+  documents: QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory_SignatoryDocumentConnection
   # A download link for signatories to download their signed documents. Signatories must verify their identity before downloading. Can be used when signature order is closed with document retention.
-  downloadHref: "Optional[StringScalar]" = Field(default=None)
-  evidenceProviders: "list[QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory_SignatureEvidenceProvider]"
+  downloadHref: Optional[StringScalar] = Field(default=None)
+  evidenceProviders: list[
+    QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory_SignatureEvidenceProvider
+  ]
   # A link to the signatures frontend, you can send this link to your users to enable them to sign your documents.
-  href: "StringScalar"
-  id: "IDScalar"
-  reference: "Optional[StringScalar]" = Field(default=None)
-  role: "Optional[StringScalar]" = Field(default=None)
+  href: StringScalar
+  id: IDScalar
+  reference: Optional[StringScalar] = Field(default=None)
+  role: Optional[StringScalar] = Field(default=None)
   # Signature order for the signatory.
-  signatureOrder: "QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory_SignatureOrder"
+  signatureOrder: QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory_SignatureOrder
   # The current status of the signatory.
-  status: "SignatoryStatus"
+  status: SignatoryStatus
   # The reason for the signatory status (rejection reason when rejected).
-  statusReason: "Optional[StringScalar]" = Field(default=None)
+  statusReason: Optional[StringScalar] = Field(default=None)
 
 
 class QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge(
   BaseModel
 ):
-  node: "QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document"
-  status: "Optional[SignatoryDocumentStatus]" = Field(default=None)
+  node: QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document
+  status: Optional[SignatoryDocumentStatus] = Field(default=None)
 
 
 class QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory_SignatoryDocumentConnection(
   BaseModel
 ):
-  edges: "list[QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge]"
+  edges: list[
+    QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge
+  ]
 
 
 class QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory_SignatureEvidenceProvider(
   BaseModel
 ):
-  id: "IDScalar"
+  id: IDScalar
 
 
 class QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory_SignatureOrder(
   BaseModel
 ):
-  closedAt: "Optional[DateTimeScalar]" = Field(default=None)
-  expiresAt: "DateTimeScalar"
-  id: "IDScalar"
-  status: "SignatureOrderStatus"
+  closedAt: Optional[DateTimeScalar] = Field(default=None)
+  expiresAt: DateTimeScalar
+  id: IDScalar
+  status: SignatureOrderStatus
 
 
 class QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document(
   BaseModel
 ):
-  id: "IDScalar"
+  id: IDScalar
 
 
 class QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge(
   BaseModel
 ):
-  node: "QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document"
-  status: "Optional[SignatoryDocumentStatus]" = Field(default=None)
+  node: QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document
+  status: Optional[SignatoryDocumentStatus] = Field(default=None)
 
 
 class QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document(
   BaseModel
 ):
-  id: "IDScalar"
+  id: IDScalar
 
 
 queryBatchSignatoryDocument = f"""query batchSignatory($id: ID!) {{

--- a/packages/python/src/criipto_signatures/operations.py
+++ b/packages/python/src/criipto_signatures/operations.py
@@ -18,15 +18,24 @@ from .models import (
   ChangeSignatureOrderInput,
 )
 from .models import (
-  IDScalar,
-  StringScalar,
-  BooleanScalar,
-  IntScalar,
-  BlobScalar,
-  DateScalar,
-  DateTimeScalar,
-  FloatScalar,
-  URIScalar,
+  IDScalarInput,
+  IDScalarOutput,
+  StringScalarInput,
+  StringScalarOutput,
+  BooleanScalarInput,
+  BooleanScalarOutput,
+  IntScalarInput,
+  IntScalarOutput,
+  BlobScalarInput,
+  BlobScalarOutput,
+  DateScalarInput,
+  DateScalarOutput,
+  DateTimeScalarInput,
+  DateTimeScalarOutput,
+  FloatScalarInput,
+  FloatScalarOutput,
+  URIScalarInput,
+  URIScalarOutput,
 )
 from .models import (
   ApplicationApiKeyMode,
@@ -133,37 +142,37 @@ class CreateSignatureOrder_CreateSignatureOrderOutput(BaseModel):
 
 
 class CreateSignatureOrder_CreateSignatureOrderOutput_SignatureOrder(BaseModel):
-  closedAt: Optional[DateTimeScalar] = Field(default=None)
+  closedAt: Optional[DateTimeScalarOutput] = Field(default=None)
   documents: list[
     CreateSignatureOrder_CreateSignatureOrderOutput_SignatureOrder_Document
   ]
   evidenceProviders: list[
     CreateSignatureOrder_CreateSignatureOrderOutput_SignatureOrder_SignatureEvidenceProvider
   ]
-  expiresAt: DateTimeScalar
-  id: IDScalar
+  expiresAt: DateTimeScalarOutput
+  id: IDScalarOutput
   # Number of max signatories for the signature order
-  maxSignatories: IntScalar
+  maxSignatories: IntScalarOutput
   # List of signatories for the signature order.
   signatories: list[
     CreateSignatureOrder_CreateSignatureOrderOutput_SignatureOrder_Signatory
   ]
   status: SignatureOrderStatus
-  title: Optional[StringScalar] = Field(default=None)
+  title: Optional[StringScalarOutput] = Field(default=None)
 
 
 class CreateSignatureOrder_CreateSignatureOrderOutput_SignatureOrder_Document(
   BaseModel
 ):
-  id: IDScalar
-  reference: Optional[StringScalar] = Field(default=None)
-  title: StringScalar
+  id: IDScalarOutput
+  reference: Optional[StringScalarOutput] = Field(default=None)
+  title: StringScalarOutput
 
 
 class CreateSignatureOrder_CreateSignatureOrderOutput_SignatureOrder_SignatureEvidenceProvider(
   BaseModel
 ):
-  id: IDScalar
+  id: IDScalarOutput
 
 
 class CreateSignatureOrder_CreateSignatureOrderOutput_SignatureOrder_Signatory(
@@ -171,21 +180,21 @@ class CreateSignatureOrder_CreateSignatureOrderOutput_SignatureOrder_Signatory(
 ):
   documents: CreateSignatureOrder_CreateSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection
   # A download link for signatories to download their signed documents. Signatories must verify their identity before downloading. Can be used when signature order is closed with document retention.
-  downloadHref: Optional[StringScalar] = Field(default=None)
+  downloadHref: Optional[StringScalarOutput] = Field(default=None)
   evidenceProviders: list[
     CreateSignatureOrder_CreateSignatureOrderOutput_SignatureOrder_Signatory_SignatureEvidenceProvider
   ]
   # A link to the signatures frontend, you can send this link to your users to enable them to sign your documents.
-  href: StringScalar
-  id: IDScalar
-  reference: Optional[StringScalar] = Field(default=None)
-  role: Optional[StringScalar] = Field(default=None)
+  href: StringScalarOutput
+  id: IDScalarOutput
+  reference: Optional[StringScalarOutput] = Field(default=None)
+  role: Optional[StringScalarOutput] = Field(default=None)
   # Signature order for the signatory.
   signatureOrder: CreateSignatureOrder_CreateSignatureOrderOutput_SignatureOrder_Signatory_SignatureOrder
   # The current status of the signatory.
   status: SignatoryStatus
   # The reason for the signatory status (rejection reason when rejected).
-  statusReason: Optional[StringScalar] = Field(default=None)
+  statusReason: Optional[StringScalarOutput] = Field(default=None)
 
 
 class CreateSignatureOrder_CreateSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection(
@@ -199,15 +208,15 @@ class CreateSignatureOrder_CreateSignatureOrderOutput_SignatureOrder_Signatory_S
 class CreateSignatureOrder_CreateSignatureOrderOutput_SignatureOrder_Signatory_SignatureEvidenceProvider(
   BaseModel
 ):
-  id: IDScalar
+  id: IDScalarOutput
 
 
 class CreateSignatureOrder_CreateSignatureOrderOutput_SignatureOrder_Signatory_SignatureOrder(
   BaseModel
 ):
-  closedAt: Optional[DateTimeScalar] = Field(default=None)
-  expiresAt: DateTimeScalar
-  id: IDScalar
+  closedAt: Optional[DateTimeScalarOutput] = Field(default=None)
+  expiresAt: DateTimeScalarOutput
+  id: IDScalarOutput
   status: SignatureOrderStatus
 
 
@@ -221,7 +230,7 @@ class CreateSignatureOrder_CreateSignatureOrderOutput_SignatureOrder_Signatory_S
 class CreateSignatureOrder_CreateSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document(
   BaseModel
 ):
-  id: IDScalar
+  id: IDScalarOutput
 
 
 createSignatureOrderDocument = f"""mutation createSignatureOrder($input: CreateSignatureOrderInput!) {{
@@ -244,37 +253,37 @@ class CleanupSignatureOrder_CleanupSignatureOrderOutput(BaseModel):
 
 
 class CleanupSignatureOrder_CleanupSignatureOrderOutput_SignatureOrder(BaseModel):
-  closedAt: Optional[DateTimeScalar] = Field(default=None)
+  closedAt: Optional[DateTimeScalarOutput] = Field(default=None)
   documents: list[
     CleanupSignatureOrder_CleanupSignatureOrderOutput_SignatureOrder_Document
   ]
   evidenceProviders: list[
     CleanupSignatureOrder_CleanupSignatureOrderOutput_SignatureOrder_SignatureEvidenceProvider
   ]
-  expiresAt: DateTimeScalar
-  id: IDScalar
+  expiresAt: DateTimeScalarOutput
+  id: IDScalarOutput
   # Number of max signatories for the signature order
-  maxSignatories: IntScalar
+  maxSignatories: IntScalarOutput
   # List of signatories for the signature order.
   signatories: list[
     CleanupSignatureOrder_CleanupSignatureOrderOutput_SignatureOrder_Signatory
   ]
   status: SignatureOrderStatus
-  title: Optional[StringScalar] = Field(default=None)
+  title: Optional[StringScalarOutput] = Field(default=None)
 
 
 class CleanupSignatureOrder_CleanupSignatureOrderOutput_SignatureOrder_Document(
   BaseModel
 ):
-  id: IDScalar
-  reference: Optional[StringScalar] = Field(default=None)
-  title: StringScalar
+  id: IDScalarOutput
+  reference: Optional[StringScalarOutput] = Field(default=None)
+  title: StringScalarOutput
 
 
 class CleanupSignatureOrder_CleanupSignatureOrderOutput_SignatureOrder_SignatureEvidenceProvider(
   BaseModel
 ):
-  id: IDScalar
+  id: IDScalarOutput
 
 
 class CleanupSignatureOrder_CleanupSignatureOrderOutput_SignatureOrder_Signatory(
@@ -282,21 +291,21 @@ class CleanupSignatureOrder_CleanupSignatureOrderOutput_SignatureOrder_Signatory
 ):
   documents: CleanupSignatureOrder_CleanupSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection
   # A download link for signatories to download their signed documents. Signatories must verify their identity before downloading. Can be used when signature order is closed with document retention.
-  downloadHref: Optional[StringScalar] = Field(default=None)
+  downloadHref: Optional[StringScalarOutput] = Field(default=None)
   evidenceProviders: list[
     CleanupSignatureOrder_CleanupSignatureOrderOutput_SignatureOrder_Signatory_SignatureEvidenceProvider
   ]
   # A link to the signatures frontend, you can send this link to your users to enable them to sign your documents.
-  href: StringScalar
-  id: IDScalar
-  reference: Optional[StringScalar] = Field(default=None)
-  role: Optional[StringScalar] = Field(default=None)
+  href: StringScalarOutput
+  id: IDScalarOutput
+  reference: Optional[StringScalarOutput] = Field(default=None)
+  role: Optional[StringScalarOutput] = Field(default=None)
   # Signature order for the signatory.
   signatureOrder: CleanupSignatureOrder_CleanupSignatureOrderOutput_SignatureOrder_Signatory_SignatureOrder
   # The current status of the signatory.
   status: SignatoryStatus
   # The reason for the signatory status (rejection reason when rejected).
-  statusReason: Optional[StringScalar] = Field(default=None)
+  statusReason: Optional[StringScalarOutput] = Field(default=None)
 
 
 class CleanupSignatureOrder_CleanupSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection(
@@ -310,15 +319,15 @@ class CleanupSignatureOrder_CleanupSignatureOrderOutput_SignatureOrder_Signatory
 class CleanupSignatureOrder_CleanupSignatureOrderOutput_SignatureOrder_Signatory_SignatureEvidenceProvider(
   BaseModel
 ):
-  id: IDScalar
+  id: IDScalarOutput
 
 
 class CleanupSignatureOrder_CleanupSignatureOrderOutput_SignatureOrder_Signatory_SignatureOrder(
   BaseModel
 ):
-  closedAt: Optional[DateTimeScalar] = Field(default=None)
-  expiresAt: DateTimeScalar
-  id: IDScalar
+  closedAt: Optional[DateTimeScalarOutput] = Field(default=None)
+  expiresAt: DateTimeScalarOutput
+  id: IDScalarOutput
   status: SignatureOrderStatus
 
 
@@ -332,7 +341,7 @@ class CleanupSignatureOrder_CleanupSignatureOrderOutput_SignatureOrder_Signatory
 class CleanupSignatureOrder_CleanupSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document(
   BaseModel
 ):
-  id: IDScalar
+  id: IDScalarOutput
 
 
 cleanupSignatureOrderDocument = f"""mutation cleanupSignatureOrder($input: CleanupSignatureOrderInput!) {{
@@ -357,21 +366,21 @@ class AddSignatory_AddSignatoryOutput(BaseModel):
 class AddSignatory_AddSignatoryOutput_Signatory(BaseModel):
   documents: AddSignatory_AddSignatoryOutput_Signatory_SignatoryDocumentConnection
   # A download link for signatories to download their signed documents. Signatories must verify their identity before downloading. Can be used when signature order is closed with document retention.
-  downloadHref: Optional[StringScalar] = Field(default=None)
+  downloadHref: Optional[StringScalarOutput] = Field(default=None)
   evidenceProviders: list[
     AddSignatory_AddSignatoryOutput_Signatory_SignatureEvidenceProvider
   ]
   # A link to the signatures frontend, you can send this link to your users to enable them to sign your documents.
-  href: StringScalar
-  id: IDScalar
-  reference: Optional[StringScalar] = Field(default=None)
-  role: Optional[StringScalar] = Field(default=None)
+  href: StringScalarOutput
+  id: IDScalarOutput
+  reference: Optional[StringScalarOutput] = Field(default=None)
+  role: Optional[StringScalarOutput] = Field(default=None)
   # Signature order for the signatory.
   signatureOrder: AddSignatory_AddSignatoryOutput_Signatory_SignatureOrder
   # The current status of the signatory.
   status: SignatoryStatus
   # The reason for the signatory status (rejection reason when rejected).
-  statusReason: Optional[StringScalar] = Field(default=None)
+  statusReason: Optional[StringScalarOutput] = Field(default=None)
 
 
 class AddSignatory_AddSignatoryOutput_Signatory_SignatoryDocumentConnection(BaseModel):
@@ -381,13 +390,13 @@ class AddSignatory_AddSignatoryOutput_Signatory_SignatoryDocumentConnection(Base
 
 
 class AddSignatory_AddSignatoryOutput_Signatory_SignatureEvidenceProvider(BaseModel):
-  id: IDScalar
+  id: IDScalarOutput
 
 
 class AddSignatory_AddSignatoryOutput_Signatory_SignatureOrder(BaseModel):
-  closedAt: Optional[DateTimeScalar] = Field(default=None)
-  expiresAt: DateTimeScalar
-  id: IDScalar
+  closedAt: Optional[DateTimeScalarOutput] = Field(default=None)
+  expiresAt: DateTimeScalarOutput
+  id: IDScalarOutput
   status: SignatureOrderStatus
 
 
@@ -401,7 +410,7 @@ class AddSignatory_AddSignatoryOutput_Signatory_SignatoryDocumentConnection_Sign
 class AddSignatory_AddSignatoryOutput_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document(
   BaseModel
 ):
-  id: IDScalar
+  id: IDScalarOutput
 
 
 addSignatoryDocument = f"""mutation addSignatory($input: AddSignatoryInput!) {{
@@ -421,21 +430,21 @@ class AddSignatories_AddSignatoriesOutput(BaseModel):
 class AddSignatories_AddSignatoriesOutput_Signatory(BaseModel):
   documents: AddSignatories_AddSignatoriesOutput_Signatory_SignatoryDocumentConnection
   # A download link for signatories to download their signed documents. Signatories must verify their identity before downloading. Can be used when signature order is closed with document retention.
-  downloadHref: Optional[StringScalar] = Field(default=None)
+  downloadHref: Optional[StringScalarOutput] = Field(default=None)
   evidenceProviders: list[
     AddSignatories_AddSignatoriesOutput_Signatory_SignatureEvidenceProvider
   ]
   # A link to the signatures frontend, you can send this link to your users to enable them to sign your documents.
-  href: StringScalar
-  id: IDScalar
-  reference: Optional[StringScalar] = Field(default=None)
-  role: Optional[StringScalar] = Field(default=None)
+  href: StringScalarOutput
+  id: IDScalarOutput
+  reference: Optional[StringScalarOutput] = Field(default=None)
+  role: Optional[StringScalarOutput] = Field(default=None)
   # Signature order for the signatory.
   signatureOrder: AddSignatories_AddSignatoriesOutput_Signatory_SignatureOrder
   # The current status of the signatory.
   status: SignatoryStatus
   # The reason for the signatory status (rejection reason when rejected).
-  statusReason: Optional[StringScalar] = Field(default=None)
+  statusReason: Optional[StringScalarOutput] = Field(default=None)
 
 
 class AddSignatories_AddSignatoriesOutput_Signatory_SignatoryDocumentConnection(
@@ -449,13 +458,13 @@ class AddSignatories_AddSignatoriesOutput_Signatory_SignatoryDocumentConnection(
 class AddSignatories_AddSignatoriesOutput_Signatory_SignatureEvidenceProvider(
   BaseModel
 ):
-  id: IDScalar
+  id: IDScalarOutput
 
 
 class AddSignatories_AddSignatoriesOutput_Signatory_SignatureOrder(BaseModel):
-  closedAt: Optional[DateTimeScalar] = Field(default=None)
-  expiresAt: DateTimeScalar
-  id: IDScalar
+  closedAt: Optional[DateTimeScalarOutput] = Field(default=None)
+  expiresAt: DateTimeScalarOutput
+  id: IDScalarOutput
   status: SignatureOrderStatus
 
 
@@ -469,7 +478,7 @@ class AddSignatories_AddSignatoriesOutput_Signatory_SignatoryDocumentConnection_
 class AddSignatories_AddSignatoriesOutput_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document(
   BaseModel
 ):
-  id: IDScalar
+  id: IDScalarOutput
 
 
 addSignatoriesDocument = f"""mutation addSignatories($input: AddSignatoriesInput!) {{
@@ -489,21 +498,21 @@ class ChangeSignatory_ChangeSignatoryOutput(BaseModel):
 class ChangeSignatory_ChangeSignatoryOutput_Signatory(BaseModel):
   documents: ChangeSignatory_ChangeSignatoryOutput_Signatory_SignatoryDocumentConnection
   # A download link for signatories to download their signed documents. Signatories must verify their identity before downloading. Can be used when signature order is closed with document retention.
-  downloadHref: Optional[StringScalar] = Field(default=None)
+  downloadHref: Optional[StringScalarOutput] = Field(default=None)
   evidenceProviders: list[
     ChangeSignatory_ChangeSignatoryOutput_Signatory_SignatureEvidenceProvider
   ]
   # A link to the signatures frontend, you can send this link to your users to enable them to sign your documents.
-  href: StringScalar
-  id: IDScalar
-  reference: Optional[StringScalar] = Field(default=None)
-  role: Optional[StringScalar] = Field(default=None)
+  href: StringScalarOutput
+  id: IDScalarOutput
+  reference: Optional[StringScalarOutput] = Field(default=None)
+  role: Optional[StringScalarOutput] = Field(default=None)
   # Signature order for the signatory.
   signatureOrder: ChangeSignatory_ChangeSignatoryOutput_Signatory_SignatureOrder
   # The current status of the signatory.
   status: SignatoryStatus
   # The reason for the signatory status (rejection reason when rejected).
-  statusReason: Optional[StringScalar] = Field(default=None)
+  statusReason: Optional[StringScalarOutput] = Field(default=None)
 
 
 class ChangeSignatory_ChangeSignatoryOutput_Signatory_SignatoryDocumentConnection(
@@ -517,13 +526,13 @@ class ChangeSignatory_ChangeSignatoryOutput_Signatory_SignatoryDocumentConnectio
 class ChangeSignatory_ChangeSignatoryOutput_Signatory_SignatureEvidenceProvider(
   BaseModel
 ):
-  id: IDScalar
+  id: IDScalarOutput
 
 
 class ChangeSignatory_ChangeSignatoryOutput_Signatory_SignatureOrder(BaseModel):
-  closedAt: Optional[DateTimeScalar] = Field(default=None)
-  expiresAt: DateTimeScalar
-  id: IDScalar
+  closedAt: Optional[DateTimeScalarOutput] = Field(default=None)
+  expiresAt: DateTimeScalarOutput
+  id: IDScalarOutput
   status: SignatureOrderStatus
 
 
@@ -537,7 +546,7 @@ class ChangeSignatory_ChangeSignatoryOutput_Signatory_SignatoryDocumentConnectio
 class ChangeSignatory_ChangeSignatoryOutput_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document(
   BaseModel
 ):
-  id: IDScalar
+  id: IDScalarOutput
 
 
 changeSignatoryDocument = f"""mutation changeSignatory($input: ChangeSignatoryInput!) {{
@@ -555,59 +564,59 @@ class CloseSignatureOrder_CloseSignatureOrderOutput(BaseModel):
 
 
 class CloseSignatureOrder_CloseSignatureOrderOutput_SignatureOrder(BaseModel):
-  closedAt: Optional[DateTimeScalar] = Field(default=None)
+  closedAt: Optional[DateTimeScalarOutput] = Field(default=None)
   documents: list[CloseSignatureOrder_CloseSignatureOrderOutput_SignatureOrder_Document]
   evidenceProviders: list[
     CloseSignatureOrder_CloseSignatureOrderOutput_SignatureOrder_SignatureEvidenceProvider
   ]
-  expiresAt: DateTimeScalar
-  id: IDScalar
+  expiresAt: DateTimeScalarOutput
+  id: IDScalarOutput
   # Number of max signatories for the signature order
-  maxSignatories: IntScalar
+  maxSignatories: IntScalarOutput
   # List of signatories for the signature order.
   signatories: list[
     CloseSignatureOrder_CloseSignatureOrderOutput_SignatureOrder_Signatory
   ]
   status: SignatureOrderStatus
-  title: Optional[StringScalar] = Field(default=None)
+  title: Optional[StringScalarOutput] = Field(default=None)
 
 
 class CloseSignatureOrder_CloseSignatureOrderOutput_SignatureOrder_Document(BaseModel):
-  blob: Optional[BlobScalar] = Field(default=None)
-  id: IDScalar
-  reference: Optional[StringScalar] = Field(default=None)
+  blob: Optional[BlobScalarOutput] = Field(default=None)
+  id: IDScalarOutput
+  reference: Optional[StringScalarOutput] = Field(default=None)
   signatures: Optional[
     list[
       CloseSignatureOrder_CloseSignatureOrderOutput_SignatureOrder_Document_Signature
     ]
   ] = Field(default=None)
-  title: StringScalar
+  title: StringScalarOutput
 
 
 class CloseSignatureOrder_CloseSignatureOrderOutput_SignatureOrder_SignatureEvidenceProvider(
   BaseModel
 ):
-  id: IDScalar
+  id: IDScalarOutput
 
 
 class CloseSignatureOrder_CloseSignatureOrderOutput_SignatureOrder_Signatory(BaseModel):
   documents: CloseSignatureOrder_CloseSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection
   # A download link for signatories to download their signed documents. Signatories must verify their identity before downloading. Can be used when signature order is closed with document retention.
-  downloadHref: Optional[StringScalar] = Field(default=None)
+  downloadHref: Optional[StringScalarOutput] = Field(default=None)
   evidenceProviders: list[
     CloseSignatureOrder_CloseSignatureOrderOutput_SignatureOrder_Signatory_SignatureEvidenceProvider
   ]
   # A link to the signatures frontend, you can send this link to your users to enable them to sign your documents.
-  href: StringScalar
-  id: IDScalar
-  reference: Optional[StringScalar] = Field(default=None)
-  role: Optional[StringScalar] = Field(default=None)
+  href: StringScalarOutput
+  id: IDScalarOutput
+  reference: Optional[StringScalarOutput] = Field(default=None)
+  role: Optional[StringScalarOutput] = Field(default=None)
   # Signature order for the signatory.
   signatureOrder: CloseSignatureOrder_CloseSignatureOrderOutput_SignatureOrder_Signatory_SignatureOrder
   # The current status of the signatory.
   status: SignatoryStatus
   # The reason for the signatory status (rejection reason when rejected).
-  statusReason: Optional[StringScalar] = Field(default=None)
+  statusReason: Optional[StringScalarOutput] = Field(default=None)
 
 
 # Represents a signature on a document.
@@ -630,22 +639,22 @@ class CloseSignatureOrder_CloseSignatureOrderOutput_SignatureOrder_Signatory_Sig
 class CloseSignatureOrder_CloseSignatureOrderOutput_SignatureOrder_Signatory_SignatureEvidenceProvider(
   BaseModel
 ):
-  id: IDScalar
+  id: IDScalarOutput
 
 
 class CloseSignatureOrder_CloseSignatureOrderOutput_SignatureOrder_Signatory_SignatureOrder(
   BaseModel
 ):
-  closedAt: Optional[DateTimeScalar] = Field(default=None)
-  expiresAt: DateTimeScalar
-  id: IDScalar
+  closedAt: Optional[DateTimeScalarOutput] = Field(default=None)
+  expiresAt: DateTimeScalarOutput
+  id: IDScalarOutput
   status: SignatureOrderStatus
 
 
 class CloseSignatureOrder_CloseSignatureOrderOutput_SignatureOrder_Document_Signature_Signatory(
   BaseModel
 ):
-  id: IDScalar
+  id: IDScalarOutput
 
 
 class CloseSignatureOrder_CloseSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge(
@@ -658,7 +667,7 @@ class CloseSignatureOrder_CloseSignatureOrderOutput_SignatureOrder_Signatory_Sig
 class CloseSignatureOrder_CloseSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document(
   BaseModel
 ):
-  id: IDScalar
+  id: IDScalarOutput
 
 
 closeSignatureOrderDocument = f"""mutation closeSignatureOrder($input: CloseSignatureOrderInput!) {{
@@ -683,37 +692,37 @@ class CancelSignatureOrder_CancelSignatureOrderOutput(BaseModel):
 
 
 class CancelSignatureOrder_CancelSignatureOrderOutput_SignatureOrder(BaseModel):
-  closedAt: Optional[DateTimeScalar] = Field(default=None)
+  closedAt: Optional[DateTimeScalarOutput] = Field(default=None)
   documents: list[
     CancelSignatureOrder_CancelSignatureOrderOutput_SignatureOrder_Document
   ]
   evidenceProviders: list[
     CancelSignatureOrder_CancelSignatureOrderOutput_SignatureOrder_SignatureEvidenceProvider
   ]
-  expiresAt: DateTimeScalar
-  id: IDScalar
+  expiresAt: DateTimeScalarOutput
+  id: IDScalarOutput
   # Number of max signatories for the signature order
-  maxSignatories: IntScalar
+  maxSignatories: IntScalarOutput
   # List of signatories for the signature order.
   signatories: list[
     CancelSignatureOrder_CancelSignatureOrderOutput_SignatureOrder_Signatory
   ]
   status: SignatureOrderStatus
-  title: Optional[StringScalar] = Field(default=None)
+  title: Optional[StringScalarOutput] = Field(default=None)
 
 
 class CancelSignatureOrder_CancelSignatureOrderOutput_SignatureOrder_Document(
   BaseModel
 ):
-  id: IDScalar
-  reference: Optional[StringScalar] = Field(default=None)
-  title: StringScalar
+  id: IDScalarOutput
+  reference: Optional[StringScalarOutput] = Field(default=None)
+  title: StringScalarOutput
 
 
 class CancelSignatureOrder_CancelSignatureOrderOutput_SignatureOrder_SignatureEvidenceProvider(
   BaseModel
 ):
-  id: IDScalar
+  id: IDScalarOutput
 
 
 class CancelSignatureOrder_CancelSignatureOrderOutput_SignatureOrder_Signatory(
@@ -721,21 +730,21 @@ class CancelSignatureOrder_CancelSignatureOrderOutput_SignatureOrder_Signatory(
 ):
   documents: CancelSignatureOrder_CancelSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection
   # A download link for signatories to download their signed documents. Signatories must verify their identity before downloading. Can be used when signature order is closed with document retention.
-  downloadHref: Optional[StringScalar] = Field(default=None)
+  downloadHref: Optional[StringScalarOutput] = Field(default=None)
   evidenceProviders: list[
     CancelSignatureOrder_CancelSignatureOrderOutput_SignatureOrder_Signatory_SignatureEvidenceProvider
   ]
   # A link to the signatures frontend, you can send this link to your users to enable them to sign your documents.
-  href: StringScalar
-  id: IDScalar
-  reference: Optional[StringScalar] = Field(default=None)
-  role: Optional[StringScalar] = Field(default=None)
+  href: StringScalarOutput
+  id: IDScalarOutput
+  reference: Optional[StringScalarOutput] = Field(default=None)
+  role: Optional[StringScalarOutput] = Field(default=None)
   # Signature order for the signatory.
   signatureOrder: CancelSignatureOrder_CancelSignatureOrderOutput_SignatureOrder_Signatory_SignatureOrder
   # The current status of the signatory.
   status: SignatoryStatus
   # The reason for the signatory status (rejection reason when rejected).
-  statusReason: Optional[StringScalar] = Field(default=None)
+  statusReason: Optional[StringScalarOutput] = Field(default=None)
 
 
 class CancelSignatureOrder_CancelSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection(
@@ -749,15 +758,15 @@ class CancelSignatureOrder_CancelSignatureOrderOutput_SignatureOrder_Signatory_S
 class CancelSignatureOrder_CancelSignatureOrderOutput_SignatureOrder_Signatory_SignatureEvidenceProvider(
   BaseModel
 ):
-  id: IDScalar
+  id: IDScalarOutput
 
 
 class CancelSignatureOrder_CancelSignatureOrderOutput_SignatureOrder_Signatory_SignatureOrder(
   BaseModel
 ):
-  closedAt: Optional[DateTimeScalar] = Field(default=None)
-  expiresAt: DateTimeScalar
-  id: IDScalar
+  closedAt: Optional[DateTimeScalarOutput] = Field(default=None)
+  expiresAt: DateTimeScalarOutput
+  id: IDScalarOutput
   status: SignatureOrderStatus
 
 
@@ -771,7 +780,7 @@ class CancelSignatureOrder_CancelSignatureOrderOutput_SignatureOrder_Signatory_S
 class CancelSignatureOrder_CancelSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document(
   BaseModel
 ):
-  id: IDScalar
+  id: IDScalarOutput
 
 
 cancelSignatureOrderDocument = f"""mutation cancelSignatureOrder($input: CancelSignatureOrderInput!) {{
@@ -796,21 +805,21 @@ class SignActingAs_SignActingAsOutput(BaseModel):
 class SignActingAs_SignActingAsOutput_Signatory(BaseModel):
   documents: SignActingAs_SignActingAsOutput_Signatory_SignatoryDocumentConnection
   # A download link for signatories to download their signed documents. Signatories must verify their identity before downloading. Can be used when signature order is closed with document retention.
-  downloadHref: Optional[StringScalar] = Field(default=None)
+  downloadHref: Optional[StringScalarOutput] = Field(default=None)
   evidenceProviders: list[
     SignActingAs_SignActingAsOutput_Signatory_SignatureEvidenceProvider
   ]
   # A link to the signatures frontend, you can send this link to your users to enable them to sign your documents.
-  href: StringScalar
-  id: IDScalar
-  reference: Optional[StringScalar] = Field(default=None)
-  role: Optional[StringScalar] = Field(default=None)
+  href: StringScalarOutput
+  id: IDScalarOutput
+  reference: Optional[StringScalarOutput] = Field(default=None)
+  role: Optional[StringScalarOutput] = Field(default=None)
   # Signature order for the signatory.
   signatureOrder: SignActingAs_SignActingAsOutput_Signatory_SignatureOrder
   # The current status of the signatory.
   status: SignatoryStatus
   # The reason for the signatory status (rejection reason when rejected).
-  statusReason: Optional[StringScalar] = Field(default=None)
+  statusReason: Optional[StringScalarOutput] = Field(default=None)
 
 
 class SignActingAs_SignActingAsOutput_Signatory_SignatoryDocumentConnection(BaseModel):
@@ -820,13 +829,13 @@ class SignActingAs_SignActingAsOutput_Signatory_SignatoryDocumentConnection(Base
 
 
 class SignActingAs_SignActingAsOutput_Signatory_SignatureEvidenceProvider(BaseModel):
-  id: IDScalar
+  id: IDScalarOutput
 
 
 class SignActingAs_SignActingAsOutput_Signatory_SignatureOrder(BaseModel):
-  closedAt: Optional[DateTimeScalar] = Field(default=None)
-  expiresAt: DateTimeScalar
-  id: IDScalar
+  closedAt: Optional[DateTimeScalarOutput] = Field(default=None)
+  expiresAt: DateTimeScalarOutput
+  id: IDScalarOutput
   status: SignatureOrderStatus
 
 
@@ -840,7 +849,7 @@ class SignActingAs_SignActingAsOutput_Signatory_SignatoryDocumentConnection_Sign
 class SignActingAs_SignActingAsOutput_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document(
   BaseModel
 ):
-  id: IDScalar
+  id: IDScalarOutput
 
 
 signActingAsDocument = f"""mutation signActingAs($input: SignActingAsInput!) {{
@@ -854,10 +863,10 @@ signActingAsDocument = f"""mutation signActingAs($input: SignActingAsInput!) {{
 
 
 class ValidateDocument_ValidateDocumentOutput(BaseModel):
-  errors: Optional[list[StringScalar]] = Field(default=None)
+  errors: Optional[list[StringScalarOutput]] = Field(default=None)
   # Whether or not the errors are fixable using 'fixDocumentFormattingErrors'
-  fixable: Optional[BooleanScalar] = Field(default=None)
-  valid: BooleanScalar
+  fixable: Optional[BooleanScalarOutput] = Field(default=None)
+  valid: BooleanScalarOutput
 
 
 validateDocumentDocument = """mutation validateDocument($input: ValidateDocumentInput!) {
@@ -874,37 +883,37 @@ class ExtendSignatureOrder_ExtendSignatureOrderOutput(BaseModel):
 
 
 class ExtendSignatureOrder_ExtendSignatureOrderOutput_SignatureOrder(BaseModel):
-  closedAt: Optional[DateTimeScalar] = Field(default=None)
+  closedAt: Optional[DateTimeScalarOutput] = Field(default=None)
   documents: list[
     ExtendSignatureOrder_ExtendSignatureOrderOutput_SignatureOrder_Document
   ]
   evidenceProviders: list[
     ExtendSignatureOrder_ExtendSignatureOrderOutput_SignatureOrder_SignatureEvidenceProvider
   ]
-  expiresAt: DateTimeScalar
-  id: IDScalar
+  expiresAt: DateTimeScalarOutput
+  id: IDScalarOutput
   # Number of max signatories for the signature order
-  maxSignatories: IntScalar
+  maxSignatories: IntScalarOutput
   # List of signatories for the signature order.
   signatories: list[
     ExtendSignatureOrder_ExtendSignatureOrderOutput_SignatureOrder_Signatory
   ]
   status: SignatureOrderStatus
-  title: Optional[StringScalar] = Field(default=None)
+  title: Optional[StringScalarOutput] = Field(default=None)
 
 
 class ExtendSignatureOrder_ExtendSignatureOrderOutput_SignatureOrder_Document(
   BaseModel
 ):
-  id: IDScalar
-  reference: Optional[StringScalar] = Field(default=None)
-  title: StringScalar
+  id: IDScalarOutput
+  reference: Optional[StringScalarOutput] = Field(default=None)
+  title: StringScalarOutput
 
 
 class ExtendSignatureOrder_ExtendSignatureOrderOutput_SignatureOrder_SignatureEvidenceProvider(
   BaseModel
 ):
-  id: IDScalar
+  id: IDScalarOutput
 
 
 class ExtendSignatureOrder_ExtendSignatureOrderOutput_SignatureOrder_Signatory(
@@ -912,21 +921,21 @@ class ExtendSignatureOrder_ExtendSignatureOrderOutput_SignatureOrder_Signatory(
 ):
   documents: ExtendSignatureOrder_ExtendSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection
   # A download link for signatories to download their signed documents. Signatories must verify their identity before downloading. Can be used when signature order is closed with document retention.
-  downloadHref: Optional[StringScalar] = Field(default=None)
+  downloadHref: Optional[StringScalarOutput] = Field(default=None)
   evidenceProviders: list[
     ExtendSignatureOrder_ExtendSignatureOrderOutput_SignatureOrder_Signatory_SignatureEvidenceProvider
   ]
   # A link to the signatures frontend, you can send this link to your users to enable them to sign your documents.
-  href: StringScalar
-  id: IDScalar
-  reference: Optional[StringScalar] = Field(default=None)
-  role: Optional[StringScalar] = Field(default=None)
+  href: StringScalarOutput
+  id: IDScalarOutput
+  reference: Optional[StringScalarOutput] = Field(default=None)
+  role: Optional[StringScalarOutput] = Field(default=None)
   # Signature order for the signatory.
   signatureOrder: ExtendSignatureOrder_ExtendSignatureOrderOutput_SignatureOrder_Signatory_SignatureOrder
   # The current status of the signatory.
   status: SignatoryStatus
   # The reason for the signatory status (rejection reason when rejected).
-  statusReason: Optional[StringScalar] = Field(default=None)
+  statusReason: Optional[StringScalarOutput] = Field(default=None)
 
 
 class ExtendSignatureOrder_ExtendSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection(
@@ -940,15 +949,15 @@ class ExtendSignatureOrder_ExtendSignatureOrderOutput_SignatureOrder_Signatory_S
 class ExtendSignatureOrder_ExtendSignatureOrderOutput_SignatureOrder_Signatory_SignatureEvidenceProvider(
   BaseModel
 ):
-  id: IDScalar
+  id: IDScalarOutput
 
 
 class ExtendSignatureOrder_ExtendSignatureOrderOutput_SignatureOrder_Signatory_SignatureOrder(
   BaseModel
 ):
-  closedAt: Optional[DateTimeScalar] = Field(default=None)
-  expiresAt: DateTimeScalar
-  id: IDScalar
+  closedAt: Optional[DateTimeScalarOutput] = Field(default=None)
+  expiresAt: DateTimeScalarOutput
+  id: IDScalarOutput
   status: SignatureOrderStatus
 
 
@@ -962,7 +971,7 @@ class ExtendSignatureOrder_ExtendSignatureOrderOutput_SignatureOrder_Signatory_S
 class ExtendSignatureOrder_ExtendSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document(
   BaseModel
 ):
-  id: IDScalar
+  id: IDScalarOutput
 
 
 extendSignatureOrderDocument = f"""mutation extendSignatureOrder($input: ExtendSignatureOrderInput!) {{
@@ -985,38 +994,38 @@ class DeleteSignatory_DeleteSignatoryOutput(BaseModel):
 
 
 class DeleteSignatory_DeleteSignatoryOutput_SignatureOrder(BaseModel):
-  closedAt: Optional[DateTimeScalar] = Field(default=None)
+  closedAt: Optional[DateTimeScalarOutput] = Field(default=None)
   evidenceProviders: list[
     DeleteSignatory_DeleteSignatoryOutput_SignatureOrder_SignatureEvidenceProvider
   ]
-  expiresAt: DateTimeScalar
-  id: IDScalar
+  expiresAt: DateTimeScalarOutput
+  id: IDScalarOutput
   # Number of max signatories for the signature order
-  maxSignatories: IntScalar
+  maxSignatories: IntScalarOutput
   # List of signatories for the signature order.
   signatories: list[DeleteSignatory_DeleteSignatoryOutput_SignatureOrder_Signatory]
   status: SignatureOrderStatus
-  title: Optional[StringScalar] = Field(default=None)
+  title: Optional[StringScalarOutput] = Field(default=None)
 
 
 class DeleteSignatory_DeleteSignatoryOutput_SignatureOrder_SignatureEvidenceProvider(
   BaseModel
 ):
-  id: IDScalar
+  id: IDScalarOutput
 
 
 class DeleteSignatory_DeleteSignatoryOutput_SignatureOrder_Signatory(BaseModel):
   documents: DeleteSignatory_DeleteSignatoryOutput_SignatureOrder_Signatory_SignatoryDocumentConnection
   # A download link for signatories to download their signed documents. Signatories must verify their identity before downloading. Can be used when signature order is closed with document retention.
-  downloadHref: Optional[StringScalar] = Field(default=None)
+  downloadHref: Optional[StringScalarOutput] = Field(default=None)
   evidenceProviders: list[
     DeleteSignatory_DeleteSignatoryOutput_SignatureOrder_Signatory_SignatureEvidenceProvider
   ]
   # A link to the signatures frontend, you can send this link to your users to enable them to sign your documents.
-  href: StringScalar
-  id: IDScalar
-  reference: Optional[StringScalar] = Field(default=None)
-  role: Optional[StringScalar] = Field(default=None)
+  href: StringScalarOutput
+  id: IDScalarOutput
+  reference: Optional[StringScalarOutput] = Field(default=None)
+  role: Optional[StringScalarOutput] = Field(default=None)
   # Signature order for the signatory.
   signatureOrder: (
     DeleteSignatory_DeleteSignatoryOutput_SignatureOrder_Signatory_SignatureOrder
@@ -1024,7 +1033,7 @@ class DeleteSignatory_DeleteSignatoryOutput_SignatureOrder_Signatory(BaseModel):
   # The current status of the signatory.
   status: SignatoryStatus
   # The reason for the signatory status (rejection reason when rejected).
-  statusReason: Optional[StringScalar] = Field(default=None)
+  statusReason: Optional[StringScalarOutput] = Field(default=None)
 
 
 class DeleteSignatory_DeleteSignatoryOutput_SignatureOrder_Signatory_SignatoryDocumentConnection(
@@ -1038,15 +1047,15 @@ class DeleteSignatory_DeleteSignatoryOutput_SignatureOrder_Signatory_SignatoryDo
 class DeleteSignatory_DeleteSignatoryOutput_SignatureOrder_Signatory_SignatureEvidenceProvider(
   BaseModel
 ):
-  id: IDScalar
+  id: IDScalarOutput
 
 
 class DeleteSignatory_DeleteSignatoryOutput_SignatureOrder_Signatory_SignatureOrder(
   BaseModel
 ):
-  closedAt: Optional[DateTimeScalar] = Field(default=None)
-  expiresAt: DateTimeScalar
-  id: IDScalar
+  closedAt: Optional[DateTimeScalarOutput] = Field(default=None)
+  expiresAt: DateTimeScalarOutput
+  id: IDScalarOutput
   status: SignatureOrderStatus
 
 
@@ -1060,7 +1069,7 @@ class DeleteSignatory_DeleteSignatoryOutput_SignatureOrder_Signatory_SignatoryDo
 class DeleteSignatory_DeleteSignatoryOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document(
   BaseModel
 ):
-  id: IDScalar
+  id: IDScalarOutput
 
 
 deleteSignatoryDocument = f"""mutation deleteSignatory($input: DeleteSignatoryInput!) {{
@@ -1079,13 +1088,13 @@ class CreateBatchSignatory_CreateBatchSignatoryOutput(BaseModel):
 
 
 class CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory(BaseModel):
-  href: StringScalar
-  id: IDScalar
+  href: StringScalarOutput
+  id: IDScalarOutput
   items: list[
     CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem
   ]
   # The authentication token required for performing batch operations.
-  token: StringScalar
+  token: StringScalarOutput
 
 
 class CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem(
@@ -1100,40 +1109,40 @@ class CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignat
 ):
   documents: CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_Signatory_SignatoryDocumentConnection
   # A download link for signatories to download their signed documents. Signatories must verify their identity before downloading. Can be used when signature order is closed with document retention.
-  downloadHref: Optional[StringScalar] = Field(default=None)
+  downloadHref: Optional[StringScalarOutput] = Field(default=None)
   evidenceProviders: list[
     CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_Signatory_SignatureEvidenceProvider
   ]
   # A link to the signatures frontend, you can send this link to your users to enable them to sign your documents.
-  href: StringScalar
-  id: IDScalar
-  reference: Optional[StringScalar] = Field(default=None)
-  role: Optional[StringScalar] = Field(default=None)
+  href: StringScalarOutput
+  id: IDScalarOutput
+  reference: Optional[StringScalarOutput] = Field(default=None)
+  role: Optional[StringScalarOutput] = Field(default=None)
   # Signature order for the signatory.
   signatureOrder: CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_Signatory_SignatureOrder
   # The current status of the signatory.
   status: SignatoryStatus
   # The reason for the signatory status (rejection reason when rejected).
-  statusReason: Optional[StringScalar] = Field(default=None)
+  statusReason: Optional[StringScalarOutput] = Field(default=None)
 
 
 class CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_SignatureOrder(
   BaseModel
 ):
-  closedAt: Optional[DateTimeScalar] = Field(default=None)
+  closedAt: Optional[DateTimeScalarOutput] = Field(default=None)
   evidenceProviders: list[
     CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_SignatureOrder_SignatureEvidenceProvider
   ]
-  expiresAt: DateTimeScalar
-  id: IDScalar
+  expiresAt: DateTimeScalarOutput
+  id: IDScalarOutput
   # Number of max signatories for the signature order
-  maxSignatories: IntScalar
+  maxSignatories: IntScalarOutput
   # List of signatories for the signature order.
   signatories: list[
     CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory
   ]
   status: SignatureOrderStatus
-  title: Optional[StringScalar] = Field(default=None)
+  title: Optional[StringScalarOutput] = Field(default=None)
 
 
 class CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_Signatory_SignatoryDocumentConnection(
@@ -1147,22 +1156,22 @@ class CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignat
 class CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_Signatory_SignatureEvidenceProvider(
   BaseModel
 ):
-  id: IDScalar
+  id: IDScalarOutput
 
 
 class CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_Signatory_SignatureOrder(
   BaseModel
 ):
-  closedAt: Optional[DateTimeScalar] = Field(default=None)
-  expiresAt: DateTimeScalar
-  id: IDScalar
+  closedAt: Optional[DateTimeScalarOutput] = Field(default=None)
+  expiresAt: DateTimeScalarOutput
+  id: IDScalarOutput
   status: SignatureOrderStatus
 
 
 class CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_SignatureOrder_SignatureEvidenceProvider(
   BaseModel
 ):
-  id: IDScalar
+  id: IDScalarOutput
 
 
 class CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory(
@@ -1170,21 +1179,21 @@ class CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignat
 ):
   documents: CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory_SignatoryDocumentConnection
   # A download link for signatories to download their signed documents. Signatories must verify their identity before downloading. Can be used when signature order is closed with document retention.
-  downloadHref: Optional[StringScalar] = Field(default=None)
+  downloadHref: Optional[StringScalarOutput] = Field(default=None)
   evidenceProviders: list[
     CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory_SignatureEvidenceProvider
   ]
   # A link to the signatures frontend, you can send this link to your users to enable them to sign your documents.
-  href: StringScalar
-  id: IDScalar
-  reference: Optional[StringScalar] = Field(default=None)
-  role: Optional[StringScalar] = Field(default=None)
+  href: StringScalarOutput
+  id: IDScalarOutput
+  reference: Optional[StringScalarOutput] = Field(default=None)
+  role: Optional[StringScalarOutput] = Field(default=None)
   # Signature order for the signatory.
   signatureOrder: CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory_SignatureOrder
   # The current status of the signatory.
   status: SignatoryStatus
   # The reason for the signatory status (rejection reason when rejected).
-  statusReason: Optional[StringScalar] = Field(default=None)
+  statusReason: Optional[StringScalarOutput] = Field(default=None)
 
 
 class CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge(
@@ -1205,22 +1214,22 @@ class CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignat
 class CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory_SignatureEvidenceProvider(
   BaseModel
 ):
-  id: IDScalar
+  id: IDScalarOutput
 
 
 class CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory_SignatureOrder(
   BaseModel
 ):
-  closedAt: Optional[DateTimeScalar] = Field(default=None)
-  expiresAt: DateTimeScalar
-  id: IDScalar
+  closedAt: Optional[DateTimeScalarOutput] = Field(default=None)
+  expiresAt: DateTimeScalarOutput
+  id: IDScalarOutput
   status: SignatureOrderStatus
 
 
 class CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document(
   BaseModel
 ):
-  id: IDScalar
+  id: IDScalarOutput
 
 
 class CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge(
@@ -1233,7 +1242,7 @@ class CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignat
 class CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document(
   BaseModel
 ):
-  id: IDScalar
+  id: IDScalarOutput
 
 
 createBatchSignatoryDocument = f"""mutation createBatchSignatory($input: CreateBatchSignatoryInput!) {{
@@ -1261,26 +1270,26 @@ class ChangeSignatureOrder_ChangeSignatureOrderOutput(BaseModel):
 
 
 class ChangeSignatureOrder_ChangeSignatureOrderOutput_SignatureOrder(BaseModel):
-  closedAt: Optional[DateTimeScalar] = Field(default=None)
+  closedAt: Optional[DateTimeScalarOutput] = Field(default=None)
   evidenceProviders: list[
     ChangeSignatureOrder_ChangeSignatureOrderOutput_SignatureOrder_SignatureEvidenceProvider
   ]
-  expiresAt: DateTimeScalar
-  id: IDScalar
+  expiresAt: DateTimeScalarOutput
+  id: IDScalarOutput
   # Number of max signatories for the signature order
-  maxSignatories: IntScalar
+  maxSignatories: IntScalarOutput
   # List of signatories for the signature order.
   signatories: list[
     ChangeSignatureOrder_ChangeSignatureOrderOutput_SignatureOrder_Signatory
   ]
   status: SignatureOrderStatus
-  title: Optional[StringScalar] = Field(default=None)
+  title: Optional[StringScalarOutput] = Field(default=None)
 
 
 class ChangeSignatureOrder_ChangeSignatureOrderOutput_SignatureOrder_SignatureEvidenceProvider(
   BaseModel
 ):
-  id: IDScalar
+  id: IDScalarOutput
 
 
 class ChangeSignatureOrder_ChangeSignatureOrderOutput_SignatureOrder_Signatory(
@@ -1288,21 +1297,21 @@ class ChangeSignatureOrder_ChangeSignatureOrderOutput_SignatureOrder_Signatory(
 ):
   documents: ChangeSignatureOrder_ChangeSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection
   # A download link for signatories to download their signed documents. Signatories must verify their identity before downloading. Can be used when signature order is closed with document retention.
-  downloadHref: Optional[StringScalar] = Field(default=None)
+  downloadHref: Optional[StringScalarOutput] = Field(default=None)
   evidenceProviders: list[
     ChangeSignatureOrder_ChangeSignatureOrderOutput_SignatureOrder_Signatory_SignatureEvidenceProvider
   ]
   # A link to the signatures frontend, you can send this link to your users to enable them to sign your documents.
-  href: StringScalar
-  id: IDScalar
-  reference: Optional[StringScalar] = Field(default=None)
-  role: Optional[StringScalar] = Field(default=None)
+  href: StringScalarOutput
+  id: IDScalarOutput
+  reference: Optional[StringScalarOutput] = Field(default=None)
+  role: Optional[StringScalarOutput] = Field(default=None)
   # Signature order for the signatory.
   signatureOrder: ChangeSignatureOrder_ChangeSignatureOrderOutput_SignatureOrder_Signatory_SignatureOrder
   # The current status of the signatory.
   status: SignatoryStatus
   # The reason for the signatory status (rejection reason when rejected).
-  statusReason: Optional[StringScalar] = Field(default=None)
+  statusReason: Optional[StringScalarOutput] = Field(default=None)
 
 
 class ChangeSignatureOrder_ChangeSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection(
@@ -1316,15 +1325,15 @@ class ChangeSignatureOrder_ChangeSignatureOrderOutput_SignatureOrder_Signatory_S
 class ChangeSignatureOrder_ChangeSignatureOrderOutput_SignatureOrder_Signatory_SignatureEvidenceProvider(
   BaseModel
 ):
-  id: IDScalar
+  id: IDScalarOutput
 
 
 class ChangeSignatureOrder_ChangeSignatureOrderOutput_SignatureOrder_Signatory_SignatureOrder(
   BaseModel
 ):
-  closedAt: Optional[DateTimeScalar] = Field(default=None)
-  expiresAt: DateTimeScalar
-  id: IDScalar
+  closedAt: Optional[DateTimeScalarOutput] = Field(default=None)
+  expiresAt: DateTimeScalarOutput
+  id: IDScalarOutput
   status: SignatureOrderStatus
 
 
@@ -1338,7 +1347,7 @@ class ChangeSignatureOrder_ChangeSignatureOrderOutput_SignatureOrder_Signatory_S
 class ChangeSignatureOrder_ChangeSignatureOrderOutput_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document(
   BaseModel
 ):
-  id: IDScalar
+  id: IDScalarOutput
 
 
 changeSignatureOrderDocument = f"""mutation changeSignatureOrder($input: ChangeSignatureOrderInput!) {{
@@ -1353,40 +1362,40 @@ changeSignatureOrderDocument = f"""mutation changeSignatureOrder($input: ChangeS
 
 
 class QuerySignatureOrder_SignatureOrder(BaseModel):
-  closedAt: Optional[DateTimeScalar] = Field(default=None)
+  closedAt: Optional[DateTimeScalarOutput] = Field(default=None)
   evidenceProviders: list[QuerySignatureOrder_SignatureOrder_SignatureEvidenceProvider]
-  expiresAt: DateTimeScalar
-  id: IDScalar
+  expiresAt: DateTimeScalarOutput
+  id: IDScalarOutput
   # Number of max signatories for the signature order
-  maxSignatories: IntScalar
+  maxSignatories: IntScalarOutput
   # List of signatories for the signature order.
   signatories: list[QuerySignatureOrder_SignatureOrder_Signatory]
   status: SignatureOrderStatus
-  title: Optional[StringScalar] = Field(default=None)
+  title: Optional[StringScalarOutput] = Field(default=None)
 
 
 class QuerySignatureOrder_SignatureOrder_SignatureEvidenceProvider(BaseModel):
-  id: IDScalar
+  id: IDScalarOutput
 
 
 class QuerySignatureOrder_SignatureOrder_Signatory(BaseModel):
   documents: QuerySignatureOrder_SignatureOrder_Signatory_SignatoryDocumentConnection
   # A download link for signatories to download their signed documents. Signatories must verify their identity before downloading. Can be used when signature order is closed with document retention.
-  downloadHref: Optional[StringScalar] = Field(default=None)
+  downloadHref: Optional[StringScalarOutput] = Field(default=None)
   evidenceProviders: list[
     QuerySignatureOrder_SignatureOrder_Signatory_SignatureEvidenceProvider
   ]
   # A link to the signatures frontend, you can send this link to your users to enable them to sign your documents.
-  href: StringScalar
-  id: IDScalar
-  reference: Optional[StringScalar] = Field(default=None)
-  role: Optional[StringScalar] = Field(default=None)
+  href: StringScalarOutput
+  id: IDScalarOutput
+  reference: Optional[StringScalarOutput] = Field(default=None)
+  role: Optional[StringScalarOutput] = Field(default=None)
   # Signature order for the signatory.
   signatureOrder: QuerySignatureOrder_SignatureOrder_Signatory_SignatureOrder
   # The current status of the signatory.
   status: SignatoryStatus
   # The reason for the signatory status (rejection reason when rejected).
-  statusReason: Optional[StringScalar] = Field(default=None)
+  statusReason: Optional[StringScalarOutput] = Field(default=None)
 
 
 class QuerySignatureOrder_SignatureOrder_Signatory_SignatoryDocumentConnection(
@@ -1398,13 +1407,13 @@ class QuerySignatureOrder_SignatureOrder_Signatory_SignatoryDocumentConnection(
 
 
 class QuerySignatureOrder_SignatureOrder_Signatory_SignatureEvidenceProvider(BaseModel):
-  id: IDScalar
+  id: IDScalarOutput
 
 
 class QuerySignatureOrder_SignatureOrder_Signatory_SignatureOrder(BaseModel):
-  closedAt: Optional[DateTimeScalar] = Field(default=None)
-  expiresAt: DateTimeScalar
-  id: IDScalar
+  closedAt: Optional[DateTimeScalarOutput] = Field(default=None)
+  expiresAt: DateTimeScalarOutput
+  id: IDScalarOutput
   status: SignatureOrderStatus
 
 
@@ -1418,7 +1427,7 @@ class QuerySignatureOrder_SignatureOrder_Signatory_SignatoryDocumentConnection_S
 class QuerySignatureOrder_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document(
   BaseModel
 ):
-  id: IDScalar
+  id: IDScalarOutput
 
 
 querySignatureOrderDocument = f"""query signatureOrder($id: ID!) {{
@@ -1431,49 +1440,49 @@ querySignatureOrderDocument = f"""query signatureOrder($id: ID!) {{
 
 
 class QuerySignatureOrderWithDocuments_SignatureOrder(BaseModel):
-  closedAt: Optional[DateTimeScalar] = Field(default=None)
+  closedAt: Optional[DateTimeScalarOutput] = Field(default=None)
   documents: list[QuerySignatureOrderWithDocuments_SignatureOrder_Document]
   evidenceProviders: list[
     QuerySignatureOrderWithDocuments_SignatureOrder_SignatureEvidenceProvider
   ]
-  expiresAt: DateTimeScalar
-  id: IDScalar
+  expiresAt: DateTimeScalarOutput
+  id: IDScalarOutput
   # Number of max signatories for the signature order
-  maxSignatories: IntScalar
+  maxSignatories: IntScalarOutput
   # List of signatories for the signature order.
   signatories: list[QuerySignatureOrderWithDocuments_SignatureOrder_Signatory]
   status: SignatureOrderStatus
-  title: Optional[StringScalar] = Field(default=None)
+  title: Optional[StringScalarOutput] = Field(default=None)
 
 
 class QuerySignatureOrderWithDocuments_SignatureOrder_Document(BaseModel):
-  blob: Optional[BlobScalar] = Field(default=None)
-  id: IDScalar
-  reference: Optional[StringScalar] = Field(default=None)
+  blob: Optional[BlobScalarOutput] = Field(default=None)
+  id: IDScalarOutput
+  reference: Optional[StringScalarOutput] = Field(default=None)
   signatures: Optional[
     list[QuerySignatureOrderWithDocuments_SignatureOrder_Document_Signature]
   ] = Field(default=None)
-  title: StringScalar
+  title: StringScalarOutput
 
 
 class QuerySignatureOrderWithDocuments_SignatureOrder_SignatureEvidenceProvider(
   BaseModel
 ):
-  id: IDScalar
+  id: IDScalarOutput
 
 
 class QuerySignatureOrderWithDocuments_SignatureOrder_Signatory(BaseModel):
   documents: QuerySignatureOrderWithDocuments_SignatureOrder_Signatory_SignatoryDocumentConnection
   # A download link for signatories to download their signed documents. Signatories must verify their identity before downloading. Can be used when signature order is closed with document retention.
-  downloadHref: Optional[StringScalar] = Field(default=None)
+  downloadHref: Optional[StringScalarOutput] = Field(default=None)
   evidenceProviders: list[
     QuerySignatureOrderWithDocuments_SignatureOrder_Signatory_SignatureEvidenceProvider
   ]
   # A link to the signatures frontend, you can send this link to your users to enable them to sign your documents.
-  href: StringScalar
-  id: IDScalar
-  reference: Optional[StringScalar] = Field(default=None)
-  role: Optional[StringScalar] = Field(default=None)
+  href: StringScalarOutput
+  id: IDScalarOutput
+  reference: Optional[StringScalarOutput] = Field(default=None)
+  role: Optional[StringScalarOutput] = Field(default=None)
   # Signature order for the signatory.
   signatureOrder: (
     QuerySignatureOrderWithDocuments_SignatureOrder_Signatory_SignatureOrder
@@ -1481,7 +1490,7 @@ class QuerySignatureOrderWithDocuments_SignatureOrder_Signatory(BaseModel):
   # The current status of the signatory.
   status: SignatoryStatus
   # The reason for the signatory status (rejection reason when rejected).
-  statusReason: Optional[StringScalar] = Field(default=None)
+  statusReason: Optional[StringScalarOutput] = Field(default=None)
 
 
 # Represents a signature on a document.
@@ -1502,22 +1511,22 @@ class QuerySignatureOrderWithDocuments_SignatureOrder_Signatory_SignatoryDocumen
 class QuerySignatureOrderWithDocuments_SignatureOrder_Signatory_SignatureEvidenceProvider(
   BaseModel
 ):
-  id: IDScalar
+  id: IDScalarOutput
 
 
 class QuerySignatureOrderWithDocuments_SignatureOrder_Signatory_SignatureOrder(
   BaseModel
 ):
-  closedAt: Optional[DateTimeScalar] = Field(default=None)
-  expiresAt: DateTimeScalar
-  id: IDScalar
+  closedAt: Optional[DateTimeScalarOutput] = Field(default=None)
+  expiresAt: DateTimeScalarOutput
+  id: IDScalarOutput
   status: SignatureOrderStatus
 
 
 class QuerySignatureOrderWithDocuments_SignatureOrder_Document_Signature_Signatory(
   BaseModel
 ):
-  id: IDScalar
+  id: IDScalarOutput
 
 
 class QuerySignatureOrderWithDocuments_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge(
@@ -1530,7 +1539,7 @@ class QuerySignatureOrderWithDocuments_SignatureOrder_Signatory_SignatoryDocumen
 class QuerySignatureOrderWithDocuments_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document(
   BaseModel
 ):
-  id: IDScalar
+  id: IDScalarOutput
 
 
 querySignatureOrderWithDocumentsDocument = f"""query signatureOrderWithDocuments($id: ID!) {{
@@ -1551,19 +1560,19 @@ querySignatureOrderWithDocumentsDocument = f"""query signatureOrderWithDocuments
 class QuerySignatory_Signatory(BaseModel):
   documents: QuerySignatory_Signatory_SignatoryDocumentConnection
   # A download link for signatories to download their signed documents. Signatories must verify their identity before downloading. Can be used when signature order is closed with document retention.
-  downloadHref: Optional[StringScalar] = Field(default=None)
+  downloadHref: Optional[StringScalarOutput] = Field(default=None)
   evidenceProviders: list[QuerySignatory_Signatory_SignatureEvidenceProvider]
   # A link to the signatures frontend, you can send this link to your users to enable them to sign your documents.
-  href: StringScalar
-  id: IDScalar
-  reference: Optional[StringScalar] = Field(default=None)
-  role: Optional[StringScalar] = Field(default=None)
+  href: StringScalarOutput
+  id: IDScalarOutput
+  reference: Optional[StringScalarOutput] = Field(default=None)
+  role: Optional[StringScalarOutput] = Field(default=None)
   # Signature order for the signatory.
   signatureOrder: QuerySignatory_Signatory_SignatureOrder
   # The current status of the signatory.
   status: SignatoryStatus
   # The reason for the signatory status (rejection reason when rejected).
-  statusReason: Optional[StringScalar] = Field(default=None)
+  statusReason: Optional[StringScalarOutput] = Field(default=None)
 
 
 class QuerySignatory_Signatory_SignatoryDocumentConnection(BaseModel):
@@ -1573,22 +1582,22 @@ class QuerySignatory_Signatory_SignatoryDocumentConnection(BaseModel):
 
 
 class QuerySignatory_Signatory_SignatureEvidenceProvider(BaseModel):
-  id: IDScalar
+  id: IDScalarOutput
 
 
 class QuerySignatory_Signatory_SignatureOrder(BaseModel):
-  closedAt: Optional[DateTimeScalar] = Field(default=None)
+  closedAt: Optional[DateTimeScalarOutput] = Field(default=None)
   evidenceProviders: list[
     QuerySignatory_Signatory_SignatureOrder_SignatureEvidenceProvider
   ]
-  expiresAt: DateTimeScalar
-  id: IDScalar
+  expiresAt: DateTimeScalarOutput
+  id: IDScalarOutput
   # Number of max signatories for the signature order
-  maxSignatories: IntScalar
+  maxSignatories: IntScalarOutput
   # List of signatories for the signature order.
   signatories: list[QuerySignatory_Signatory_SignatureOrder_Signatory]
   status: SignatureOrderStatus
-  title: Optional[StringScalar] = Field(default=None)
+  title: Optional[StringScalarOutput] = Field(default=None)
 
 
 class QuerySignatory_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge(
@@ -1601,7 +1610,7 @@ class QuerySignatory_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge
 
 
 class QuerySignatory_Signatory_SignatureOrder_SignatureEvidenceProvider(BaseModel):
-  id: IDScalar
+  id: IDScalarOutput
 
 
 class QuerySignatory_Signatory_SignatureOrder_Signatory(BaseModel):
@@ -1609,27 +1618,27 @@ class QuerySignatory_Signatory_SignatureOrder_Signatory(BaseModel):
     QuerySignatory_Signatory_SignatureOrder_Signatory_SignatoryDocumentConnection
   )
   # A download link for signatories to download their signed documents. Signatories must verify their identity before downloading. Can be used when signature order is closed with document retention.
-  downloadHref: Optional[StringScalar] = Field(default=None)
+  downloadHref: Optional[StringScalarOutput] = Field(default=None)
   evidenceProviders: list[
     QuerySignatory_Signatory_SignatureOrder_Signatory_SignatureEvidenceProvider
   ]
   # A link to the signatures frontend, you can send this link to your users to enable them to sign your documents.
-  href: StringScalar
-  id: IDScalar
-  reference: Optional[StringScalar] = Field(default=None)
-  role: Optional[StringScalar] = Field(default=None)
+  href: StringScalarOutput
+  id: IDScalarOutput
+  reference: Optional[StringScalarOutput] = Field(default=None)
+  role: Optional[StringScalarOutput] = Field(default=None)
   # Signature order for the signatory.
   signatureOrder: QuerySignatory_Signatory_SignatureOrder_Signatory_SignatureOrder
   # The current status of the signatory.
   status: SignatoryStatus
   # The reason for the signatory status (rejection reason when rejected).
-  statusReason: Optional[StringScalar] = Field(default=None)
+  statusReason: Optional[StringScalarOutput] = Field(default=None)
 
 
 class QuerySignatory_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document(
   BaseModel
 ):
-  id: IDScalar
+  id: IDScalarOutput
 
 
 class QuerySignatory_Signatory_SignatureOrder_Signatory_SignatoryDocumentConnection(
@@ -1643,13 +1652,13 @@ class QuerySignatory_Signatory_SignatureOrder_Signatory_SignatoryDocumentConnect
 class QuerySignatory_Signatory_SignatureOrder_Signatory_SignatureEvidenceProvider(
   BaseModel
 ):
-  id: IDScalar
+  id: IDScalarOutput
 
 
 class QuerySignatory_Signatory_SignatureOrder_Signatory_SignatureOrder(BaseModel):
-  closedAt: Optional[DateTimeScalar] = Field(default=None)
-  expiresAt: DateTimeScalar
-  id: IDScalar
+  closedAt: Optional[DateTimeScalarOutput] = Field(default=None)
+  expiresAt: DateTimeScalarOutput
+  id: IDScalarOutput
   status: SignatureOrderStatus
 
 
@@ -1663,7 +1672,7 @@ class QuerySignatory_Signatory_SignatureOrder_Signatory_SignatoryDocumentConnect
 class QuerySignatory_Signatory_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document(
   BaseModel
 ):
-  id: IDScalar
+  id: IDScalarOutput
 
 
 querySignatoryDocument = f"""query signatory($id: ID!) {{
@@ -1701,11 +1710,11 @@ querySignatureOrdersDocument = f"""query signatureOrders($status: SignatureOrder
 
 
 class QueryBatchSignatory_BatchSignatory(BaseModel):
-  href: StringScalar
-  id: IDScalar
+  href: StringScalarOutput
+  id: IDScalarOutput
   items: list[QueryBatchSignatory_BatchSignatory_BatchSignatoryItem]
   # The authentication token required for performing batch operations.
-  token: StringScalar
+  token: StringScalarOutput
 
 
 class QueryBatchSignatory_BatchSignatory_BatchSignatoryItem(BaseModel):
@@ -1716,15 +1725,15 @@ class QueryBatchSignatory_BatchSignatory_BatchSignatoryItem(BaseModel):
 class QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_Signatory(BaseModel):
   documents: QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_Signatory_SignatoryDocumentConnection
   # A download link for signatories to download their signed documents. Signatories must verify their identity before downloading. Can be used when signature order is closed with document retention.
-  downloadHref: Optional[StringScalar] = Field(default=None)
+  downloadHref: Optional[StringScalarOutput] = Field(default=None)
   evidenceProviders: list[
     QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_Signatory_SignatureEvidenceProvider
   ]
   # A link to the signatures frontend, you can send this link to your users to enable them to sign your documents.
-  href: StringScalar
-  id: IDScalar
-  reference: Optional[StringScalar] = Field(default=None)
-  role: Optional[StringScalar] = Field(default=None)
+  href: StringScalarOutput
+  id: IDScalarOutput
+  reference: Optional[StringScalarOutput] = Field(default=None)
+  role: Optional[StringScalarOutput] = Field(default=None)
   # Signature order for the signatory.
   signatureOrder: (
     QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_Signatory_SignatureOrder
@@ -1732,24 +1741,24 @@ class QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_Signatory(BaseModel)
   # The current status of the signatory.
   status: SignatoryStatus
   # The reason for the signatory status (rejection reason when rejected).
-  statusReason: Optional[StringScalar] = Field(default=None)
+  statusReason: Optional[StringScalarOutput] = Field(default=None)
 
 
 class QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_SignatureOrder(BaseModel):
-  closedAt: Optional[DateTimeScalar] = Field(default=None)
+  closedAt: Optional[DateTimeScalarOutput] = Field(default=None)
   evidenceProviders: list[
     QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_SignatureOrder_SignatureEvidenceProvider
   ]
-  expiresAt: DateTimeScalar
-  id: IDScalar
+  expiresAt: DateTimeScalarOutput
+  id: IDScalarOutput
   # Number of max signatories for the signature order
-  maxSignatories: IntScalar
+  maxSignatories: IntScalarOutput
   # List of signatories for the signature order.
   signatories: list[
     QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory
   ]
   status: SignatureOrderStatus
-  title: Optional[StringScalar] = Field(default=None)
+  title: Optional[StringScalarOutput] = Field(default=None)
 
 
 class QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_Signatory_SignatoryDocumentConnection(
@@ -1763,22 +1772,22 @@ class QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_Signatory_SignatoryD
 class QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_Signatory_SignatureEvidenceProvider(
   BaseModel
 ):
-  id: IDScalar
+  id: IDScalarOutput
 
 
 class QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_Signatory_SignatureOrder(
   BaseModel
 ):
-  closedAt: Optional[DateTimeScalar] = Field(default=None)
-  expiresAt: DateTimeScalar
-  id: IDScalar
+  closedAt: Optional[DateTimeScalarOutput] = Field(default=None)
+  expiresAt: DateTimeScalarOutput
+  id: IDScalarOutput
   status: SignatureOrderStatus
 
 
 class QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_SignatureOrder_SignatureEvidenceProvider(
   BaseModel
 ):
-  id: IDScalar
+  id: IDScalarOutput
 
 
 class QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory(
@@ -1786,21 +1795,21 @@ class QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signa
 ):
   documents: QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory_SignatoryDocumentConnection
   # A download link for signatories to download their signed documents. Signatories must verify their identity before downloading. Can be used when signature order is closed with document retention.
-  downloadHref: Optional[StringScalar] = Field(default=None)
+  downloadHref: Optional[StringScalarOutput] = Field(default=None)
   evidenceProviders: list[
     QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory_SignatureEvidenceProvider
   ]
   # A link to the signatures frontend, you can send this link to your users to enable them to sign your documents.
-  href: StringScalar
-  id: IDScalar
-  reference: Optional[StringScalar] = Field(default=None)
-  role: Optional[StringScalar] = Field(default=None)
+  href: StringScalarOutput
+  id: IDScalarOutput
+  reference: Optional[StringScalarOutput] = Field(default=None)
+  role: Optional[StringScalarOutput] = Field(default=None)
   # Signature order for the signatory.
   signatureOrder: QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory_SignatureOrder
   # The current status of the signatory.
   status: SignatoryStatus
   # The reason for the signatory status (rejection reason when rejected).
-  statusReason: Optional[StringScalar] = Field(default=None)
+  statusReason: Optional[StringScalarOutput] = Field(default=None)
 
 
 class QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge(
@@ -1821,22 +1830,22 @@ class QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signa
 class QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory_SignatureEvidenceProvider(
   BaseModel
 ):
-  id: IDScalar
+  id: IDScalarOutput
 
 
 class QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory_SignatureOrder(
   BaseModel
 ):
-  closedAt: Optional[DateTimeScalar] = Field(default=None)
-  expiresAt: DateTimeScalar
-  id: IDScalar
+  closedAt: Optional[DateTimeScalarOutput] = Field(default=None)
+  expiresAt: DateTimeScalarOutput
+  id: IDScalarOutput
   status: SignatureOrderStatus
 
 
 class QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document(
   BaseModel
 ):
-  id: IDScalar
+  id: IDScalarOutput
 
 
 class QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge(
@@ -1849,7 +1858,7 @@ class QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signa
 class QueryBatchSignatory_BatchSignatory_BatchSignatoryItem_SignatureOrder_Signatory_SignatoryDocumentConnection_SignatoryDocumentEdge_Document(
   BaseModel
 ):
-  id: IDScalar
+  id: IDScalarOutput
 
 
 queryBatchSignatoryDocument = f"""query batchSignatory($id: ID!) {{
@@ -2013,7 +2022,9 @@ class CriiptoSignaturesSDK:
     )
     return parsed
 
-  def querySignatureOrder(self, id: IDScalar) -> QuerySignatureOrder_SignatureOrder:
+  def querySignatureOrder(
+    self, id: IDScalarInput
+  ) -> QuerySignatureOrder_SignatureOrder:
     query = gql(querySignatureOrderDocument)
     variables = {"id": id}
     result = self.client.execute(query, variable_values=variables)
@@ -2023,7 +2034,7 @@ class CriiptoSignaturesSDK:
     return parsed
 
   def querySignatureOrderWithDocuments(
-    self, id: IDScalar
+    self, id: IDScalarInput
   ) -> QuerySignatureOrderWithDocuments_SignatureOrder:
     query = gql(querySignatureOrderWithDocumentsDocument)
     variables = {"id": id}
@@ -2033,7 +2044,7 @@ class CriiptoSignaturesSDK:
     )
     return parsed
 
-  def querySignatory(self, id: IDScalar) -> QuerySignatory_Signatory:
+  def querySignatory(self, id: IDScalarInput) -> QuerySignatory_Signatory:
     query = gql(querySignatoryDocument)
     variables = {"id": id}
     result = self.client.execute(query, variable_values=variables)
@@ -2043,8 +2054,8 @@ class CriiptoSignaturesSDK:
   def querySignatureOrders(
     self,
     status: Optional[SignatureOrderStatus],
-    first: IntScalar,
-    after: Optional[StringScalar],
+    first: IntScalarInput,
+    after: Optional[StringScalarInput],
   ) -> QuerySignatureOrders_Viewer:
     query = gql(querySignatureOrdersDocument)
     variables = {"status": status, "first": first, "after": after}
@@ -2052,7 +2063,9 @@ class CriiptoSignaturesSDK:
     parsed = QuerySignatureOrders_Viewer.model_validate(result.get("viewer"))
     return parsed
 
-  def queryBatchSignatory(self, id: IDScalar) -> QueryBatchSignatory_BatchSignatory:
+  def queryBatchSignatory(
+    self, id: IDScalarInput
+  ) -> QueryBatchSignatory_BatchSignatory:
     query = gql(queryBatchSignatoryDocument)
     variables = {"id": id}
     result = self.client.execute(query, variable_values=variables)

--- a/packages/python/src/criipto_signatures/operations.py
+++ b/packages/python/src/criipto_signatures/operations.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from .utils import CustomBlobInput
 from enum import StrEnum
 from typing import Optional
 from pydantic import BaseModel, Field

--- a/packages/python/src/criipto_signatures/test_operations.py
+++ b/packages/python/src/criipto_signatures/test_operations.py
@@ -1,5 +1,4 @@
 import os
-import base64
 
 from .operations import CriiptoSignaturesSDK
 from .models import (
@@ -13,15 +12,17 @@ from .models import (
 )
 
 dir_path = os.path.dirname(os.path.realpath(__file__))
-with open(dir_path + "/sample.pdf", "rb") as sample_file:
-  contents = sample_file.read()
-  base64_encoded_data = base64.b64encode(contents)
-  sample_file_content = base64_encoded_data.decode("utf-8")
+
+
+def getFileBytes() -> bytes:
+  with open(dir_path + "/sample.pdf", "rb") as sample_file:
+    return sample_file.read()
+
 
 documentFixture = DocumentInput(
   pdf=PadesDocumentInput(
     title="Python sample document",
-    blob=sample_file_content,
+    blob=getFileBytes(),
     storageMode=DocumentStorageMode.Temporary,
   )
 )

--- a/packages/python/src/criipto_signatures/utils.py
+++ b/packages/python/src/criipto_signatures/utils.py
@@ -1,0 +1,17 @@
+from typing import Annotated
+from pydantic import PlainSerializer
+from base64 import b64encode
+
+
+def serializeBlob(blob: str | bytes) -> str:
+  if isinstance(
+    blob,
+    bytes,
+  ):
+    base64_encoded_data = b64encode(blob)
+    return base64_encoded_data.decode("utf-8")
+  else:
+    return blob
+
+
+type CustomBlobInput = Annotated[str | bytes, PlainSerializer(serializeBlob)]


### PR DESCRIPTION
We want our SDK to be as ergonomic as possible. For one thing, that means consumers should not have to worry about how to encode files in the right format.

When you `.read()` from a file in python you get a `bytes` object. You can now pass that directly into a `PadesDocumentInput`, without having to base64 encode it.

I've included the changes to the generated code in each commit along the way, instead of creating a single commit for all the codegen changes at the end. Let me know if that makes it easier to follow.