### PR TITLE
change(packages/python): Simplify the return type from mutations.

### DIFF
--- a/packages/python/example/app.py
+++ b/packages/python/example/app.py
@@ -54,7 +54,7 @@ async def uploadFile():
     # time validating that what you got is actually a PDF. `createSignatureOrder` will fail if
     # called with something that is not actually a PDF.
     data: bytes = file.read()
-    createSignatureOrderResponse = await criiptoSdk.createSignatureOrder(
+    signatureOrder = await criiptoSdk.createSignatureOrder(
       CreateSignatureOrderInput(
         documents=[
           DocumentInput(
@@ -68,20 +68,19 @@ async def uploadFile():
       )
     )
 
-    signatureOrderId = createSignatureOrderResponse.signatureOrder.id
     # Now that we have a signature order, add someone to sign it.
-    addSignatoryResponse = await criiptoSdk.addSignatory(
+    signatory = await criiptoSdk.addSignatory(
       AddSignatoryInput(
-        signatureOrderId=signatureOrderId,
+        signatureOrderId=signatureOrder.id,
         ui=SignatoryUIInput(
           # Return to our application once the signatory completes the process.
-          signatoryRedirectUri="http://localhost:5000/callback/" + signatureOrderId
+          signatoryRedirectUri="http://localhost:5000/callback/" + signatureOrder.id
         ),
       )
     )
 
     # Render a page with the link to the Criipto hosted signature page.
-    return render_template("signature.html", href=addSignatoryResponse.signatory.href)
+    return render_template("signature.html", href=signatory.href)
   else:
     flash("Could not process file")
     return redirect("/")

--- a/packages/python/src/criipto_signatures/operations.py
+++ b/packages/python/src/criipto_signatures/operations.py
@@ -2465,105 +2465,105 @@ class CriiptoSignaturesSDK:
 
   async def createSignatureOrder(
     self, input: CreateSignatureOrderInput
-  ) -> CreateSignatureOrder_CreateSignatureOrderOutput:
+  ) -> CreateSignatureOrder_CreateSignatureOrderOutput_SignatureOrder:
     query = gql(createSignatureOrderDocument)
     variables = {"input": input.model_dump()}
     result = await self.client.execute_async(query, variable_values=variables)
     parsed = (
       RootModel[CreateSignatureOrder_CreateSignatureOrderOutput]
       .model_validate(result.get("createSignatureOrder"))
-      .root
+      .root.signatureOrder
     )
     return parsed
 
   async def cleanupSignatureOrder(
     self, input: CleanupSignatureOrderInput
-  ) -> CleanupSignatureOrder_CleanupSignatureOrderOutput:
+  ) -> CleanupSignatureOrder_CleanupSignatureOrderOutput_SignatureOrder:
     query = gql(cleanupSignatureOrderDocument)
     variables = {"input": input.model_dump()}
     result = await self.client.execute_async(query, variable_values=variables)
     parsed = (
       RootModel[CleanupSignatureOrder_CleanupSignatureOrderOutput]
       .model_validate(result.get("cleanupSignatureOrder"))
-      .root
+      .root.signatureOrder
     )
     return parsed
 
   async def addSignatory(
     self, input: AddSignatoryInput
-  ) -> AddSignatory_AddSignatoryOutput:
+  ) -> AddSignatory_AddSignatoryOutput_Signatory:
     query = gql(addSignatoryDocument)
     variables = {"input": input.model_dump()}
     result = await self.client.execute_async(query, variable_values=variables)
     parsed = (
       RootModel[AddSignatory_AddSignatoryOutput]
       .model_validate(result.get("addSignatory"))
-      .root
+      .root.signatory
     )
     return parsed
 
   async def addSignatories(
     self, input: AddSignatoriesInput
-  ) -> AddSignatories_AddSignatoriesOutput:
+  ) -> list[AddSignatories_AddSignatoriesOutput_Signatory]:
     query = gql(addSignatoriesDocument)
     variables = {"input": input.model_dump()}
     result = await self.client.execute_async(query, variable_values=variables)
     parsed = (
       RootModel[AddSignatories_AddSignatoriesOutput]
       .model_validate(result.get("addSignatories"))
-      .root
+      .root.signatories
     )
     return parsed
 
   async def changeSignatory(
     self, input: ChangeSignatoryInput
-  ) -> ChangeSignatory_ChangeSignatoryOutput:
+  ) -> ChangeSignatory_ChangeSignatoryOutput_Signatory:
     query = gql(changeSignatoryDocument)
     variables = {"input": input.model_dump()}
     result = await self.client.execute_async(query, variable_values=variables)
     parsed = (
       RootModel[ChangeSignatory_ChangeSignatoryOutput]
       .model_validate(result.get("changeSignatory"))
-      .root
+      .root.signatory
     )
     return parsed
 
   async def closeSignatureOrder(
     self, input: CloseSignatureOrderInput
-  ) -> CloseSignatureOrder_CloseSignatureOrderOutput:
+  ) -> CloseSignatureOrder_CloseSignatureOrderOutput_SignatureOrder:
     query = gql(closeSignatureOrderDocument)
     variables = {"input": input.model_dump()}
     result = await self.client.execute_async(query, variable_values=variables)
     parsed = (
       RootModel[CloseSignatureOrder_CloseSignatureOrderOutput]
       .model_validate(result.get("closeSignatureOrder"))
-      .root
+      .root.signatureOrder
     )
     return parsed
 
   async def cancelSignatureOrder(
     self, input: CancelSignatureOrderInput
-  ) -> CancelSignatureOrder_CancelSignatureOrderOutput:
+  ) -> CancelSignatureOrder_CancelSignatureOrderOutput_SignatureOrder:
     query = gql(cancelSignatureOrderDocument)
     variables = {"input": input.model_dump()}
     result = await self.client.execute_async(query, variable_values=variables)
     parsed = (
       RootModel[CancelSignatureOrder_CancelSignatureOrderOutput]
       .model_validate(result.get("cancelSignatureOrder"))
-      .root
+      .root.signatureOrder
     )
     return parsed
 
   async def signActingAs(
     self, input: SignActingAsInput
-  ) -> SignActingAs_SignActingAsOutput:
+  ) -> SignActingAs_SignActingAsOutput_Signatory:
     query = gql(signActingAsDocument)
     variables = {"input": input.model_dump()}
     result = await self.client.execute_async(query, variable_values=variables)
     parsed = (
       RootModel[SignActingAs_SignActingAsOutput]
       .model_validate(result.get("signActingAs"))
-      .root
+      .root.signatory
     )
     return parsed
 
@@ -2582,53 +2582,53 @@ class CriiptoSignaturesSDK:
 
   async def extendSignatureOrder(
     self, input: ExtendSignatureOrderInput
-  ) -> ExtendSignatureOrder_ExtendSignatureOrderOutput:
+  ) -> ExtendSignatureOrder_ExtendSignatureOrderOutput_SignatureOrder:
     query = gql(extendSignatureOrderDocument)
     variables = {"input": input.model_dump()}
     result = await self.client.execute_async(query, variable_values=variables)
     parsed = (
       RootModel[ExtendSignatureOrder_ExtendSignatureOrderOutput]
       .model_validate(result.get("extendSignatureOrder"))
-      .root
+      .root.signatureOrder
     )
     return parsed
 
   async def deleteSignatory(
     self, input: DeleteSignatoryInput
-  ) -> DeleteSignatory_DeleteSignatoryOutput:
+  ) -> DeleteSignatory_DeleteSignatoryOutput_SignatureOrder:
     query = gql(deleteSignatoryDocument)
     variables = {"input": input.model_dump()}
     result = await self.client.execute_async(query, variable_values=variables)
     parsed = (
       RootModel[DeleteSignatory_DeleteSignatoryOutput]
       .model_validate(result.get("deleteSignatory"))
-      .root
+      .root.signatureOrder
     )
     return parsed
 
   async def createBatchSignatory(
     self, input: CreateBatchSignatoryInput
-  ) -> CreateBatchSignatory_CreateBatchSignatoryOutput:
+  ) -> CreateBatchSignatory_CreateBatchSignatoryOutput_BatchSignatory:
     query = gql(createBatchSignatoryDocument)
     variables = {"input": input.model_dump()}
     result = await self.client.execute_async(query, variable_values=variables)
     parsed = (
       RootModel[CreateBatchSignatory_CreateBatchSignatoryOutput]
       .model_validate(result.get("createBatchSignatory"))
-      .root
+      .root.batchSignatory
     )
     return parsed
 
   async def changeSignatureOrder(
     self, input: ChangeSignatureOrderInput
-  ) -> ChangeSignatureOrder_ChangeSignatureOrderOutput:
+  ) -> ChangeSignatureOrder_ChangeSignatureOrderOutput_SignatureOrder:
     query = gql(changeSignatureOrderDocument)
     variables = {"input": input.model_dump()}
     result = await self.client.execute_async(query, variable_values=variables)
     parsed = (
       RootModel[ChangeSignatureOrder_ChangeSignatureOrderOutput]
       .model_validate(result.get("changeSignatureOrder"))
-      .root
+      .root.signatureOrder
     )
     return parsed
 

--- a/packages/python/src/criipto_signatures/test_operations.py
+++ b/packages/python/src/criipto_signatures/test_operations.py
@@ -43,7 +43,7 @@ async def test_create_signature_order_add_signatory():
     os.environ["CRIIPTO_SIGNATURES_CLIENT_SECRET"],
   )
 
-  signatureOrderResponse = await sdk.createSignatureOrder(
+  signatureOrder = await sdk.createSignatureOrder(
     CreateSignatureOrderInput(
       title="Python sample signature order",
       expiresInDays=1,
@@ -51,18 +51,16 @@ async def test_create_signature_order_add_signatory():
     )
   )
 
-  assert signatureOrderResponse.signatureOrder
-  assert signatureOrderResponse.signatureOrder.id
+  assert signatureOrder.id
 
-  signatoryResp = await sdk.addSignatory(
-    AddSignatoryInput(signatureOrderId=signatureOrderResponse.signatureOrder.id)
+  signatory = await sdk.addSignatory(
+    AddSignatoryInput(signatureOrderId=signatureOrder.id)
   )
 
-  assert signatoryResp.signatory
-  assert signatoryResp.signatory.href
+  assert signatory.href
 
   await sdk.cancelSignatureOrder(
-    CancelSignatureOrderInput(signatureOrderId=signatureOrderResponse.signatureOrder.id)
+    CancelSignatureOrderInput(signatureOrderId=signatureOrder.id)
   )
 
 
@@ -73,7 +71,7 @@ async def test_create_signature_order_with_form():
     os.environ["CRIIPTO_SIGNATURES_CLIENT_SECRET"],
   )
 
-  signatureOrderResponse = await sdk.createSignatureOrder(
+  signatureOrder = await sdk.createSignatureOrder(
     CreateSignatureOrderInput(
       title="Python sample signature order",
       expiresInDays=1,
@@ -90,7 +88,7 @@ async def test_create_signature_order_with_form():
     )
   )
 
-  document = signatureOrderResponse.signatureOrder.documents[0]
+  document = signatureOrder.documents[0]
   # TODO: This should use an auto-generated type guard, instead of an instanceof check.
   assert isinstance(
     document,
@@ -101,7 +99,7 @@ async def test_create_signature_order_with_form():
   assert document.form.enabled
 
   await sdk.cancelSignatureOrder(
-    CancelSignatureOrderInput(signatureOrderId=signatureOrderResponse.signatureOrder.id)
+    CancelSignatureOrderInput(signatureOrderId=signatureOrder.id)
   )
 
 
@@ -112,7 +110,7 @@ async def test_change_max_signatories():
     os.environ["CRIIPTO_SIGNATURES_CLIENT_SECRET"],
   )
 
-  signatureOrderResponse = await sdk.createSignatureOrder(
+  signatureOrder = await sdk.createSignatureOrder(
     CreateSignatureOrderInput(
       title="Python sample signature order",
       expiresInDays=1,
@@ -121,20 +119,16 @@ async def test_change_max_signatories():
     )
   )
 
-  assert signatureOrderResponse.signatureOrder
-  assert signatureOrderResponse.signatureOrder.id
+  assert signatureOrder.id
 
-  changedSignatureOrderResponse = await sdk.changeSignatureOrder(
-    ChangeSignatureOrderInput(
-      signatureOrderId=signatureOrderResponse.signatureOrder.id, maxSignatories=20
-    )
+  changedSignatureOrder = await sdk.changeSignatureOrder(
+    ChangeSignatureOrderInput(signatureOrderId=signatureOrder.id, maxSignatories=20)
   )
 
-  assert changedSignatureOrderResponse.signatureOrder
-  assert changedSignatureOrderResponse.signatureOrder.maxSignatories == 20
+  assert changedSignatureOrder.maxSignatories == 20
 
   await sdk.cancelSignatureOrder(
-    CancelSignatureOrderInput(signatureOrderId=signatureOrderResponse.signatureOrder.id)
+    CancelSignatureOrderInput(signatureOrderId=signatureOrder.id)
   )
 
 
@@ -147,7 +141,7 @@ async def test_query_signature_orders():
 
   title = "Python sample signature order" + str(datetime.now())
 
-  createSignatureOrderResponse = await sdk.createSignatureOrder(
+  signatureOrder = await sdk.createSignatureOrder(
     CreateSignatureOrderInput(
       title=title,
       expiresInDays=1,
@@ -163,14 +157,12 @@ async def test_query_signature_orders():
   createdSignatureOrder = next(
     edge.node
     for edge in signatureOrdersResponse.signatureOrders.edges
-    if edge.node.id == createSignatureOrderResponse.signatureOrder.id
+    if edge.node.id == signatureOrder.id
   )
 
   assert createdSignatureOrder is not None
   assert createdSignatureOrder.title == title
 
   await sdk.cancelSignatureOrder(
-    CancelSignatureOrderInput(
-      signatureOrderId=createSignatureOrderResponse.signatureOrder.id
-    )
+    CancelSignatureOrderInput(signatureOrderId=signatureOrder.id)
   )


### PR DESCRIPTION
Most mutations have a single top-level selection, such as ```createSignatureOrder { signatureOrder { ... }}```. There is no reason to have to access `response.signatureOrder` when it's the only prop available, we just want to return the `signatureOrder` directly.