### PR TITLE
change(packages/python): Prepare for publishing to pypi

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,4 @@ SDKs for Criipto Signatures API
 
 - [Node.js](https://github.com/criipto/criipto-signatures-sdk/tree/master/packages/nodejs/)
 - [.NET (C#)](https://github.com/criipto/criipto-signatures-sdk/tree/master/packages/dotnet/)
+- [Python](https://github.com/criipto/criipto-signatures-sdk/tree/master/packages/python/)

--- a/packages/python/README.md
+++ b/packages/python/README.md
@@ -1,3 +1,94 @@
-:building_construction:
+# criipto-signatures
 
-This project is under construction - Check back soon.
+A python SDK for Criipto Signatures.
+
+Sign PAdeS-LTA documents using MitID, BankID or any other eID supported by Criipto.
+
+[Examples](https://docs.criipto.com/signatures/graphql/examples/)
+
+## Getting started
+
+### Requirements
+
+This library supports python 3.13 and later.
+
+### Installation
+
+The SDK is available on [PYPI](https://pypi.org/project/criipto-signatures/):
+
+```
+python3 -m pip install criipto-signatures
+```
+
+### Configure the SDK
+
+The SDK is available in both a sync and an async version
+
+```python
+from criipto_signatures import (
+  CriiptoSignaturesSDKAsync,
+  CriiptoSignaturesSDKSync,
+)
+asyncClient = CriiptoSignaturesSDKAsync(
+    '{YOUR_CRIIPTO_CLIENT_ID}',
+    '{YOUR_CRIIPTO_CLIENT_SECRET}'
+)
+syncClient = CriiptoSignaturesSDKSync(
+    '{YOUR_CRIIPTO_CLIENT_ID}',
+    '{YOUR_CRIIPTO_CLIENT_SECRET}'
+)
+```
+
+## Basic example
+
+```python
+from criipto_signatures import CriiptoSignaturesSDKAsync
+from criipto_signatures.models import (
+    CreateSignatureOrderInput,
+    DocumentInput,
+    PadesDocumentInput,
+    DocumentStorageMode,
+    AddSignatoryInput,
+    CloseSignatureOrderInput,
+)
+
+client = CriiptoSignaturesSDKAsync(
+    '{YOUR_CRIIPTO_CLIENT_ID}',
+    '{YOUR_CRIIPTO_CLIENT_SECRET}'
+)
+
+# Create signature order
+signatureOrder = await client.createSignatureOrder(
+    CreateSignatureOrderInput(
+        documents=[
+            DocumentInput(
+                pdf=PadesDocumentInput(
+                    title="My document",
+                    blob=data, # bytes object, or a base64 encoded string
+                    storageMode=DocumentStorageMode.Temporary,
+                )
+            )
+        ]
+    )
+)
+
+# Add signatory to signature order
+signatory = await client.addSignatory(
+    AddSignatoryInput(
+        signatureOrderId=signatureOrder.id
+    )
+)
+print(signatory.href)
+
+# ... Wait for the signatory to sign
+
+# And close the order
+await client.closeSignatureOrder(
+    CloseSignatureOrderInput(
+        signatureOrderId=signatureOrder.id,
+        retainDocumentsForDays=1
+    )
+)
+```
+
+For a more complete example, see the [example project](https://github.com/criipto/criipto-signatures-sdk/tree/master/packages/python/example)

--- a/packages/python/example/uv.lock
+++ b/packages/python/example/uv.lock
@@ -83,7 +83,7 @@ wheels = [
 
 [[package]]
 name = "criipto-signatures"
-version = "0.1.0"
+version = "0.1.0a5"
 source = { editable = "../" }
 dependencies = [
     { name = "gql", extra = ["httpx"] },

--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -1,15 +1,22 @@
 [project]
 name = "criipto-signatures"
-version = "0.1.0"
+version = "0.1.0a5"
 description = "A library for interacting with the Criipto signatures GraphQL API."
 readme = "README.md"
+license = "MIT"
 authors = [{ name = "Jan Aagaard Meier", email = "jan.meier@criipto.com" }]
 requires-python = ">=3.13"
-dependencies = [
-    "gql[httpx]>=4.0.0",
-    "httpx>=0.28.1",
-    "pydantic>=2.11.7",
+dependencies = ["gql[httpx]>=4.0.0", "httpx>=0.28.1", "pydantic>=2.11.7"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "License :: OSI Approved :: MIT License",
 ]
+
+[project.urls]
+homepage = "https://criipto.com"
+source = "https://github.com/criipto/criipto-signatures-sdk/tree/master/packages/python"
+issues = "https://github.com/criipto/criipto-signatures-sdk/issues"
+changelog = "https://github.com/criipto/criipto-signatures-sdk/releases"
 
 [build-system]
 requires = ["uv_build>=0.8.4,<0.9.0"]

--- a/packages/python/uv.lock
+++ b/packages/python/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "criipto-signatures"
-version = "0.1.0"
+version = "0.1.0a5"
 source = { editable = "." }
 dependencies = [
     { name = "gql", extra = ["httpx"] },


### PR DESCRIPTION
🎉 https://pypi.org/project/criipto-signatures/

I have purposefully _not_ enabled automagic publishing from github yet. I would like to be able to quickly publish packages locally, until we get to a more stable state.

@mickhansen Would you be okay with me announcing on slack that the SDK is ready for alpha testing? And updating the docs site as well?