### PR TITLE
Allow overriding the GraphQL endpoint across all SDK variants

### DIFF
--- a/codegen/graphql-codegen-plugin-python/src/PythonOperationsVisitor.ts
+++ b/codegen/graphql-codegen-plugin-python/src/PythonOperationsVisitor.ts
@@ -169,10 +169,12 @@ ${expressions.map(expression => `{${expression}}`).join('\n')}"""`;
   generateSDK({ async }: { async: boolean }) {
     let result = `
 class CriiptoSignaturesSDK${async ? 'Async' : 'Sync'}:
-  def __init__(self, clientId: str, clientSecret: str):
+  DEFAULT_ENDPOINT = "https://signatures-api.criipto.com/v1/graphql"
+
+  def __init__(self, clientId: str, clientSecret: str, endpoint: Optional[str] = None):
     auth = BasicAuth(username=clientId, password=clientSecret)
     headers= {"Criipto-Sdk": "criipto-signatures-python"}
-    transport = ${async ? 'HTTPXAsyncTransport' : 'HTTPXTransport'}(url="https://signatures-api.criipto.com/v1/graphql", auth=auth, headers=headers)
+    transport = ${async ? 'HTTPXAsyncTransport' : 'HTTPXTransport'}(url=endpoint or self.DEFAULT_ENDPOINT, auth=auth, headers=headers)
     self.client = Client(transport=transport, fetch_schema_from_transport=False)
 `;
 

--- a/packages/dotnet/Criipto.Signatures.IntegrationTests/CreateSignatureOrderTests.cs
+++ b/packages/dotnet/Criipto.Signatures.IntegrationTests/CreateSignatureOrderTests.cs
@@ -67,6 +67,29 @@ public class CreateSignatureOrderTests
     }
 
     [Fact]
+    public async Task MutationReturnsSignatureOrderWithCustomEndpoint()
+    {
+        using var client = new CriiptoSignaturesClient(
+            Dsl.CLIENT_ID,
+            Dsl.CLIENT_SECRET,
+            Dsl.CustomEndpoint
+        );
+        var signatureOrder = await client.CreateSignatureOrder(
+            new CreateSignatureOrderInput()
+            {
+                title = "Title",
+                expiresInDays = 1,
+                documents = DefaultDocuments,
+            }
+        );
+
+        Assert.NotNull(signatureOrder?.id);
+        Assert.NotNull(signatureOrder?.traceId);
+
+        await client.CancelSignatureOrder(signatureOrder!);
+    }
+
+    [Fact]
     public async Task MutationSupportsDrawable()
     {
         using var client = new CriiptoSignaturesClient(Dsl.CLIENT_ID, Dsl.CLIENT_SECRET, "test");

--- a/packages/dotnet/Criipto.Signatures.IntegrationTests/Dsl.cs
+++ b/packages/dotnet/Criipto.Signatures.IntegrationTests/Dsl.cs
@@ -7,6 +7,8 @@ public class Dsl
 {
     public static readonly byte[] Sample = File.ReadAllBytes("./sample.pdf");
 
+    public static readonly Uri CustomEndpoint = new("https://signatures.idura.app/v1/graphql");
+
     public static IConfiguration InitConfiguration()
     {
         var config = new ConfigurationBuilder()

--- a/packages/dotnet/Criipto.Signatures/Client.cs
+++ b/packages/dotnet/Criipto.Signatures/Client.cs
@@ -10,15 +10,19 @@ namespace Criipto.Signatures;
 
 public class CriiptoSignaturesClient : IDisposable
 {
+    public const string DefaultEndpoint = "https://signatures-api.criipto.com/v1/graphql";
+
     private readonly GraphQLHttpClient graphQLClient;
     private bool isDisposed;
 
-    public CriiptoSignaturesClient(string clientId, string clientSecret, string criiptoSdk)
+    public CriiptoSignaturesClient(
+        string clientId,
+        string clientSecret,
+        string criiptoSdk,
+        string endpoint
+    )
     {
-        this.graphQLClient = new GraphQLHttpClient(
-            "https://signatures-api.criipto.com/v1/graphql",
-            new NewtonsoftJsonSerializer()
-        );
+        this.graphQLClient = new GraphQLHttpClient(endpoint, new NewtonsoftJsonSerializer());
 
         this.graphQLClient.HttpClient.DefaultRequestHeaders.Authorization =
             new AuthenticationHeaderValue(
@@ -30,8 +34,19 @@ public class CriiptoSignaturesClient : IDisposable
         this.graphQLClient.HttpClient.DefaultRequestHeaders.Add("Criipto-Sdk", criiptoSdk);
     }
 
+    public CriiptoSignaturesClient(string clientId, string clientSecret, string criiptoSdk)
+        : this(clientId, clientSecret, criiptoSdk, DefaultEndpoint) { }
+
     public CriiptoSignaturesClient(string clientId, string clientSecret)
-        : this(clientId, clientSecret, "criipto-signatures-dotnet") { }
+        : this(clientId, clientSecret, "criipto-signatures-dotnet", DefaultEndpoint) { }
+
+    public CriiptoSignaturesClient(string clientId, string clientSecret, Uri endpoint)
+        : this(
+            clientId,
+            clientSecret,
+            "criipto-signatures-dotnet",
+            (endpoint ?? throw new ArgumentNullException(nameof(endpoint))).ToString()
+        ) { }
 
     public void Dispose()
     {

--- a/packages/dotnet/README.md
+++ b/packages/dotnet/README.md
@@ -19,6 +19,18 @@ dotnet add package Criipto.Signatures
 var client = new CriiptoSignaturesClient("{YOUR_CRIIPTO_CLIENT_ID}", "{YOUR_CRIIPTO_CLIENT_SECRET}");
 ```
 
+### Overriding the GraphQL endpoint
+
+By default the SDK targets `https://signatures-api.criipto.com/v1/graphql`. `https://signatures.idura.app` is the future home of the Idura Signatures solution — migrate now to avoid timeline worries later. You can override the endpoint by passing a custom URI:
+
+```csharp
+var client = new CriiptoSignaturesClient(
+    "{YOUR_CRIIPTO_CLIENT_ID}",
+    "{YOUR_CRIIPTO_CLIENT_SECRET}",
+    new Uri("https://signatures.idura.app/v1/graphql")
+);
+```
+
 ## Basic example
 
 ```csharp

--- a/packages/nodejs/README.md
+++ b/packages/nodejs/README.md
@@ -28,6 +28,27 @@ import CriiptoSignatures from '@criipto/signatures';
 const client = new CriiptoSignatures('{YOUR_CRIIPTO_CLIENT_ID}', '{YOUR_CRIIPTO_CLIENT_SECRET}');
 ```
 
+### Overriding the GraphQL endpoint
+
+By default the SDK targets `https://signatures-api.criipto.com/v1/graphql`. `https://signatures.idura.app` is the future home of the Idura Signatures solution — migrate now to avoid timeline worries later. You can override the endpoint by passing an `endpoint` option:
+
+```javascript
+import CriiptoSignatures from '@criipto/signatures';
+const client = new CriiptoSignatures('{YOUR_CRIIPTO_CLIENT_ID}', '{YOUR_CRIIPTO_CLIENT_SECRET}', {
+  endpoint: 'https://signatures.idura.app/v1/graphql',
+});
+```
+
+The same option is supported by `SignatoryViewerClient`:
+
+```javascript
+import { SignatoryViewerClient } from '@criipto/signatures';
+const client = new SignatoryViewerClient(
+  { token: '{SIGNATORY_TOKEN}' },
+  { endpoint: 'https://signatures.idura.app/v1/graphql' },
+);
+```
+
 ## Basic example
 
 ```javascript

--- a/packages/nodejs/src/application-viewer.ts
+++ b/packages/nodejs/src/application-viewer.ts
@@ -17,18 +17,25 @@ import * as Types from './application-viewer-types';
 import jsonSerializer from './json-serializer';
 export { Types as CriiptoSignaturesTypes };
 
+export interface CriiptoSignaturesOptions {
+  endpoint?: string;
+}
+
 export class CriiptoSignatures {
   client: GraphQLClient;
   sdk: Sdk;
 
-  constructor(clientId: string, clientSecret: string) {
-    this.client = new GraphQLClient('https://signatures-api.criipto.com/v1/graphql', {
-      headers: {
-        Authorization: `Basic ${Buffer.from(clientId + ':' + clientSecret).toString('base64')}`,
-        'Criipto-Sdk': 'criipto-signatures-nodejs',
+  constructor(clientId: string, clientSecret: string, options?: CriiptoSignaturesOptions) {
+    this.client = new GraphQLClient(
+      options?.endpoint ?? 'https://signatures-api.criipto.com/v1/graphql',
+      {
+        headers: {
+          Authorization: `Basic ${Buffer.from(clientId + ':' + clientSecret).toString('base64')}`,
+          'Criipto-Sdk': 'criipto-signatures-nodejs',
+        },
+        jsonSerializer,
       },
-      jsonSerializer,
-    });
+    );
     this.sdk = getSdk(this.client);
   }
 

--- a/packages/nodejs/src/signatory-viewer.ts
+++ b/packages/nodejs/src/signatory-viewer.ts
@@ -12,14 +12,21 @@ export { Types as SignatoryViewerTypes };
 
 type Authentication = { token: string; validation?: string };
 
+export interface SignatoryViewerClientOptions {
+  endpoint?: string;
+}
+
 export class SignatoryViewerClient {
   client: GraphQLClient;
   sdk: Sdk;
 
-  constructor(options: Authentication) {
-    this.client = new GraphQLClient('https://signatures-api.criipto.com/v1/graphql', {
-      jsonSerializer,
-    });
+  constructor(options: Authentication, clientOptions?: SignatoryViewerClientOptions) {
+    this.client = new GraphQLClient(
+      clientOptions?.endpoint ?? 'https://signatures-api.criipto.com/v1/graphql',
+      {
+        jsonSerializer,
+      },
+    );
 
     this.setAuthentication(options);
     this.sdk = getSdk(this.client);

--- a/packages/nodejs/src/test/integration/basic.test.ts
+++ b/packages/nodejs/src/test/integration/basic.test.ts
@@ -15,10 +15,23 @@ const documentFixture = {
   },
 };
 
+const CUSTOM_ENDPOINT = 'https://signatures.idura.app/v1/graphql';
+
 function arrange() {
   const client = new CriiptoSignatures(
     process.env.CRIIPTO_SIGNATURES_CLIENT_ID!,
     process.env.CRIIPTO_SIGNATURES_CLIENT_SECRET!,
+  );
+  client.client.setHeader('Criipto-Sdk', 'test');
+
+  return { client };
+}
+
+function arrangeWithCustomEndpoint() {
+  const client = new CriiptoSignatures(
+    process.env.CRIIPTO_SIGNATURES_CLIENT_ID!,
+    process.env.CRIIPTO_SIGNATURES_CLIENT_SECRET!,
+    { endpoint: CUSTOM_ENDPOINT },
   );
   client.client.setHeader('Criipto-Sdk', 'test');
 
@@ -156,6 +169,24 @@ test('can create batch signatory', async t => {
         elem.signatureOrderId === expectedItems[idx].signatureOrderId,
     ),
   );
+});
+
+test('can create signature order against a custom endpoint', async t => {
+  // ARRANGE
+  const { client } = arrangeWithCustomEndpoint();
+
+  // ACT
+  const signatureOrder = await client.createSignatureOrder({
+    title: 'Node.js sample (custom endpoint)',
+    expiresInDays: 1,
+    documents: [documentFixture],
+  });
+
+  // ASSERT
+  t.truthy(signatureOrder);
+  t.truthy(signatureOrder.id);
+
+  await client.cancelSignatureOrder(signatureOrder.id);
 });
 
 test('can change signature order with new maxSignatories', async t => {

--- a/packages/nodejs/src/test/integration/signatory.test.ts
+++ b/packages/nodejs/src/test/integration/signatory.test.ts
@@ -17,10 +17,23 @@ const documentFixture = {
   },
 };
 
+const CUSTOM_ENDPOINT = 'https://signatures.idura.app/v1/graphql';
+
 function arrange() {
   const applicationClient = new CriiptoSignatures(
     process.env.CRIIPTO_SIGNATURES_CLIENT_ID!,
     process.env.CRIIPTO_SIGNATURES_CLIENT_SECRET!,
+  );
+  applicationClient.client.setHeader('Criipto-Sdk', 'test');
+
+  return { applicationClient };
+}
+
+function arrangeWithCustomEndpoint() {
+  const applicationClient = new CriiptoSignatures(
+    process.env.CRIIPTO_SIGNATURES_CLIENT_ID!,
+    process.env.CRIIPTO_SIGNATURES_CLIENT_SECRET!,
+    { endpoint: CUSTOM_ENDPOINT },
   );
   applicationClient.client.setHeader('Criipto-Sdk', 'test');
 
@@ -243,6 +256,47 @@ test('can authenticate to view and then sign', async t => {
   // ASSERT
   assert.strictEqual(signed.__typename, 'SignatoryViewer');
   t.is(signed.status, 'SIGNED');
+});
+
+test('can authenticate with criiptoVerify mock against a custom endpoint', async t => {
+  // ARRANGE
+  const { applicationClient } = arrangeWithCustomEndpoint();
+  const signatureOrder = await applicationClient.createSignatureOrder({
+    title: 'Node.js sample (custom endpoint)',
+    expiresInDays: 1,
+    documents: [documentFixture],
+  });
+  const signatory = await applicationClient.addSignatory(signatureOrder.id);
+
+  const signatoryClient = new SignatoryViewerClient(
+    { token: signatory.token },
+    { endpoint: CUSTOM_ENDPOINT },
+  );
+
+  const viewer = await signatoryClient.viewer();
+  assert.strictEqual(viewer.__typename, 'SignatoryViewer');
+  const ep = viewer.evidenceProviders.find(
+    s => s.__typename === 'CriiptoVerifySignatureEvidenceProvider',
+  );
+  assert(ep);
+
+  // ACT
+  const started = await signatoryClient.startCriiptoVerifyEvidenceProvider({
+    id: ep.id,
+    acrValue: 'urn:grn:authn:mock',
+    redirectUri: `https://${ep.domain}/signatures`,
+    stage: 'VIEW',
+  });
+
+  const login = await followMock(started.redirectUri);
+  assert.strictEqual(login.status, 'ok');
+
+  const completed = await signatoryClient.completeCriiptoVerifyEvidenceProvider({
+    code: login.code,
+    state: login.state,
+  });
+
+  t.truthy(completed.jwt);
 });
 
 async function followMock(initial: string) {

--- a/packages/python/README.md
+++ b/packages/python/README.md
@@ -39,6 +39,20 @@ syncClient = CriiptoSignaturesSDKSync(
 )
 ```
 
+### Overriding the GraphQL endpoint
+
+By default the SDK targets `https://signatures-api.criipto.com/v1/graphql`. `https://signatures.idura.app` is the future home of the Idura Signatures solution — migrate now to avoid timeline worries later. You can override the endpoint by passing an `endpoint` argument to either client:
+
+```python
+from criipto_signatures import CriiptoSignaturesSDKAsync
+
+client = CriiptoSignaturesSDKAsync(
+    '{YOUR_CRIIPTO_CLIENT_ID}',
+    '{YOUR_CRIIPTO_CLIENT_SECRET}',
+    endpoint='https://signatures.idura.app/v1/graphql',
+)
+```
+
 ## Basic example
 
 ```python

--- a/packages/python/src/criipto_signatures/operations.py
+++ b/packages/python/src/criipto_signatures/operations.py
@@ -3488,11 +3488,13 @@ queryBatchSignatoryDocument = f"""query batchSignatory($id: ID!) {{
 
 
 class CriiptoSignaturesSDKAsync:
-  def __init__(self, clientId: str, clientSecret: str):
+  DEFAULT_ENDPOINT = "https://signatures-api.criipto.com/v1/graphql"
+
+  def __init__(self, clientId: str, clientSecret: str, endpoint: Optional[str] = None):
     auth = BasicAuth(username=clientId, password=clientSecret)
     headers = {"Criipto-Sdk": "criipto-signatures-python"}
     transport = HTTPXAsyncTransport(
-      url="https://signatures-api.criipto.com/v1/graphql", auth=auth, headers=headers
+      url=endpoint or self.DEFAULT_ENDPOINT, auth=auth, headers=headers
     )
     self.client = Client(transport=transport, fetch_schema_from_transport=False)
 
@@ -3733,11 +3735,13 @@ class CriiptoSignaturesSDKAsync:
 
 
 class CriiptoSignaturesSDKSync:
-  def __init__(self, clientId: str, clientSecret: str):
+  DEFAULT_ENDPOINT = "https://signatures-api.criipto.com/v1/graphql"
+
+  def __init__(self, clientId: str, clientSecret: str, endpoint: Optional[str] = None):
     auth = BasicAuth(username=clientId, password=clientSecret)
     headers = {"Criipto-Sdk": "criipto-signatures-python"}
     transport = HTTPXTransport(
-      url="https://signatures-api.criipto.com/v1/graphql", auth=auth, headers=headers
+      url=endpoint or self.DEFAULT_ENDPOINT, auth=auth, headers=headers
     )
     self.client = Client(transport=transport, fetch_schema_from_transport=False)
 

--- a/packages/python/src/criipto_signatures/test_sdk.py
+++ b/packages/python/src/criipto_signatures/test_sdk.py
@@ -45,6 +45,9 @@ async def unwrapResult[T](maybeCoroutine: T | Coroutine[Any, Any, T]) -> T:
   return cast(T, maybeCoroutine)
 
 
+CUSTOM_ENDPOINT = "https://signatures.idura.app/v1/graphql"
+
+
 @pytest.mark.parametrize(
   ("sdk"),
   [
@@ -58,6 +61,20 @@ async def unwrapResult[T](maybeCoroutine: T | Coroutine[Any, Any, T]) -> T:
       CriiptoSignaturesSDKSync(
         os.environ["CRIIPTO_SIGNATURES_CLIENT_ID"],
         os.environ["CRIIPTO_SIGNATURES_CLIENT_SECRET"],
+      )
+    ),
+    (
+      CriiptoSignaturesSDKAsync(
+        os.environ["CRIIPTO_SIGNATURES_CLIENT_ID"],
+        os.environ["CRIIPTO_SIGNATURES_CLIENT_SECRET"],
+        endpoint=CUSTOM_ENDPOINT,
+      )
+    ),
+    (
+      CriiptoSignaturesSDKSync(
+        os.environ["CRIIPTO_SIGNATURES_CLIENT_ID"],
+        os.environ["CRIIPTO_SIGNATURES_CLIENT_SECRET"],
+        endpoint=CUSTOM_ENDPOINT,
       )
     ),
   ],

--- a/packages/rust/README.md
+++ b/packages/rust/README.md
@@ -1,0 +1,54 @@
+# criipto-signatures-rs
+
+A Rust SDK for Criipto Signatures.
+
+Sign PAdeS-LTA documents using MitID, BankID or any other eID supported by Criipto.
+
+[Examples](https://docs.criipto.com/signatures/graphql/examples/)
+
+## Getting started
+
+### Installation
+
+```toml
+[dependencies]
+criipto-signatures-rs = "0.1"
+```
+
+### Configure the SDK
+
+```rust
+use criipto_signatures_rs::{
+    CriiptoSignaturesClientOpts,
+    reqwest::create_reqwest_blocking_client,
+};
+
+let opts = CriiptoSignaturesClientOpts::new(
+    "{YOUR_CRIIPTO_CLIENT_ID}".to_string(),
+    "{YOUR_CRIIPTO_CLIENT_SECRET}".to_string(),
+);
+let client = create_reqwest_blocking_client(&opts)?;
+```
+
+### Overriding the GraphQL endpoint
+
+By default the SDK targets `https://signatures-api.criipto.com/v1/graphql`. `https://signatures.idura.app` is the future home of the Idura Signatures solution — migrate now to avoid timeline worries later. Override the endpoint with `with_endpoint`:
+
+```rust
+use criipto_signatures_rs::{
+    CriiptoSignaturesClientOpts,
+    reqwest::create_reqwest_blocking_client,
+};
+
+let opts = CriiptoSignaturesClientOpts::new(
+    "{YOUR_CRIIPTO_CLIENT_ID}".to_string(),
+    "{YOUR_CRIIPTO_CLIENT_SECRET}".to_string(),
+)
+.with_endpoint("https://signatures.idura.app/v1/graphql");
+
+let client = create_reqwest_blocking_client(&opts)?;
+```
+
+The same `with_endpoint` works for the async factory `create_reqwest_async_client`.
+
+For more usage examples (including the async client and using the SDK without `reqwest`), see the crate-level documentation.

--- a/packages/rust/src/lib.rs
+++ b/packages/rust/src/lib.rs
@@ -9,7 +9,6 @@
 //! ```no_run
 //! # use reqwest_crate as reqwest;
 //!
-//! use reqwest::{blocking::Client, header::HeaderMap};
 //! use criipto_signatures_rs::{
 //!     CriiptoSignaturesClientOpts,
 //!     reqwest::{create_reqwest_blocking_client},
@@ -43,6 +42,19 @@
 //!     println!("Response: {:#?}", response);
 //!     Ok(())
 //! }
+//! ```
+//!
+//! ## Overriding the GraphQL endpoint
+//!
+//! By default the SDK targets `https://signatures-api.criipto.com/v1/graphql`. You can override
+//! it on the [CriiptoSignaturesClientOpts] via [CriiptoSignaturesClientOpts::with_endpoint]:
+//!
+//! ```no_run
+//! use criipto_signatures_rs::{CriiptoSignaturesClientOpts, reqwest::create_reqwest_blocking_client};
+//!
+//! let opts = CriiptoSignaturesClientOpts::new("CLIENT_ID".to_string(), "CLIENT_SECRET".to_string())
+//!     .with_endpoint("https://signatures-api.criipto.com/v1/graphql");
+//! let client = create_reqwest_blocking_client(&opts).unwrap();
 //! ```
 //!
 //! ## Usage without `reqwest`
@@ -92,15 +104,33 @@ pub mod types {
     pub use crate::generated::types::*;
 }
 
+pub const DEFAULT_ENDPOINT: &str = "https://signatures-api.criipto.com/v1/graphql";
+
 #[derive(Clone)]
 pub struct CriiptoSignaturesClientOpts {
     client_id: String,
     client_secret: String,
+    endpoint: String,
 }
 
 impl CriiptoSignaturesClientOpts {
     pub fn new(client_id: String, client_secret: String) -> Self {
-        Self { client_id, client_secret }
+        Self {
+            client_id,
+            client_secret,
+            endpoint: DEFAULT_ENDPOINT.to_string(),
+        }
+    }
+
+    /// Override the GraphQL endpoint.
+    /// Defaults to `https://signatures-api.criipto.com/v1/graphql`.
+    pub fn with_endpoint(mut self, endpoint: impl Into<String>) -> Self {
+        self.endpoint = endpoint.into();
+        self
+    }
+
+    pub fn endpoint(&self) -> &str {
+        &self.endpoint
     }
 
     pub fn authorization_header(&self) -> String {

--- a/packages/rust/src/reqwest.rs
+++ b/packages/rust/src/reqwest.rs
@@ -4,8 +4,24 @@ use crate::CriiptoSignaturesClientOpts;
 use crate::graphql::{CriiptoSignaturesClientAsync, CriiptoSignaturesClientBlocking, GraphQlQuery, GraphQlResponse};
 use reqwest_crate as reqwest;
 
+/// A reqwest-backed Criipto Signatures client that carries the GraphQL endpoint to call.
 #[cfg(any(feature = "reqwest", feature = "reqwest-rustls"))]
-pub fn create_reqwest_async_client(opts: &CriiptoSignaturesClientOpts) -> Result<reqwest::Client, reqwest::Error> {
+#[derive(Clone)]
+pub struct CriiptoSignaturesReqwestClient {
+    pub client: reqwest::Client,
+    pub endpoint: String,
+}
+
+/// A reqwest-blocking-backed Criipto Signatures client that carries the GraphQL endpoint to call.
+#[cfg(feature = "reqwest-blocking")]
+#[derive(Clone)]
+pub struct CriiptoSignaturesReqwestBlockingClient {
+    pub client: reqwest::blocking::Client,
+    pub endpoint: String,
+}
+
+#[cfg(any(feature = "reqwest", feature = "reqwest-rustls"))]
+pub fn create_reqwest_async_client(opts: &CriiptoSignaturesClientOpts) -> Result<CriiptoSignaturesReqwestClient, reqwest::Error> {
     let client = reqwest::Client::builder()
         .default_headers({
             let mut headers = reqwest::header::HeaderMap::new();
@@ -14,11 +30,14 @@ pub fn create_reqwest_async_client(opts: &CriiptoSignaturesClientOpts) -> Result
         })
         .build()?;
 
-    Ok(client)
+    Ok(CriiptoSignaturesReqwestClient {
+        client,
+        endpoint: opts.endpoint().to_string(),
+    })
 }
 
 #[cfg(feature = "reqwest-blocking")]
-pub fn create_reqwest_blocking_client(opts: &CriiptoSignaturesClientOpts) -> Result<reqwest::blocking::Client, reqwest::Error> {
+pub fn create_reqwest_blocking_client(opts: &CriiptoSignaturesClientOpts) -> Result<CriiptoSignaturesReqwestBlockingClient, reqwest::Error> {
     let client = reqwest::blocking::Client::builder()
         .default_headers({
             let mut headers = reqwest::header::HeaderMap::new();
@@ -27,16 +46,19 @@ pub fn create_reqwest_blocking_client(opts: &CriiptoSignaturesClientOpts) -> Res
         })
         .build()?;
 
-    Ok(client)
+    Ok(CriiptoSignaturesReqwestBlockingClient {
+        client,
+        endpoint: opts.endpoint().to_string(),
+    })
 }
 
 #[cfg(any(feature = "reqwest", feature = "reqwest-rustls"))]
-impl CriiptoSignaturesClientAsync for reqwest::Client {
+impl CriiptoSignaturesClientAsync for CriiptoSignaturesReqwestClient {
     type Error = reqwest::Error;
 
     fn post_graphql_async<Q: GraphQlQuery>(&self, variables: Q::Variables) -> impl std::future::Future<Output = Result<GraphQlResponse<Q::ResponseBody>, Self::Error>> + Send {
         let body = Q::build_query(variables);
-        let reqwest_response = self.post("https://signatures-api.criipto.com/v1/graphql").json(&body).send();
+        let reqwest_response = self.client.post(&self.endpoint).json(&body).send();
 
         async move {
             let reqwest_response = reqwest_response.await?;
@@ -46,12 +68,12 @@ impl CriiptoSignaturesClientAsync for reqwest::Client {
 }
 
 #[cfg(feature = "reqwest-blocking")]
-impl CriiptoSignaturesClientBlocking for reqwest::blocking::Client {
+impl CriiptoSignaturesClientBlocking for CriiptoSignaturesReqwestBlockingClient {
     type Error = reqwest::Error;
 
     fn post_graphql_blocking<Q: GraphQlQuery>(&self, variables: Q::Variables) -> Result<GraphQlResponse<Q::ResponseBody>, Self::Error> {
         let body = Q::build_query(variables);
-        let reqwest_response = self.post("https://signatures-api.criipto.com/v1/graphql").json(&body).send()?;
+        let reqwest_response = self.client.post(&self.endpoint).json(&body).send()?;
 
         reqwest_response.json()
     }

--- a/packages/rust/tests/common/mod.rs
+++ b/packages/rust/tests/common/mod.rs
@@ -1,11 +1,22 @@
+use criipto_signatures_rs::reqwest::CriiptoSignaturesReqwestBlockingClient;
 use criipto_signatures_rs::types::{DocumentInput, DocumentStorageMode, PadesDocumentInput};
-use reqwest_crate::{blocking::Client, header::HeaderMap};
 
-pub fn make_client() -> Client {
+pub const CUSTOM_ENDPOINT: &str = "https://signatures.idura.app/v1/graphql";
+
+pub fn make_client() -> CriiptoSignaturesReqwestBlockingClient {
     let client_id = std::env::var("CRIIPTO_SIGNATURES_CLIENT_ID").expect("CLIENT_ID must be set");
     let client_secret = std::env::var("CRIIPTO_SIGNATURES_CLIENT_SECRET").expect("CLIENT_SECRET must be set");
 
     criipto_signatures_rs::reqwest::create_reqwest_blocking_client(&criipto_signatures_rs::CriiptoSignaturesClientOpts::new(client_id, client_secret)).expect("Failed to create client")
+}
+
+pub fn make_client_with_custom_endpoint() -> CriiptoSignaturesReqwestBlockingClient {
+    let client_id = std::env::var("CRIIPTO_SIGNATURES_CLIENT_ID").expect("CLIENT_ID must be set");
+    let client_secret = std::env::var("CRIIPTO_SIGNATURES_CLIENT_SECRET").expect("CLIENT_SECRET must be set");
+
+    let opts = criipto_signatures_rs::CriiptoSignaturesClientOpts::new(client_id, client_secret)
+        .with_endpoint(CUSTOM_ENDPOINT);
+    criipto_signatures_rs::reqwest::create_reqwest_blocking_client(&opts).expect("Failed to create client")
 }
 
 pub fn make_document_input() -> DocumentInput {

--- a/packages/rust/tests/test_sdk.rs
+++ b/packages/rust/tests/test_sdk.rs
@@ -41,3 +41,21 @@ fn test_create_signature_order_add_signatory() {
     let data = signatory.data.unwrap();
     assert!(data.addSignatory.signatory.id.len() > 0);
 }
+
+#[test]
+fn test_create_signature_order_with_custom_endpoint() {
+    let client = common::make_client_with_custom_endpoint();
+
+    let signature_order = client
+        .createSignatureOrder(CreateSignatureOrderInput {
+            title: Some("Test Signature Order (custom endpoint)".to_string()),
+            expiresInDays: Some(1),
+            documents: vec![common::make_document_input()],
+            ..Default::default()
+        })
+        .unwrap();
+
+    let data = signature_order.data.unwrap();
+    assert!(data.createSignatureOrder.signatureOrder.id.len() > 0);
+    assert!(data.createSignatureOrder.signatureOrder.traceId.len() > 0);
+}


### PR DESCRIPTION
Lets customers adopt our new GraphQL endpoints before they are made the default/mandatory, so they can validate against the new infrastructure on their own timeline rather than being switched over in lockstep.