### PR TITLE
fix(docs): use correct documentation URL

### DIFF
--- a/packages/dotnet/Criipto.Signatures/Criipto.Signatures.csproj
+++ b/packages/dotnet/Criipto.Signatures/Criipto.Signatures.csproj
@@ -15,7 +15,7 @@
     <Authors>Mick Hansen</Authors>
     <Company>Criipto</Company>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageProjectUrl>https://docs.criipto.com/signatures/integrations/csharp/</PackageProjectUrl>
+    <PackageProjectUrl>https://docs.idura.app/signatures/integrations/csharp/</PackageProjectUrl>
     <RepositoryUrl>https://github.com/criipto/criipto-signatures-sdk</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
   </PropertyGroup>

--- a/packages/dotnet/README.md
+++ b/packages/dotnet/README.md
@@ -1,6 +1,6 @@
 A dotnet/C# SDK for Criipto Signatures
 
-[Examples](https://docs.criipto.com/signatures/graphql/examples/)
+[Examples](https://docs.idura.app/signatures/graphql/examples/)
 
 ## Getting started
 
@@ -70,7 +70,7 @@ using (var client = new CriiptoSignaturesClient("{YOUR_CRIIPTO_CLIENT_ID}", "{YO
 }
 ```
 
-More examples can be found in the [test suite](https://github.com/criipto/criipto-signatures-sdk/tree/master/packages/dotnet/Criipto.Signatures.IntegrationTests) and in the [documentation](https://docs.criipto.com/signatures/graphql/examples/)
+More examples can be found in the [test suite](https://github.com/criipto/criipto-signatures-sdk/tree/master/packages/dotnet/Criipto.Signatures.IntegrationTests) and in the [documentation](https://docs.idura.app/signatures/graphql/examples/)
 
 ## Methods
 

--- a/packages/nodejs/README.md
+++ b/packages/nodejs/README.md
@@ -4,7 +4,7 @@ A Node.js SDK for Criipto Signatures
 
 Sign PAdeS-LTA documents using MitID, BankID or any other eID supported by Criipto.
 
-[Examples](https://docs.criipto.com/signatures/graphql/examples/)
+[Examples](https://docs.idura.app/signatures/graphql/examples/)
 
 ## Getting started
 

--- a/packages/python/README.md
+++ b/packages/python/README.md
@@ -4,7 +4,7 @@ A python SDK for Criipto Signatures.
 
 Sign PAdeS-LTA documents using MitID, BankID or any other eID supported by Criipto.
 
-[Examples](https://docs.criipto.com/signatures/graphql/examples/)
+[Examples](https://docs.idura.app/signatures/graphql/examples/)
 
 ## Getting started
 

--- a/packages/rust/README.md
+++ b/packages/rust/README.md
@@ -4,7 +4,7 @@ A Rust SDK for Criipto Signatures.
 
 Sign PAdeS-LTA documents using MitID, BankID or any other eID supported by Criipto.
 
-[Examples](https://docs.criipto.com/signatures/graphql/examples/)
+[Examples](https://docs.idura.app/signatures/graphql/examples/)
 
 ## Getting started
 


### PR DESCRIPTION
`docs.criipto.com` has been moved to `docs.idura.app`.