### PR TITLE
use signatures.idura.app by default

### DIFF
--- a/codegen.ts
+++ b/codegen.ts
@@ -33,7 +33,7 @@ const rustCommonConfig: Partial<CodegenConfig> = {
 const config: CodegenConfig = {
   schema: [
     {
-      'https://signatures-api.criipto.com/v1/graphql': {
+      'https://signatures.idura.app/v1/graphql': {
         method: 'GET',
       },
     },

--- a/codegen/graphql-codegen-plugin-python/src/PythonOperationsVisitor.ts
+++ b/codegen/graphql-codegen-plugin-python/src/PythonOperationsVisitor.ts
@@ -169,7 +169,7 @@ ${expressions.map(expression => `{${expression}}`).join('\n')}"""`;
   generateSDK({ async }: { async: boolean }) {
     let result = `
 class CriiptoSignaturesSDK${async ? 'Async' : 'Sync'}:
-  DEFAULT_ENDPOINT = "https://signatures-api.criipto.com/v1/graphql"
+  DEFAULT_ENDPOINT = "https://signatures.idura.app/v1/graphql"
 
   def __init__(self, clientId: str, clientSecret: str, endpoint: Optional[str] = None):
     auth = BasicAuth(username=clientId, password=clientSecret)

--- a/packages/dotnet/Criipto.Signatures/Client.cs
+++ b/packages/dotnet/Criipto.Signatures/Client.cs
@@ -10,7 +10,7 @@ namespace Criipto.Signatures;
 
 public class CriiptoSignaturesClient : IDisposable
 {
-    public const string DefaultEndpoint = "https://signatures-api.criipto.com/v1/graphql";
+    public const string DefaultEndpoint = "https://signatures.idura.app/v1/graphql";
 
     private readonly GraphQLHttpClient graphQLClient;
     private bool isDisposed;

--- a/packages/dotnet/README.md
+++ b/packages/dotnet/README.md
@@ -21,7 +21,7 @@ var client = new CriiptoSignaturesClient("{YOUR_CRIIPTO_CLIENT_ID}", "{YOUR_CRII
 
 ### Overriding the GraphQL endpoint
 
-By default the SDK targets `https://signatures-api.criipto.com/v1/graphql`. `https://signatures.idura.app` is the future home of the Idura Signatures solution — migrate now to avoid timeline worries later. You can override the endpoint by passing a custom URI:
+By default the SDK targets`https://signatures.idura.app/v1/graphql`. You can override the endpoint by passing a custom URI:
 
 ```csharp
 var client = new CriiptoSignaturesClient(

--- a/packages/nodejs/README.md
+++ b/packages/nodejs/README.md
@@ -30,7 +30,7 @@ const client = new CriiptoSignatures('{YOUR_CRIIPTO_CLIENT_ID}', '{YOUR_CRIIPTO_
 
 ### Overriding the GraphQL endpoint
 
-By default the SDK targets `https://signatures-api.criipto.com/v1/graphql`. `https://signatures.idura.app` is the future home of the Idura Signatures solution — migrate now to avoid timeline worries later. You can override the endpoint by passing an `endpoint` option:
+By default the SDK targets `https://signatures.idura.app`. You can override the endpoint by passing an `endpoint` option:
 
 ```javascript
 import CriiptoSignatures from '@criipto/signatures';

--- a/packages/nodejs/src/application-viewer.ts
+++ b/packages/nodejs/src/application-viewer.ts
@@ -27,7 +27,7 @@ export class CriiptoSignatures {
 
   constructor(clientId: string, clientSecret: string, options?: CriiptoSignaturesOptions) {
     this.client = new GraphQLClient(
-      options?.endpoint ?? 'https://signatures-api.criipto.com/v1/graphql',
+      options?.endpoint ?? 'https://signatures.idura.app/v1/graphql',
       {
         headers: {
           Authorization: `Basic ${Buffer.from(clientId + ':' + clientSecret).toString('base64')}`,

--- a/packages/nodejs/src/signatory-viewer.ts
+++ b/packages/nodejs/src/signatory-viewer.ts
@@ -22,7 +22,7 @@ export class SignatoryViewerClient {
 
   constructor(options: Authentication, clientOptions?: SignatoryViewerClientOptions) {
     this.client = new GraphQLClient(
-      clientOptions?.endpoint ?? 'https://signatures-api.criipto.com/v1/graphql',
+      clientOptions?.endpoint ?? 'https://signatures.idura.app/v1/graphql',
       {
         jsonSerializer,
       },

--- a/packages/python/README.md
+++ b/packages/python/README.md
@@ -41,7 +41,7 @@ syncClient = CriiptoSignaturesSDKSync(
 
 ### Overriding the GraphQL endpoint
 
-By default the SDK targets `https://signatures-api.criipto.com/v1/graphql`. `https://signatures.idura.app` is the future home of the Idura Signatures solution — migrate now to avoid timeline worries later. You can override the endpoint by passing an `endpoint` argument to either client:
+By default the SDK targets `https://signatures.idura.app/v1/graphql`. You can override the endpoint by passing an `endpoint` argument to either client:
 
 ```python
 from criipto_signatures import CriiptoSignaturesSDKAsync

--- a/packages/python/src/criipto_signatures/operations.py
+++ b/packages/python/src/criipto_signatures/operations.py
@@ -3570,7 +3570,7 @@ queryBatchSignatoryDocument = f"""query batchSignatory($id: ID!) {{
 
 
 class CriiptoSignaturesSDKAsync:
-  DEFAULT_ENDPOINT = "https://signatures-api.criipto.com/v1/graphql"
+  DEFAULT_ENDPOINT = "https://signatures.idura.app/v1/graphql"
 
   def __init__(self, clientId: str, clientSecret: str, endpoint: Optional[str] = None):
     auth = BasicAuth(username=clientId, password=clientSecret)
@@ -3817,7 +3817,7 @@ class CriiptoSignaturesSDKAsync:
 
 
 class CriiptoSignaturesSDKSync:
-  DEFAULT_ENDPOINT = "https://signatures-api.criipto.com/v1/graphql"
+  DEFAULT_ENDPOINT = "https://signatures.idura.app/v1/graphql"
 
   def __init__(self, clientId: str, clientSecret: str, endpoint: Optional[str] = None):
     auth = BasicAuth(username=clientId, password=clientSecret)

--- a/packages/rust/README.md
+++ b/packages/rust/README.md
@@ -32,7 +32,7 @@ let client = create_reqwest_blocking_client(&opts)?;
 
 ### Overriding the GraphQL endpoint
 
-By default the SDK targets `https://signatures-api.criipto.com/v1/graphql`. `https://signatures.idura.app` is the future home of the Idura Signatures solution — migrate now to avoid timeline worries later. Override the endpoint with `with_endpoint`:
+By default the SDK targets `https://signatures.idura.app`. Override the endpoint with `with_endpoint`:
 
 ```rust
 use criipto_signatures_rs::{

--- a/packages/rust/src/lib.rs
+++ b/packages/rust/src/lib.rs
@@ -46,14 +46,14 @@
 //!
 //! ## Overriding the GraphQL endpoint
 //!
-//! By default the SDK targets `https://signatures-api.criipto.com/v1/graphql`. You can override
+//! By default the SDK targets `https://signatures.idura.app/v1/graphql`. You can override
 //! it on the [CriiptoSignaturesClientOpts] via [CriiptoSignaturesClientOpts::with_endpoint]:
 //!
 //! ```no_run
 //! use criipto_signatures_rs::{CriiptoSignaturesClientOpts, reqwest::create_reqwest_blocking_client};
 //!
 //! let opts = CriiptoSignaturesClientOpts::new("CLIENT_ID".to_string(), "CLIENT_SECRET".to_string())
-//!     .with_endpoint("https://signatures-api.criipto.com/v1/graphql");
+//!     .with_endpoint("https://signatures.idura.app/v1/graphql");
 //! let client = create_reqwest_blocking_client(&opts).unwrap();
 //! ```
 //!
@@ -104,7 +104,7 @@ pub mod types {
     pub use crate::generated::types::*;
 }
 
-pub const DEFAULT_ENDPOINT: &str = "https://signatures-api.criipto.com/v1/graphql";
+pub const DEFAULT_ENDPOINT: &str = "https://signatures.idura.app/v1/graphql";
 
 #[derive(Clone)]
 pub struct CriiptoSignaturesClientOpts {
@@ -119,7 +119,7 @@ impl CriiptoSignaturesClientOpts {
     }
 
     /// Override the GraphQL endpoint.
-    /// Defaults to `https://signatures-api.criipto.com/v1/graphql`.
+    /// Defaults to `https://signatures.idura.app/v1/graphql`.
     pub fn with_endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = endpoint.into();
         self


### PR DESCRIPTION
We want to start moving customers to the idura.app based domain by default.