### PR TITLE
change(packages/python): Simplify the return type from `querySignatureOrders`.

### DIFF
--- a/packages/python/src/criipto_signatures/__init__.py
+++ b/packages/python/src/criipto_signatures/__init__.py
@@ -1,3 +1,3 @@
 from . import operations as operations
-from .operations import CriiptoSignaturesSDK as CriiptoSignaturesSDK
+from .sdk import CriiptoSignaturesSDK as CriiptoSignaturesSDK
 from . import models as models

--- a/packages/python/src/criipto_signatures/sdk.py
+++ b/packages/python/src/criipto_signatures/sdk.py
@@ -1,7 +1,25 @@
+from typing import Optional
+from criipto_signatures.models import (
+  IntScalarInput,
+  SignatureOrderStatus,
+  StringScalarInput,
+)
 from .operations import (
   CriiptoSignaturesSDK as CriiptoSignaturesSDKInternal,
+  QuerySignatureOrders_Viewer_Application,
+  QuerySignatureOrders_Viewer_Application_SignatureOrderConnection_SignatureOrderEdge_SignatureOrder,
 )
 
 
 class CriiptoSignaturesSDK(CriiptoSignaturesSDKInternal):
-  pass
+  async def querySignatureOrders(
+    self,
+    first: IntScalarInput,
+    status: Optional[SignatureOrderStatus] = None,
+    after: Optional[StringScalarInput] = None,
+  ) -> list[
+    QuerySignatureOrders_Viewer_Application_SignatureOrderConnection_SignatureOrderEdge_SignatureOrder
+  ]:
+    result = await super().querySignatureOrders(first, status, after)
+    assert isinstance(result, QuerySignatureOrders_Viewer_Application)
+    return list(map(lambda edge: edge.node, result.signatureOrders.edges))

--- a/packages/python/src/criipto_signatures/sdk.py
+++ b/packages/python/src/criipto_signatures/sdk.py
@@ -1,0 +1,7 @@
+from .operations import (
+  CriiptoSignaturesSDK as CriiptoSignaturesSDKInternal,
+)
+
+
+class CriiptoSignaturesSDK(CriiptoSignaturesSDKInternal):
+  pass

--- a/packages/python/src/criipto_signatures/test_sdk.py
+++ b/packages/python/src/criipto_signatures/test_sdk.py
@@ -1,8 +1,10 @@
 import os
 from datetime import datetime
 
-from .operations import (
+from .sdk import (
   CriiptoSignaturesSDK,
+)
+from .operations import (
   QuerySignatureOrders_Viewer_Application,
   CreateSignatureOrder_CreateSignatureOrderOutput_SignatureOrder_Document_PdfDocument,
 )

--- a/packages/python/src/criipto_signatures/test_sdk.py
+++ b/packages/python/src/criipto_signatures/test_sdk.py
@@ -5,7 +5,6 @@ from .sdk import (
   CriiptoSignaturesSDK,
 )
 from .operations import (
-  QuerySignatureOrders_Viewer_Application,
   CreateSignatureOrder_CreateSignatureOrderOutput_SignatureOrder_Document_PdfDocument,
 )
 from .models import (
@@ -151,15 +150,14 @@ async def test_query_signature_orders():
     )
   )
 
-  signatureOrdersResponse = await sdk.querySignatureOrders(
+  signatureOrders = await sdk.querySignatureOrders(
     first=1000, status=SignatureOrderStatus.OPEN
   )
 
-  assert isinstance(signatureOrdersResponse, QuerySignatureOrders_Viewer_Application)
   createdSignatureOrder = next(
-    edge.node
-    for edge in signatureOrdersResponse.signatureOrders.edges
-    if edge.node.id == signatureOrder.id
+    _signatureOrder
+    for _signatureOrder in signatureOrders
+    if _signatureOrder.id == signatureOrder.id
   )
 
   assert createdSignatureOrder is not None


### PR DESCRIPTION
In the GraphQL schema, we query signature orders on the viewer. The viewer can have many different types, but we know that in an SDK context, `viewer` will always return an application viewer.

Furthermore, we also remove the notion of edges and nodes from the return type, and just return a list of signature orders. This does make it harder to do pagination, since we loose the `pageInfo` and `cursor`, but it is in line with what we do in the node.js SDK.