### PR TITLE
change(packages/python): Return graphql blob as bytes, instead of str…

### DIFF
--- a/codegen/graphql-codegen-plugin-python/src/PythonTypesVisitor.ts
+++ b/codegen/graphql-codegen-plugin-python/src/PythonTypesVisitor.ts
@@ -33,7 +33,7 @@ const DEFAULT_SCALARS = {
   Int: { input: 'int', output: 'int' },
   Float: { input: 'float', output: 'float' },
   Boolean: { input: 'bool', output: 'bool' },
-  Blob: { input: 'CustomBlobInput', output: 'str' },
+  Blob: { input: 'CustomBlobInput', output: 'CustomBlobOutput' },
 } as const;
 
 export class PythonTypesVisitor extends BaseVisitor {
@@ -57,7 +57,7 @@ export class PythonTypesVisitor extends BaseVisitor {
   static getImports() {
     return [
       'from __future__ import annotations',
-      'from .utils import CustomBlobInput',
+      'from .utils import CustomBlobInput, CustomBlobOutput',
       'from enum import StrEnum',
       'from typing import Optional',
       'from pydantic import BaseModel, Field',

--- a/packages/python/example/app.py
+++ b/packages/python/example/app.py
@@ -1,5 +1,4 @@
 import os
-from base64 import b64decode
 from flask import Flask, flash, make_response, redirect, render_template, request
 
 from criipto_signatures import CriiptoSignaturesSDK
@@ -129,8 +128,7 @@ async def callback(signatureOrderId: str):
     )
     and document.blob is not None
   ):
-    decoded = b64decode(document.blob)
-    response = make_response(decoded)
+    response = make_response(document.blob)
     response.headers["Content-Type"] = "application/pdf"
     response.headers["Content-Disposition"] = "inline; filename=signed.pdf"
     return response

--- a/packages/python/src/criipto_signatures/models.py
+++ b/packages/python/src/criipto_signatures/models.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from .utils import CustomBlobInput
+from .utils import CustomBlobInput, CustomBlobOutput
 from enum import StrEnum
 from typing import Optional
 from pydantic import BaseModel, Field
@@ -15,7 +15,7 @@ type FloatScalarOutput = float
 type BooleanScalarInput = bool
 type BooleanScalarOutput = bool
 type BlobScalarInput = CustomBlobInput
-type BlobScalarOutput = str
+type BlobScalarOutput = CustomBlobOutput
 type DateScalarInput = str
 type DateScalarOutput = str
 type DateTimeScalarInput = str
@@ -695,6 +695,7 @@ class SignActingAsOutput(BaseModel):
 
 class SignAllOfInput(BaseModel):
   criiptoVerify: Optional[SignCriiptoVerifyInput] = Field(default=None)
+  criiptoVerifyV2: Optional[SignCriiptoVerifyV2Input] = Field(default=None)
   drawable: Optional[SignDrawableInput] = Field(default=None)
   noop: Optional[BooleanScalarInput] = Field(default=None)
   oidc: Optional[SignOidcInput] = Field(default=None)
@@ -702,6 +703,11 @@ class SignAllOfInput(BaseModel):
 
 class SignCriiptoVerifyInput(BaseModel):
   jwt: StringScalarInput
+
+
+class SignCriiptoVerifyV2Input(BaseModel):
+  code: StringScalarInput
+  state: StringScalarInput
 
 
 class SignDocumentFormFieldInput(BaseModel):
@@ -726,6 +732,7 @@ class SignDrawableInput(BaseModel):
 class SignInput(BaseModel):
   allOf: Optional[SignAllOfInput] = Field(default=None)
   criiptoVerify: Optional[SignCriiptoVerifyInput] = Field(default=None)
+  criiptoVerifyV2: Optional[SignCriiptoVerifyV2Input] = Field(default=None)
   documents: Optional[list[SignDocumentInput]] = Field(default=None)
   drawable: Optional[SignDrawableInput] = Field(default=None)
   # EvidenceProvider id
@@ -1251,6 +1258,7 @@ SignActingAsInput.model_rebuild()
 SignActingAsOutput.model_rebuild()
 SignAllOfInput.model_rebuild()
 SignCriiptoVerifyInput.model_rebuild()
+SignCriiptoVerifyV2Input.model_rebuild()
 SignDocumentFormFieldInput.model_rebuild()
 SignDocumentFormInput.model_rebuild()
 SignDocumentInput.model_rebuild()

--- a/packages/python/src/criipto_signatures/operations.py
+++ b/packages/python/src/criipto_signatures/operations.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from .utils import CustomBlobInput
+from .utils import CustomBlobInput, CustomBlobOutput
 from enum import StrEnum
 from typing import Optional
 from pydantic import BaseModel, Field

--- a/packages/python/src/criipto_signatures/utils.py
+++ b/packages/python/src/criipto_signatures/utils.py
@@ -1,6 +1,6 @@
 from typing import Annotated
-from pydantic import PlainSerializer
-from base64 import b64encode
+from pydantic import PlainSerializer, PlainValidator
+from base64 import b64encode, b64decode
 
 
 def serializeBlob(blob: str | bytes) -> str:
@@ -15,3 +15,6 @@ def serializeBlob(blob: str | bytes) -> str:
 
 
 type CustomBlobInput = Annotated[str | bytes, PlainSerializer(serializeBlob)]
+
+
+type CustomBlobOutput = Annotated[bytes, PlainValidator(b64decode)]


### PR DESCRIPTION
…ings.

The fact that blobs are base64 encoded is an implementation detail of our API. As an API consumer, I expect to get some bytes back that I can easily save to a file or send back to the client. This also matches the fact that we allow passing in bytes when creating a signature order.