### PR TITLE
change(codegen/python): Make all SDK methods async

### DIFF
--- a/codegen/graphql-codegen-plugin-python/src/PythonOperationsVisitor.ts
+++ b/codegen/graphql-codegen-plugin-python/src/PythonOperationsVisitor.ts
@@ -162,7 +162,8 @@ ${expressions.map(expression => `{${expression}}`).join('\n')}"""`;
 class CriiptoSignaturesSDK:
   def __init__(self, clientId: str, clientSecret: str):
     auth = BasicAuth(clientId, clientSecret)
-    transport = AIOHTTPTransport(url=" https://signatures-api.criipto.com/v1/graphql", auth=auth)
+    headers= {"Criipto-Sdk": "criipto-signatures-python"}
+    transport = AIOHTTPTransport(url="https://signatures-api.criipto.com/v1/graphql", auth=auth, headers=headers, ssl=True)
     self.client = Client(transport=transport, fetch_schema_from_transport=False)
 `;
 
@@ -229,7 +230,7 @@ class CriiptoSignaturesSDK:
               },
             );
 
-          const functionDefinition = `def ${operationName}(self, ${functionArguments
+          const functionDefinition = `async def ${operationName}(self, ${functionArguments
             .map(({ name, type, nullable }) => {
               let typeName = type.name;
               if (isScalarType(type)) {
@@ -267,7 +268,7 @@ class CriiptoSignaturesSDK:
           const functionBody = indentMultiline(
             `query = gql(${operationName}Document)
 variables = ${queryVariables}
-result = self.client.execute(query, variable_values=variables)
+result = await self.client.execute_async(query, variable_values=variables)
 parsed = RootModel[${outputTypeName}].model_validate(result.get('${selectionNode.name}')).root
 return parsed`,
             1,

--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -12,7 +12,7 @@ requires = ["uv_build>=0.8.4,<0.9.0"]
 build-backend = "uv_build"
 
 [dependency-groups]
-dev = ["pytest>=8.4.1", "ruff>=0.12.7", "ty>=0.0.1a17"]
+dev = ["pytest>=8.4.1", "pytest-asyncio>=1.1.0", "ruff>=0.12.7", "ty>=0.0.1a17"]
 test = []
 
 [tool.ruff]

--- a/packages/python/src/criipto_signatures/operations.py
+++ b/packages/python/src/criipto_signatures/operations.py
@@ -2441,17 +2441,21 @@ queryBatchSignatoryDocument = f"""query batchSignatory($id: ID!) {{
 class CriiptoSignaturesSDK:
   def __init__(self, clientId: str, clientSecret: str):
     auth = BasicAuth(clientId, clientSecret)
+    headers = {"Criipto-Sdk": "criipto-signatures-python"}
     transport = AIOHTTPTransport(
-      url=" https://signatures-api.criipto.com/v1/graphql", auth=auth
+      url="https://signatures-api.criipto.com/v1/graphql",
+      auth=auth,
+      headers=headers,
+      ssl=True,
     )
     self.client = Client(transport=transport, fetch_schema_from_transport=False)
 
-  def createSignatureOrder(
+  async def createSignatureOrder(
     self, input: CreateSignatureOrderInput
   ) -> CreateSignatureOrder_CreateSignatureOrderOutput:
     query = gql(createSignatureOrderDocument)
     variables = {"input": input.model_dump()}
-    result = self.client.execute(query, variable_values=variables)
+    result = await self.client.execute_async(query, variable_values=variables)
     parsed = (
       RootModel[CreateSignatureOrder_CreateSignatureOrderOutput]
       .model_validate(result.get("createSignatureOrder"))
@@ -2459,12 +2463,12 @@ class CriiptoSignaturesSDK:
     )
     return parsed
 
-  def cleanupSignatureOrder(
+  async def cleanupSignatureOrder(
     self, input: CleanupSignatureOrderInput
   ) -> CleanupSignatureOrder_CleanupSignatureOrderOutput:
     query = gql(cleanupSignatureOrderDocument)
     variables = {"input": input.model_dump()}
-    result = self.client.execute(query, variable_values=variables)
+    result = await self.client.execute_async(query, variable_values=variables)
     parsed = (
       RootModel[CleanupSignatureOrder_CleanupSignatureOrderOutput]
       .model_validate(result.get("cleanupSignatureOrder"))
@@ -2472,10 +2476,12 @@ class CriiptoSignaturesSDK:
     )
     return parsed
 
-  def addSignatory(self, input: AddSignatoryInput) -> AddSignatory_AddSignatoryOutput:
+  async def addSignatory(
+    self, input: AddSignatoryInput
+  ) -> AddSignatory_AddSignatoryOutput:
     query = gql(addSignatoryDocument)
     variables = {"input": input.model_dump()}
-    result = self.client.execute(query, variable_values=variables)
+    result = await self.client.execute_async(query, variable_values=variables)
     parsed = (
       RootModel[AddSignatory_AddSignatoryOutput]
       .model_validate(result.get("addSignatory"))
@@ -2483,12 +2489,12 @@ class CriiptoSignaturesSDK:
     )
     return parsed
 
-  def addSignatories(
+  async def addSignatories(
     self, input: AddSignatoriesInput
   ) -> AddSignatories_AddSignatoriesOutput:
     query = gql(addSignatoriesDocument)
     variables = {"input": input.model_dump()}
-    result = self.client.execute(query, variable_values=variables)
+    result = await self.client.execute_async(query, variable_values=variables)
     parsed = (
       RootModel[AddSignatories_AddSignatoriesOutput]
       .model_validate(result.get("addSignatories"))
@@ -2496,12 +2502,12 @@ class CriiptoSignaturesSDK:
     )
     return parsed
 
-  def changeSignatory(
+  async def changeSignatory(
     self, input: ChangeSignatoryInput
   ) -> ChangeSignatory_ChangeSignatoryOutput:
     query = gql(changeSignatoryDocument)
     variables = {"input": input.model_dump()}
-    result = self.client.execute(query, variable_values=variables)
+    result = await self.client.execute_async(query, variable_values=variables)
     parsed = (
       RootModel[ChangeSignatory_ChangeSignatoryOutput]
       .model_validate(result.get("changeSignatory"))
@@ -2509,12 +2515,12 @@ class CriiptoSignaturesSDK:
     )
     return parsed
 
-  def closeSignatureOrder(
+  async def closeSignatureOrder(
     self, input: CloseSignatureOrderInput
   ) -> CloseSignatureOrder_CloseSignatureOrderOutput:
     query = gql(closeSignatureOrderDocument)
     variables = {"input": input.model_dump()}
-    result = self.client.execute(query, variable_values=variables)
+    result = await self.client.execute_async(query, variable_values=variables)
     parsed = (
       RootModel[CloseSignatureOrder_CloseSignatureOrderOutput]
       .model_validate(result.get("closeSignatureOrder"))
@@ -2522,12 +2528,12 @@ class CriiptoSignaturesSDK:
     )
     return parsed
 
-  def cancelSignatureOrder(
+  async def cancelSignatureOrder(
     self, input: CancelSignatureOrderInput
   ) -> CancelSignatureOrder_CancelSignatureOrderOutput:
     query = gql(cancelSignatureOrderDocument)
     variables = {"input": input.model_dump()}
-    result = self.client.execute(query, variable_values=variables)
+    result = await self.client.execute_async(query, variable_values=variables)
     parsed = (
       RootModel[CancelSignatureOrder_CancelSignatureOrderOutput]
       .model_validate(result.get("cancelSignatureOrder"))
@@ -2535,10 +2541,12 @@ class CriiptoSignaturesSDK:
     )
     return parsed
 
-  def signActingAs(self, input: SignActingAsInput) -> SignActingAs_SignActingAsOutput:
+  async def signActingAs(
+    self, input: SignActingAsInput
+  ) -> SignActingAs_SignActingAsOutput:
     query = gql(signActingAsDocument)
     variables = {"input": input.model_dump()}
-    result = self.client.execute(query, variable_values=variables)
+    result = await self.client.execute_async(query, variable_values=variables)
     parsed = (
       RootModel[SignActingAs_SignActingAsOutput]
       .model_validate(result.get("signActingAs"))
@@ -2546,12 +2554,12 @@ class CriiptoSignaturesSDK:
     )
     return parsed
 
-  def validateDocument(
+  async def validateDocument(
     self, input: ValidateDocumentInput
   ) -> ValidateDocument_ValidateDocumentOutput:
     query = gql(validateDocumentDocument)
     variables = {"input": input.model_dump()}
-    result = self.client.execute(query, variable_values=variables)
+    result = await self.client.execute_async(query, variable_values=variables)
     parsed = (
       RootModel[ValidateDocument_ValidateDocumentOutput]
       .model_validate(result.get("validateDocument"))
@@ -2559,12 +2567,12 @@ class CriiptoSignaturesSDK:
     )
     return parsed
 
-  def extendSignatureOrder(
+  async def extendSignatureOrder(
     self, input: ExtendSignatureOrderInput
   ) -> ExtendSignatureOrder_ExtendSignatureOrderOutput:
     query = gql(extendSignatureOrderDocument)
     variables = {"input": input.model_dump()}
-    result = self.client.execute(query, variable_values=variables)
+    result = await self.client.execute_async(query, variable_values=variables)
     parsed = (
       RootModel[ExtendSignatureOrder_ExtendSignatureOrderOutput]
       .model_validate(result.get("extendSignatureOrder"))
@@ -2572,12 +2580,12 @@ class CriiptoSignaturesSDK:
     )
     return parsed
 
-  def deleteSignatory(
+  async def deleteSignatory(
     self, input: DeleteSignatoryInput
   ) -> DeleteSignatory_DeleteSignatoryOutput:
     query = gql(deleteSignatoryDocument)
     variables = {"input": input.model_dump()}
-    result = self.client.execute(query, variable_values=variables)
+    result = await self.client.execute_async(query, variable_values=variables)
     parsed = (
       RootModel[DeleteSignatory_DeleteSignatoryOutput]
       .model_validate(result.get("deleteSignatory"))
@@ -2585,12 +2593,12 @@ class CriiptoSignaturesSDK:
     )
     return parsed
 
-  def createBatchSignatory(
+  async def createBatchSignatory(
     self, input: CreateBatchSignatoryInput
   ) -> CreateBatchSignatory_CreateBatchSignatoryOutput:
     query = gql(createBatchSignatoryDocument)
     variables = {"input": input.model_dump()}
-    result = self.client.execute(query, variable_values=variables)
+    result = await self.client.execute_async(query, variable_values=variables)
     parsed = (
       RootModel[CreateBatchSignatory_CreateBatchSignatoryOutput]
       .model_validate(result.get("createBatchSignatory"))
@@ -2598,12 +2606,12 @@ class CriiptoSignaturesSDK:
     )
     return parsed
 
-  def changeSignatureOrder(
+  async def changeSignatureOrder(
     self, input: ChangeSignatureOrderInput
   ) -> ChangeSignatureOrder_ChangeSignatureOrderOutput:
     query = gql(changeSignatureOrderDocument)
     variables = {"input": input.model_dump()}
-    result = self.client.execute(query, variable_values=variables)
+    result = await self.client.execute_async(query, variable_values=variables)
     parsed = (
       RootModel[ChangeSignatureOrder_ChangeSignatureOrderOutput]
       .model_validate(result.get("changeSignatureOrder"))
@@ -2611,12 +2619,12 @@ class CriiptoSignaturesSDK:
     )
     return parsed
 
-  def querySignatureOrder(
+  async def querySignatureOrder(
     self, id: IDScalarInput
   ) -> QuerySignatureOrder_SignatureOrder:
     query = gql(querySignatureOrderDocument)
     variables = {"id": id}
-    result = self.client.execute(query, variable_values=variables)
+    result = await self.client.execute_async(query, variable_values=variables)
     parsed = (
       RootModel[QuerySignatureOrder_SignatureOrder]
       .model_validate(result.get("signatureOrder"))
@@ -2624,12 +2632,12 @@ class CriiptoSignaturesSDK:
     )
     return parsed
 
-  def querySignatureOrderWithDocuments(
+  async def querySignatureOrderWithDocuments(
     self, id: IDScalarInput
   ) -> QuerySignatureOrderWithDocuments_SignatureOrder:
     query = gql(querySignatureOrderWithDocumentsDocument)
     variables = {"id": id}
-    result = self.client.execute(query, variable_values=variables)
+    result = await self.client.execute_async(query, variable_values=variables)
     parsed = (
       RootModel[QuerySignatureOrderWithDocuments_SignatureOrder]
       .model_validate(result.get("signatureOrder"))
@@ -2637,16 +2645,16 @@ class CriiptoSignaturesSDK:
     )
     return parsed
 
-  def querySignatory(self, id: IDScalarInput) -> QuerySignatory_Signatory:
+  async def querySignatory(self, id: IDScalarInput) -> QuerySignatory_Signatory:
     query = gql(querySignatoryDocument)
     variables = {"id": id}
-    result = self.client.execute(query, variable_values=variables)
+    result = await self.client.execute_async(query, variable_values=variables)
     parsed = (
       RootModel[QuerySignatory_Signatory].model_validate(result.get("signatory")).root
     )
     return parsed
 
-  def querySignatureOrders(
+  async def querySignatureOrders(
     self,
     first: IntScalarInput,
     status: Optional[SignatureOrderStatus] = None,
@@ -2658,18 +2666,18 @@ class CriiptoSignaturesSDK:
       "status": status if status is not None else "",
       "after": after,
     }
-    result = self.client.execute(query, variable_values=variables)
+    result = await self.client.execute_async(query, variable_values=variables)
     parsed = (
       RootModel[QuerySignatureOrders_Viewer].model_validate(result.get("viewer")).root
     )
     return parsed
 
-  def queryBatchSignatory(
+  async def queryBatchSignatory(
     self, id: IDScalarInput
   ) -> QueryBatchSignatory_BatchSignatory:
     query = gql(queryBatchSignatoryDocument)
     variables = {"id": id}
-    result = self.client.execute(query, variable_values=variables)
+    result = await self.client.execute_async(query, variable_values=variables)
     parsed = (
       RootModel[QueryBatchSignatory_BatchSignatory]
       .model_validate(result.get("batchSignatory"))

--- a/packages/python/src/criipto_signatures/test_operations.py
+++ b/packages/python/src/criipto_signatures/test_operations.py
@@ -17,6 +17,7 @@ from .models import (
   DocumentStorageMode,
   SignatureOrderStatus,
 )
+import pytest
 
 dir_path = os.path.dirname(os.path.realpath(__file__))
 
@@ -35,13 +36,14 @@ documentFixture = DocumentInput(
 )
 
 
-def test_create_signature_order_add_signatory():
+@pytest.mark.asyncio
+async def test_create_signature_order_add_signatory():
   sdk = CriiptoSignaturesSDK(
     os.environ["CRIIPTO_SIGNATURES_CLIENT_ID"],
     os.environ["CRIIPTO_SIGNATURES_CLIENT_SECRET"],
   )
 
-  signatureOrderResponse = sdk.createSignatureOrder(
+  signatureOrderResponse = await sdk.createSignatureOrder(
     CreateSignatureOrderInput(
       title="Python sample signature order",
       expiresInDays=1,
@@ -52,25 +54,26 @@ def test_create_signature_order_add_signatory():
   assert signatureOrderResponse.signatureOrder
   assert signatureOrderResponse.signatureOrder.id
 
-  signatoryResp = sdk.addSignatory(
+  signatoryResp = await sdk.addSignatory(
     AddSignatoryInput(signatureOrderId=signatureOrderResponse.signatureOrder.id)
   )
 
   assert signatoryResp.signatory
   assert signatoryResp.signatory.href
 
-  sdk.cancelSignatureOrder(
+  await sdk.cancelSignatureOrder(
     CancelSignatureOrderInput(signatureOrderId=signatureOrderResponse.signatureOrder.id)
   )
 
 
-def test_create_signature_order_with_form():
+@pytest.mark.asyncio
+async def test_create_signature_order_with_form():
   sdk = CriiptoSignaturesSDK(
     os.environ["CRIIPTO_SIGNATURES_CLIENT_ID"],
     os.environ["CRIIPTO_SIGNATURES_CLIENT_SECRET"],
   )
 
-  signatureOrderResponse = sdk.createSignatureOrder(
+  signatureOrderResponse = await sdk.createSignatureOrder(
     CreateSignatureOrderInput(
       title="Python sample signature order",
       expiresInDays=1,
@@ -97,18 +100,19 @@ def test_create_signature_order_with_form():
   assert document.form is not None
   assert document.form.enabled
 
-  sdk.cancelSignatureOrder(
+  await sdk.cancelSignatureOrder(
     CancelSignatureOrderInput(signatureOrderId=signatureOrderResponse.signatureOrder.id)
   )
 
 
-def test_change_max_signatories():
+@pytest.mark.asyncio
+async def test_change_max_signatories():
   sdk = CriiptoSignaturesSDK(
     os.environ["CRIIPTO_SIGNATURES_CLIENT_ID"],
     os.environ["CRIIPTO_SIGNATURES_CLIENT_SECRET"],
   )
 
-  signatureOrderResponse = sdk.createSignatureOrder(
+  signatureOrderResponse = await sdk.createSignatureOrder(
     CreateSignatureOrderInput(
       title="Python sample signature order",
       expiresInDays=1,
@@ -120,7 +124,7 @@ def test_change_max_signatories():
   assert signatureOrderResponse.signatureOrder
   assert signatureOrderResponse.signatureOrder.id
 
-  changedSignatureOrderResponse = sdk.changeSignatureOrder(
+  changedSignatureOrderResponse = await sdk.changeSignatureOrder(
     ChangeSignatureOrderInput(
       signatureOrderId=signatureOrderResponse.signatureOrder.id, maxSignatories=20
     )
@@ -129,12 +133,13 @@ def test_change_max_signatories():
   assert changedSignatureOrderResponse.signatureOrder
   assert changedSignatureOrderResponse.signatureOrder.maxSignatories == 20
 
-  sdk.cancelSignatureOrder(
+  await sdk.cancelSignatureOrder(
     CancelSignatureOrderInput(signatureOrderId=signatureOrderResponse.signatureOrder.id)
   )
 
 
-def test_query_signature_orders():
+@pytest.mark.asyncio
+async def test_query_signature_orders():
   sdk = CriiptoSignaturesSDK(
     os.environ["CRIIPTO_SIGNATURES_CLIENT_ID"],
     os.environ["CRIIPTO_SIGNATURES_CLIENT_SECRET"],
@@ -142,7 +147,7 @@ def test_query_signature_orders():
 
   title = "Python sample signature order" + str(datetime.now())
 
-  createSignatureOrderResponse = sdk.createSignatureOrder(
+  createSignatureOrderResponse = await sdk.createSignatureOrder(
     CreateSignatureOrderInput(
       title=title,
       expiresInDays=1,
@@ -150,7 +155,7 @@ def test_query_signature_orders():
     )
   )
 
-  signatureOrdersResponse = sdk.querySignatureOrders(
+  signatureOrdersResponse = await sdk.querySignatureOrders(
     first=1000, status=SignatureOrderStatus.OPEN
   )
 
@@ -164,7 +169,7 @@ def test_query_signature_orders():
   assert createdSignatureOrder is not None
   assert createdSignatureOrder.title == title
 
-  sdk.cancelSignatureOrder(
+  await sdk.cancelSignatureOrder(
     CancelSignatureOrderInput(
       signatureOrderId=createSignatureOrderResponse.signatureOrder.id
     )

--- a/packages/python/uv.lock
+++ b/packages/python/uv.lock
@@ -118,6 +118,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "ruff" },
     { name = "ty" },
 ]
@@ -131,6 +132,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "pytest", specifier = ">=8.4.1" },
+    { name = "pytest-asyncio", specifier = ">=1.1.0" },
     { name = "ruff", specifier = ">=0.12.7" },
     { name = "ty", specifier = ">=0.0.1a17" },
 ]
@@ -396,6 +398,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/08/ba/45911d754e8eba3d5a841a5ce61a65a685ff1798421ac054f85aa8747dfb/pytest-8.4.1.tar.gz", hash = "sha256:7c67fd69174877359ed9371ec3af8a3d2b04741818c51e5e99cc1742251fa93c", size = 1517714, upload-time = "2025-06-18T05:48:06.109Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/29/16/c8a903f4c4dffe7a12843191437d7cd8e32751d5de349d45d3fe69544e87/pytest-8.4.1-py3-none-any.whl", hash = "sha256:539c70ba6fcead8e78eebbf1115e8b589e7565830d7d006a8723f19ac8a0afb7", size = 365474, upload-time = "2025-06-18T05:48:03.955Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4e/51/f8794af39eeb870e87a8c8068642fc07bce0c854d6865d7dd0f2a9d338c2/pytest_asyncio-1.1.0.tar.gz", hash = "sha256:796aa822981e01b68c12e4827b8697108f7205020f24b5793b3c41555dab68ea", size = 46652, upload-time = "2025-07-16T04:29:26.393Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/9d/bf86eddabf8c6c9cb1ea9a869d6873b46f105a5d292d3a6f7071f5b07935/pytest_asyncio-1.1.0-py3-none-any.whl", hash = "sha256:5fe2d69607b0bd75c656d1211f969cadba035030156745ee09e7d71740e58ecf", size = 15157, upload-time = "2025-07-16T04:29:24.929Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Coming from node.js I've also learned "don't block the event loop!". This seems like a good idea in python as well https://realpython.com/async-io-python/#when-to-use-async-io . The overall recommendation that I've found seems to be to use asyncio when you have a lot of non-blocking IO such as database calls, network calls (like the ones to our API) etc. 

It remains to be seen whether all SDK consumers can / want to use an async version of the SDK, but let's cross that bridge when we get there.